### PR TITLE
Make status item image work in Yosemite's dark mode

### DIFF
--- a/Amethyst/AMAppDelegate.m
+++ b/Amethyst/AMAppDelegate.m
@@ -47,10 +47,14 @@
     }
 
     RAC(self, statusItem.image) = [RACObserve(AMConfiguration.sharedConfiguration, tilingEnabled) map:^id(NSNumber *tilingEnabled) {
+        NSImage *statusImage;
         if (tilingEnabled.boolValue) {
-            return [NSImage imageNamed:@"icon-statusitem"];
+            statusImage = [NSImage imageNamed:@"icon-statusitem"];
+        } else {
+            statusImage = [NSImage imageNamed:@"icon-statusitem-disabled"];
         }
-        return [NSImage imageNamed:@"icon-statusitem-disabled"];
+        [statusImage setTemplate:YES];
+        return statusImage;
     }];
 
 //    NSString *crashlyticsAPIKey = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"AMCrashlyticsAPIKey"];


### PR DESCRIPTION
@ianyh - template images work in normal mode as well as dark mode
