### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Building
 3. `brew install xctool`
     - you may need to accept all XCode licenses, e.g. `sudo xcodebuild -license` 
 2. `gem install cocoapods`
+    - you may need to `exec zsh` or similar for this command to be found, if using rbenv.
 3. `pod install`
 4. `git submodule init`
 5. `git submodule update`


### PR DESCRIPTION
When using rbenv + zsh, you need to `exec zsh` after installing cocoapods, for the command to be found.
