### PR TITLE
Make small windows float by default

### DIFF
--- a/Amethyst/AMConfiguration.h
+++ b/Amethyst/AMConfiguration.h
@@ -44,4 +44,6 @@
 - (BOOL)runningApplicationShouldFloat:(NSRunningApplication *)runningApplication;
 
 - (BOOL)ignoreMenuBar;
+
+- (BOOL)floatSmallWindows;
 @end

--- a/Amethyst/AMConfiguration.m
+++ b/Amethyst/AMConfiguration.m
@@ -62,6 +62,7 @@ static NSString *const AMConfigurationCommandToggleFloatKey = @"toggle-float";
 // should always be floating by default.
 static NSString *const AMConfigurationFloatingBundleIdentifiers = @"floating";
 static NSString *const AMConfigurationIgnoreMenuBar = @"ignore-menu-bar";
+static NSString *const AMConfigurationFloatSmallWindows = @"float-small-windows";
 
 @interface AMConfiguration ()
 @property (nonatomic, copy) NSDictionary *configuration;
@@ -283,7 +284,19 @@ static NSString *const AMConfigurationIgnoreMenuBar = @"ignore-menu-bar";
 }
 
 - (BOOL)ignoreMenuBar {
-    return [self.configuration[AMConfigurationIgnoreMenuBar] isEqualToString:@"true" ];
+    if (self.configuration[AMConfigurationIgnoreMenuBar]) {
+        return [self.configuration[AMConfigurationIgnoreMenuBar] isEqualToString:@"true"];
+    }
+
+    return [self.defaultConfiguration[AMConfigurationIgnoreMenuBar] isEqualToString:@"true"];
+}
+
+- (BOOL)floatSmallWindows {
+    if (self.configuration[AMConfigurationFloatSmallWindows]) {
+        return [self.configuration[AMConfigurationFloatSmallWindows] boolValue];
+    }
+
+    return [self.defaultConfiguration[AMConfigurationFloatSmallWindows] boolValue];
 }
 
 @end

--- a/Amethyst/AMWindowManager.m
+++ b/Amethyst/AMWindowManager.m
@@ -8,9 +8,8 @@
 
 #import "AMWindowManager.h"
 
-#import "AMFullscreenLayout.h"
+#import "AMConfiguration.h"
 #import "AMScreenManager.h"
-#import "AMTallLayout.h"
 #import "NSRunningApplication+Manageable.h"
 
 @interface AMWindowManager () <AMScreenManagerDelegate>
@@ -436,7 +435,7 @@
     SIApplication *application = [self applicationWithProcessIdentifier:window.processIdentifier];
 
     window.floating = application.floating;
-    if (window.frame.size.width < 500 && window.frame.size.height < 500) {
+    if (AMConfiguration.sharedConfiguration.floatSmallWindows && window.frame.size.width < 500 && window.frame.size.height < 500) {
         window.floating = YES;
     }
 

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -178,5 +178,6 @@
 
     "MISC": "----------------------",
     "floating": [],
-    "ignore-menu-bar": "false"
+    "ignore-menu-bar": "false",
+    "float-small-windows": true,
 }


### PR DESCRIPTION
Right now "small" is defined as fitting within 500x500. This most noticeably catches Finder auxiliary windows (e.g. copying files).

Fixes #62 
