### PR TITLE
Amethyst sometimes fails to set up Spaces mappings for windows

### DIFF
--- a/Amethyst/AMWindowManager.m
+++ b/Amethyst/AMWindowManager.m
@@ -95,7 +95,9 @@
     [[NSUserDefaults standardUserDefaults] removeSuiteNamed:@"com.apple.spaces"];
     [[NSUserDefaults standardUserDefaults] addSuiteNamed:@"com.apple.spaces"];
 
-    NSArray *spaceProperties = [[NSUserDefaults standardUserDefaults] dictionaryForKey:@"SpacesConfiguration"][@"Space Properties"];
+    NSMutableArray *spaceProperties = [[[NSUserDefaults standardUserDefaults] dictionaryForKey:@"SpacesConfiguration"][@"Space Properties"] mutableCopy];
+    [spaceProperties addObjectsFromArray:[[NSUserDefaults standardUserDefaults] dictionaryForKey:@"SpacesDisplayConfiguration"][@"Space Properties"]];
+
     NSMutableDictionary *spaceIdentifiersByWindowNumber = [NSMutableDictionary dictionary];
     for (NSDictionary *spaceDictionary in spaceProperties) {
         NSArray *windows = spaceDictionary[@"windows"];


### PR DESCRIPTION
At least on my system, sometimes `defaults read com.apple.spaces` gives me weird data, where the `windows` array is empty for all spaces.  However, the data in the SpacesConfiguration key looks fine.  In addition to this, my open windows weren't showing up with a `kCGWindowListOptionOnScreenOnly` filter.

I've noticed that Amethyst register windows after I plug my laptop into an external monitor, and continue working through sleeps/unplugging.  However, this behavior is pretty consistent after a fresh reboot of my laptop. This patch, at least, resolves for the problem for me.  I have no clue if SpacesConfiguration will _always_ work for everyone else, however.

Another option is to read from _both_ SpacesDisplayConfiguration and SpacesConfiguration keys to populate `spaceIdentifiersByWindowNumber`.
