### PR TITLE
Added configuration key to disable layout HUD.

### DIFF
--- a/Amethyst/AMConfiguration.h
+++ b/Amethyst/AMConfiguration.h
@@ -49,5 +49,7 @@
 
 - (BOOL)mouseFollowsFocus;
 
+- (BOOL)showLayoutHUDOnSpaceChange;
+
 @property (nonatomic, assign) BOOL tilingEnabled;
 @end

--- a/Amethyst/AMConfiguration.m
+++ b/Amethyst/AMConfiguration.m
@@ -68,7 +68,7 @@ static NSString *const AMConfigurationFloatingBundleIdentifiers = @"floating";
 static NSString *const AMConfigurationIgnoreMenuBar = @"ignore-menu-bar";
 static NSString *const AMConfigurationFloatSmallWindows = @"float-small-windows";
 static NSString *const AMConfigurationMouseFollowsFocus = @"mouse-follows-focus";
-
+static NSString *const AMConfigurationShowHUDOnSpaceChange = @"show-layout-HUD-on-space-change";
 
 @interface AMConfiguration ()
 @property (nonatomic, copy) NSDictionary *configuration;
@@ -329,6 +329,14 @@ static NSString *const AMConfigurationMouseFollowsFocus = @"mouse-follows-focus"
     }
 
     return [self.defaultConfiguration[AMConfigurationMouseFollowsFocus] boolValue];
+}
+
+- (BOOL)showLayoutHUDOnSpaceChange {
+    if (self.configuration[AMConfigurationShowHUDOnSpaceChange]) {
+        return [self.configuration[AMConfigurationShowHUDOnSpaceChange] boolValue];
+    }
+
+    return [self.defaultConfiguration[AMConfigurationShowHUDOnSpaceChange] boolValue];
 }
 
 @end

--- a/Amethyst/AMScreenManager.m
+++ b/Amethyst/AMScreenManager.m
@@ -60,12 +60,16 @@
             }
         }
 
-        @weakify(self);
-        [RACObserve(self, currentLayoutIndex) subscribeNext:^(NSNumber *currentLayoutIndex) {
-            @strongify(self);
+        if ([[AMConfiguration sharedConfiguration] showLayoutHUDOnSpaceChange]) {
+            @weakify(self);
+            [RACObserve(self, currentLayoutIndex) subscribeNext:^(NSNumber *currentLayoutIndex) {
+                @strongify(self);
 
-            [self displayLayoutHUD];
-        }];
+                [self displayLayoutHUD];
+            }];
+        } else {
+            [self hideLayoutHUD:self];
+        }
     }
     return self;
 }

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -187,5 +187,6 @@
     "MISC": "----------------------",
     "floating": [],
     "float-small-windows": true,
-    "mouse-follows-focus": false
+    "mouse-follows-focus": false,
+    "show-layout-HUD-on-space-change": true
 }


### PR DESCRIPTION
Configuration key is "show-layout-HUD-on-space-change", added a new
entry in the default config with the value true.
Modified the initWithScreen:delegate to wrap the observe call.

I find myself switching spaces very often, and being able to turn off the HUD makes the switch quieter.
The configuration key is a bit long, but descriptive. Tell me if you prefer another one.
