### PR TITLE
Feature display layout in menubar

### DIFF
--- a/Amethyst/AMAppDelegate.h
+++ b/Amethyst/AMAppDelegate.h
@@ -12,4 +12,6 @@
 
 @property (assign) IBOutlet NSWindow *window;
 
+- (void)setCurrentLayoutInStatus:(NSString *)layout;
+
 @end

--- a/Amethyst/AMAppDelegate.m
+++ b/Amethyst/AMAppDelegate.m
@@ -62,4 +62,8 @@
     self.startAtLoginMenuItem.state = (NSBundle.mainBundle.isLoginItem ? NSOnState : NSOffState);
 }
 
+- (void)setCurrentLayoutInStatus:(NSString *)layout {
+    self.statusItem.title = layout;
+}
+
 @end

--- a/Amethyst/AMConfiguration.h
+++ b/Amethyst/AMConfiguration.h
@@ -46,4 +46,6 @@
 - (BOOL)ignoreMenuBar;
 
 - (BOOL)floatSmallWindows;
+
+- (BOOL)displayLayoutInMenubar;
 @end

--- a/Amethyst/AMConfiguration.m
+++ b/Amethyst/AMConfiguration.m
@@ -64,6 +64,7 @@ static NSString *const AMConfigurationCommandDisplayCurrentLayoutKey = @"display
 static NSString *const AMConfigurationFloatingBundleIdentifiers = @"floating";
 static NSString *const AMConfigurationIgnoreMenuBar = @"ignore-menu-bar";
 static NSString *const AMConfigurationFloatSmallWindows = @"float-small-windows";
+static NSString *const AMConfigurationDisplayLayoutInMenubar = @"display-layout-in-menubar";
 
 @interface AMConfiguration ()
 @property (nonatomic, copy) NSDictionary *configuration;
@@ -302,6 +303,14 @@ static NSString *const AMConfigurationFloatSmallWindows = @"float-small-windows"
     }
 
     return [self.defaultConfiguration[AMConfigurationFloatSmallWindows] boolValue];
+}
+
+- (BOOL)displayLayoutInMenubar {
+    if (self.configuration[AMConfigurationDisplayLayoutInMenubar]) {
+        return [self.configuration[AMConfigurationDisplayLayoutInMenubar] boolValue];
+    }
+
+    return [self.defaultConfiguration[AMConfigurationDisplayLayoutInMenubar] boolValue];
 }
 
 @end

--- a/Amethyst/AMScreenManager.h
+++ b/Amethyst/AMScreenManager.h
@@ -74,4 +74,6 @@ typedef void (^AMScreenManagerLayoutUpdater)(AMLayout *layout);
 
 - (void)displayLayoutHUD;
 
+- (void)updateLayoutInStatus;
+
 @end

--- a/Amethyst/AMScreenManager.m
+++ b/Amethyst/AMScreenManager.m
@@ -12,6 +12,7 @@
 #import "AMLayout.h"
 #import "AMLayoutNameWindow.h"
 #import "AMWindowManager.h"
+#import "AMAppDelegate.h"
 
 @interface AMScreenManager ()
 @property (nonatomic, strong) NSScreen *screen;
@@ -65,6 +66,10 @@
             @strongify(self);
 
             [self displayLayoutHUD];
+
+            if ([AMConfiguration.sharedConfiguration displayLayoutInMenubar]) {
+              [self updateLayoutInStatus];
+            }
         }];
     }
     return self;
@@ -92,6 +97,11 @@
             self.layoutsBySpaceIdentifier[_currentSpaceIdentifier] = layouts;
         }
     }
+}
+
+- (void)updateLayoutInStatus {
+    AMAppDelegate *appDelegate = (AMAppDelegate *) [[NSApplication sharedApplication] delegate]; 
+    [appDelegate setCurrentLayoutInStatus:[self.currentLayout.class layoutName]];
 }
 
 - (void)displayLayoutHUD {

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -184,4 +184,5 @@
     "floating": [],
     "ignore-menu-bar": "false",
     "float-small-windows": true,
+    "display-layout-in-menubar": true,
 }


### PR DESCRIPTION
Option to display the current layout in menu bar, configurable via `.amethyst`.  

It hooks onto the event that displays the layout HUD and updates the status bar conditionally based on the entry in the user's configuration file, or the default entry if that does not exist.
