### PR TITLE
Migrate reflow to NSOperation and add some more intelligent cancelling

### DIFF
--- a/Amethyst.xcodeproj/project.pbxproj
+++ b/Amethyst.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		40A0A1F218F1AB60000B7614 /* AMRowLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C09C2AA18C1400F00CF5E6A /* AMRowLayout.m */; };
 		40A0A1FA18F1B401000B7614 /* AMWidescreenTallLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 40A0A1F918F1B401000B7614 /* AMWidescreenTallLayout.m */; };
 		40A0A1FB18F1B401000B7614 /* AMWidescreenTallLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 40A0A1F918F1B401000B7614 /* AMWidescreenTallLayout.m */; };
+		40AFA5AF1A0D19DF0030BC4B /* AMReflowOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 40AFA5AE1A0D19DF0030BC4B /* AMReflowOperation.m */; };
 		40B337E01745CE2B0001D8FC /* AMLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 40B337DF1745CE2B0001D8FC /* AMLayout.m */; };
 		40B337E41745D0620001D8FC /* AMFullscreenLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 40B337E31745D0620001D8FC /* AMFullscreenLayout.m */; };
 		40B337EB17465AE00001D8FC /* AMTallLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 40B337EA17465AE00001D8FC /* AMTallLayout.m */; };
@@ -160,6 +161,8 @@
 		404B0FFC1800EF7700309019 /* SIWindow+Amethyst.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SIWindow+Amethyst.m"; sourceTree = "<group>"; };
 		40A0A1F818F1B400000B7614 /* AMWidescreenTallLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMWidescreenTallLayout.h; sourceTree = "<group>"; };
 		40A0A1F918F1B401000B7614 /* AMWidescreenTallLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMWidescreenTallLayout.m; sourceTree = "<group>"; };
+		40AFA5AD1A0D19DF0030BC4B /* AMReflowOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMReflowOperation.h; sourceTree = "<group>"; };
+		40AFA5AE1A0D19DF0030BC4B /* AMReflowOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMReflowOperation.m; sourceTree = "<group>"; };
 		40B337DE1745CE2B0001D8FC /* AMLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMLayout.h; sourceTree = "<group>"; };
 		40B337DF1745CE2B0001D8FC /* AMLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMLayout.m; sourceTree = "<group>"; };
 		40B337E21745D0620001D8FC /* AMFullscreenLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMFullscreenLayout.h; sourceTree = "<group>"; };
@@ -376,6 +379,8 @@
 				5C09C2AA18C1400F00CF5E6A /* AMRowLayout.m */,
 				40A0A1F818F1B400000B7614 /* AMWidescreenTallLayout.h */,
 				40A0A1F918F1B401000B7614 /* AMWidescreenTallLayout.m */,
+				40AFA5AD1A0D19DF0030BC4B /* AMReflowOperation.h */,
+				40AFA5AE1A0D19DF0030BC4B /* AMReflowOperation.m */,
 			);
 			name = Layout;
 			sourceTree = "<group>";
@@ -668,6 +673,7 @@
 				402DB6EE1742E41A00D1C936 /* main.m in Sources */,
 				402DB6F51742E41A00D1C936 /* AMAppDelegate.m in Sources */,
 				4010E7F2174540220066097B /* AMWindowManager.m in Sources */,
+				40AFA5AF1A0D19DF0030BC4B /* AMReflowOperation.m in Sources */,
 				4008E730190C4E020049E2F6 /* AMGeneralPreferencesViewController.m in Sources */,
 				40B39286181497C0009A296B /* AMLayoutNameWindow.m in Sources */,
 				4008E73E190D81580049E2F6 /* AMShortcutsPreferencesListItemView.m in Sources */,

--- a/Amethyst.xcworkspace/xcshareddata/Amethyst.xccheckout
+++ b/Amethyst.xcworkspace/xcshareddata/Amethyst.xccheckout
@@ -10,6 +10,8 @@
 	<string>Amethyst</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
+		<key>97095EF4BAD9C8BA095B8F3D5815B76960EDFC8C</key>
+		<string>https://github.com/ianyh/wedding.git</string>
 		<key>BE91C9C5ADF3ADEE2969E31AF581A0C779CC0273</key>
 		<string>ssh://github.com/ianyh/Silica.git</string>
 		<key>EF1CF5E1F342919DE309B5C9DAEDDCF1D12D0402</key>
@@ -21,6 +23,8 @@
 	<string>Amethyst.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
+		<key>97095EF4BAD9C8BA095B8F3D5815B76960EDFC8C</key>
+		<string>../../wedding</string>
 		<key>BE91C9C5ADF3ADEE2969E31AF581A0C779CC0273</key>
 		<string>../../Silica</string>
 		<key>EF1CF5E1F342919DE309B5C9DAEDDCF1D12D0402</key>
@@ -59,6 +63,14 @@
 			<string>EF1CF5E1F342919DE309B5C9DAEDDCF1D12D0402</string>
 			<key>IDESourceControlWCCName</key>
 			<string>Sparkle</string>
+		</dict>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>97095EF4BAD9C8BA095B8F3D5815B76960EDFC8C</string>
+			<key>IDESourceControlWCCName</key>
+			<string>wedding</string>
 		</dict>
 	</array>
 </dict>

--- a/Amethyst/AMColumnLayout.m
+++ b/Amethyst/AMColumnLayout.m
@@ -8,6 +8,11 @@
 
 #import "AMColumnLayout.h"
 
+#import "AMReflowOperation.h"
+
+@interface AMColumnReflowOperation : AMReflowOperation
+@end
+
 @implementation AMColumnLayout
 
 #pragma mark AMLayout
@@ -16,19 +21,30 @@
     return @"Columns";
 }
 
-- (void)reflowScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
-    if (windows.count == 0) return;
+- (NSOperation *)reflowOperationForScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
+    return [[AMColumnReflowOperation alloc] initWithScreen:screen windows:windows];
+}
 
-    CGRect screenFrame = [self adjustedFrameForLayout:screen];
-    CGFloat windowWidth = screenFrame.size.width / windows.count;
+@end
 
+@implementation AMColumnReflowOperation
+
+- (void)main {
+    if (self.windows.count == 0) return;
+    
+    CGRect screenFrame = [self adjustedFrameForLayout:self.screen];
+    CGFloat windowWidth = screenFrame.size.width / self.windows.count;
+    
     SIWindow *focusedWindow = [SIWindow focusedWindow];
-
-    for (NSUInteger windowIndex = 0; windowIndex < windows.count; ++windowIndex) {
-        SIWindow *window = windows[windowIndex];
+    
+    for (NSUInteger windowIndex = 0; windowIndex < self.windows.count; ++windowIndex) {
+        if (self.cancelled) {
+            return;
+        }
+        SIWindow *window = self.windows[windowIndex];
         CGRect windowFrame = {
-            .origin.x = screen.frameWithoutDockOrMenu.origin.x + windowIndex * windowWidth,
-            .origin.y = screen.frameWithoutDockOrMenu.origin.y,
+            .origin.x = self.screen.frameWithoutDockOrMenu.origin.x + windowIndex * windowWidth,
+            .origin.y = self.screen.frameWithoutDockOrMenu.origin.y,
             .size.width = windowWidth,
             .size.height = screenFrame.size.height
         };

--- a/Amethyst/AMFloatingLayout.m
+++ b/Amethyst/AMFloatingLayout.m
@@ -13,8 +13,9 @@
     return @"Floating";
 }
 
-- (void)reflowScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
+- (NSOperation *)reflowOperationForScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
     // noop
+    return [[NSOperation alloc] init];
 }
 
 @end

--- a/Amethyst/AMFullscreenLayout.m
+++ b/Amethyst/AMFullscreenLayout.m
@@ -8,7 +8,26 @@
 
 #import "AMFullscreenLayout.h"
 
+#import "AMReflowOperation.h"
 #import "AMWindowManager.h"
+
+@interface AMFullscreenReflowOperation: AMReflowOperation
+@end
+
+@implementation AMFullscreenReflowOperation
+
+- (void)main {
+    CGRect screenFrame = [self adjustedFrameForLayout:self.screen];
+    
+    for (SIWindow *window in self.windows) {
+        if (self.cancelled) {
+            return;
+        }
+        window.frame = screenFrame;
+    }
+}
+
+@end
 
 @implementation AMFullscreenLayout
 
@@ -16,12 +35,8 @@
     return @"Fullscreen";
 }
 
-- (void)reflowScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
-    CGRect screenFrame = [self adjustedFrameForLayout:screen];
-
-    for (SIWindow *window in windows) {
-        window.frame = screenFrame;
-    }
+- (NSOperation *)reflowOperationForScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
+    return [[AMFullscreenReflowOperation alloc] initWithScreen:screen windows:windows];
 }
 
 @end

--- a/Amethyst/AMLayout.h
+++ b/Amethyst/AMLayout.h
@@ -26,14 +26,7 @@
 
 + (NSString *)layoutName;
 
-// Organizes the windows within a screen's frame.
-//
-// screen  - The screen on which windows will be laid out.
-// windows - The windows to be laid out on the screen.
-//
-// Subclasses MUST override this method to layout windows according to their specific algorithm.
-// Subclasses MUST NOT call super's implementation.
-- (void)reflowScreen:(NSScreen *)screen withWindows:(NSArray *)windows;
+- (NSOperation *)reflowOperationForScreen:(NSScreen *)screen withWindows:(NSArray *)windows;
 
 // Shrink the size of the main pane of content.
 // Subclasses can optionally implement this method.
@@ -50,18 +43,5 @@
 // Decrease the number of windows in the main pane of content.
 // Subclasses can optionally implement this method.
 - (void)decreaseMainPaneCount;
-
-// Returns the desired frame for the current layout based on the user's
-// configuration.
-//
-// screen - The screen from which the proper frame is desired.
-- (CGRect)adjustedFrameForLayout:(NSScreen *)screen;
-
-// Assigns the desired frame to the window taking into account whether or not the window is focused.
-//
-// frame    - The frame to set the window to. Frame origin may not be respected if window is focused.
-// window   - The window to set frame for.
-// focused  - YES if the window is the currently focused window.
-- (void)assignFrame:(CGRect)finalFrame toWindow:(SIWindow *)window focused:(BOOL)focused screenFrame:(CGRect)screenFrame;
 
 @end

--- a/Amethyst/AMLayout.m
+++ b/Amethyst/AMLayout.m
@@ -14,7 +14,7 @@
 
 + (NSString *)layoutName { return nil; }
 
-- (void)reflowScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
+- (NSOperation *)reflowOperationForScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
     @throw [NSException exceptionWithName:NSGenericException reason:@"Method should be implemented by subclasses." userInfo:nil];
 }
 
@@ -23,29 +23,5 @@
 
 - (void)increaseMainPaneCount {}
 - (void)decreaseMainPaneCount {}
-
-- (CGRect)adjustedFrameForLayout:(NSScreen *)screen {
-   return [[AMConfiguration sharedConfiguration] ignoreMenuBar] ? screen.frameIncludingDockAndMenu : screen.frameWithoutDockOrMenu;
-}
-
-- (void)assignFrame:(CGRect)finalFrame toWindow:(SIWindow *)window focused:(BOOL)focused screenFrame:(CGRect)screenFrame {
-    CGPoint finalPosition = finalFrame.origin;
-
-    // Just resize the window
-    finalFrame.origin = window.frame.origin;
-    window.frame = finalFrame;
-
-    if (focused) {
-        finalFrame.size = CGSizeMake(MAX(window.frame.size.width, finalFrame.size.width), MAX(window.frame.size.height, finalFrame.size.height));
-        if (!CGRectContainsRect(screenFrame, finalFrame)) {
-            finalPosition.x = MIN(finalPosition.x, CGRectGetMaxX(screenFrame) - CGRectGetWidth(finalFrame));
-            finalPosition.y = MIN(finalPosition.y, CGRectGetMaxY(screenFrame) - CGRectGetHeight(finalFrame));
-        }
-    }
-
-    // Move the window to its final frame
-    finalFrame.origin = finalPosition;
-    window.frame = finalFrame;
-}
 
 @end

--- a/Amethyst/AMPrefixImport.h
+++ b/Amethyst/AMPrefixImport.h
@@ -20,6 +20,7 @@
 #import "NSScreen+Amethyst.h"
 #import "SIWindow+Amethyst.h"
 #import "SIApplication+Amethyst.h"
+//#import "_CGSSpace.h"
 
 #ifdef DEBUG
 static const int ddLogLevel = LOG_LEVEL_VERBOSE;

--- a/Amethyst/AMReflowOperation.h
+++ b/Amethyst/AMReflowOperation.h
@@ -1,0 +1,31 @@
+//
+//  AMReflowOperation.h
+//  Amethyst
+//
+//  Created by Ian Ynda-Hummel on 11/7/14.
+//  Copyright (c) 2014 Ian Ynda-Hummel. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface AMReflowOperation : NSOperation
+
+- (instancetype)initWithScreen:(NSScreen *)screen windows:(NSArray *)windows;
+
+@property (nonatomic, strong, readonly) NSScreen *screen;
+@property (nonatomic, strong, readonly) NSArray *windows;
+
+// Returns the desired frame for the current layout based on the user's
+// configuration.
+//
+// screen - The screen from which the proper frame is desired.
+- (CGRect)adjustedFrameForLayout:(NSScreen *)screen;
+
+// Assigns the desired frame to the window taking into account whether or not the window is focused.
+//
+// frame    - The frame to set the window to. Frame origin may not be respected if window is focused.
+// window   - The window to set frame for.
+// focused  - YES if the window is the currently focused window.
+- (void)assignFrame:(CGRect)finalFrame toWindow:(SIWindow *)window focused:(BOOL)focused screenFrame:(CGRect)screenFrame;
+
+@end

--- a/Amethyst/AMReflowOperation.m
+++ b/Amethyst/AMReflowOperation.m
@@ -1,0 +1,61 @@
+//
+//  AMReflowOperation.m
+//  Amethyst
+//
+//  Created by Ian Ynda-Hummel on 11/7/14.
+//  Copyright (c) 2014 Ian Ynda-Hummel. All rights reserved.
+//
+
+#import "AMReflowOperation.h"
+
+#import "AMConfiguration.h"
+
+@interface AMReflowOperation ()
+@property (nonatomic, strong) NSScreen *screen;
+@property (nonatomic, strong) NSArray *windows;
+@end
+
+@implementation AMReflowOperation
+
+- (instancetype)initWithScreen:(NSScreen *)screen windows:(NSArray *)windows {
+    self = [super init];
+    if (self) {
+        self.screen = screen;
+        self.windows = windows;
+    }
+    return self;
+}
+
+- (CGRect)adjustedFrameForLayout:(NSScreen *)screen {
+    return [[AMConfiguration sharedConfiguration] ignoreMenuBar] ? screen.frameIncludingDockAndMenu : screen.frameWithoutDockOrMenu;
+}
+
+- (void)assignFrame:(CGRect)finalFrame toWindow:(SIWindow *)window focused:(BOOL)focused screenFrame:(CGRect)screenFrame {
+    if (self.cancelled) {
+        return;
+    }
+
+    if (CGSManagedDisplayIsAnimating(CGSDefaultConnection, (__bridge CFStringRef)self.screen.am_screenIdentifier)) {
+        return;
+    }
+
+    CGPoint finalPosition = finalFrame.origin;
+    
+    // Just resize the window
+    finalFrame.origin = window.frame.origin;
+    window.frame = finalFrame;
+    
+    if (focused) {
+        finalFrame.size = CGSizeMake(MAX(window.frame.size.width, finalFrame.size.width), MAX(window.frame.size.height, finalFrame.size.height));
+        if (!CGRectContainsRect(screenFrame, finalFrame)) {
+            finalPosition.x = MIN(finalPosition.x, CGRectGetMaxX(screenFrame) - CGRectGetWidth(finalFrame));
+            finalPosition.y = MIN(finalPosition.y, CGRectGetMaxY(screenFrame) - CGRectGetHeight(finalFrame));
+        }
+    }
+    
+    // Move the window to its final frame
+    finalFrame.origin = finalPosition;
+    window.frame = finalFrame;
+}
+
+@end

--- a/Amethyst/AMRowLayout.m
+++ b/Amethyst/AMRowLayout.m
@@ -8,25 +8,41 @@
 
 #import "AMRowLayout.h"
 
+#import "AMReflowOperation.h"
+
+@interface AMRowReflowOperation : AMReflowOperation
+@end
+
 @implementation AMRowLayout
 
 + (NSString *)layoutName {
     return @"Rows";
 }
 
-- (void)reflowScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
-    if (windows.count == 0) return;
+- (NSOperation *)reflowOperationForScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
+    return [[AMRowReflowOperation alloc] initWithScreen:screen windows:windows];
+}
+
+@end
+
+@implementation AMRowReflowOperation
+
+- (void)main {
+    if (self.windows.count == 0) return;
     
-    CGRect screenFrame = [self adjustedFrameForLayout:screen];
-    CGFloat windowHeight = screenFrame.size.height / windows.count;
+    CGRect screenFrame = [self adjustedFrameForLayout:self.screen];
+    CGFloat windowHeight = screenFrame.size.height / self.windows.count;
     
     SIWindow *focusedWindow = [SIWindow focusedWindow];
     
-    for (NSUInteger windowIndex = 0; windowIndex < windows.count; ++windowIndex) {
-        SIWindow *window = windows[windowIndex];
+    for (NSUInteger windowIndex = 0; windowIndex < self.windows.count; ++windowIndex) {
+        if (self.cancelled) {
+            return;
+        }
+        SIWindow *window = self.windows[windowIndex];
         CGRect windowFrame = {
-            .origin.x = screen.frameWithoutDockOrMenu.origin.x,
-            .origin.y = screen.frameWithoutDockOrMenu.origin.y + windowIndex * windowHeight,
+            .origin.x = self.screen.frameWithoutDockOrMenu.origin.x,
+            .origin.y = self.screen.frameWithoutDockOrMenu.origin.y + windowIndex * windowHeight,
             .size.width = screenFrame.size.width,
             .size.height = windowHeight
         };

--- a/Amethyst/AMTallLayout.m
+++ b/Amethyst/AMTallLayout.m
@@ -8,7 +8,14 @@
 
 #import "AMTallLayout.h"
 
+#import "AMReflowOperation.h"
 #import "AMWindowManager.h"
+
+@interface AMTallReflowOperation : AMReflowOperation
+- (instancetype)initWithScreen:(NSScreen *)screen windows:(NSArray *)windows layout:(AMTallLayout *)layout;
+@property (nonatomic, strong) AMTallLayout *layout;
+@end
+
 
 @interface AMTallLayout ()
 // Ratio of screen width taken up by main pane
@@ -36,42 +43,8 @@
     return @"Tall";
 }
 
-- (void)reflowScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
-    if (windows.count == 0) return;
-
-    NSUInteger mainPaneCount = MIN(windows.count, self.mainPaneCount);
-
-    NSInteger secondaryPaneCount = windows.count - mainPaneCount;
-    BOOL hasSecondaryPane = (secondaryPaneCount > 0);
-
-    CGRect screenFrame = [self adjustedFrameForLayout:screen];
-
-    CGFloat mainPaneWindowHeight = round(screenFrame.size.height / mainPaneCount);
-    CGFloat secondaryPaneWindowHeight = (hasSecondaryPane ? round(screenFrame.size.height / secondaryPaneCount) : 0.0);
-
-    CGFloat mainPaneWindowWidth = round(screenFrame.size.width * (hasSecondaryPane ? self.mainPaneRatio : 1));
-    CGFloat secondaryPaneWindowWidth = screenFrame.size.width - mainPaneWindowWidth;
-
-    SIWindow *focusedWindow = [SIWindow focusedWindow];
-
-    for (NSUInteger windowIndex = 0; windowIndex < windows.count; ++windowIndex) {
-        SIWindow *window = windows[windowIndex];
-        CGRect windowFrame;
-
-        if (windowIndex < mainPaneCount) {
-            windowFrame.origin.x = screenFrame.origin.x;
-            windowFrame.origin.y = screenFrame.origin.y + (mainPaneWindowHeight * windowIndex);
-            windowFrame.size.width = mainPaneWindowWidth;
-            windowFrame.size.height = mainPaneWindowHeight;
-        } else {
-            windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth;
-            windowFrame.origin.y = screenFrame.origin.y + (secondaryPaneWindowHeight * (windowIndex - mainPaneCount));
-            windowFrame.size.width = secondaryPaneWindowWidth;
-            windowFrame.size.height = secondaryPaneWindowHeight;
-        }
-
-        [self assignFrame:windowFrame toWindow:window focused:[window isEqualTo:focusedWindow] screenFrame:screenFrame];
-    }
+- (NSOperation *)reflowOperationForScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
+    return [[AMTallReflowOperation alloc] initWithScreen:screen windows:windows layout:self];
 }
 
 - (void)expandMainPane {
@@ -88,6 +61,59 @@
 
 - (void)decreaseMainPaneCount {
     self.mainPaneCount = MAX(1, self.mainPaneCount - 1);
+}
+
+@end
+
+@implementation AMTallReflowOperation
+
+- (instancetype)initWithScreen:(NSScreen *)screen windows:(NSArray *)windows layout:(AMTallLayout *)layout {
+    self = [super initWithScreen:screen windows:windows];
+    if (self) {
+        self.layout = layout;
+    }
+    return self;
+}
+
+- (void)main {
+    if (self.windows.count == 0) return;
+    
+    NSUInteger mainPaneCount = MIN(self.windows.count, self.layout.mainPaneCount);
+    
+    NSInteger secondaryPaneCount = self.windows.count - mainPaneCount;
+    BOOL hasSecondaryPane = (secondaryPaneCount > 0);
+    
+    CGRect screenFrame = [self adjustedFrameForLayout:self.screen];
+    
+    CGFloat mainPaneWindowHeight = round(screenFrame.size.height / mainPaneCount);
+    CGFloat secondaryPaneWindowHeight = (hasSecondaryPane ? round(screenFrame.size.height / secondaryPaneCount) : 0.0);
+    
+    CGFloat mainPaneWindowWidth = round(screenFrame.size.width * (hasSecondaryPane ? self.layout.mainPaneRatio : 1));
+    CGFloat secondaryPaneWindowWidth = screenFrame.size.width - mainPaneWindowWidth;
+    
+    SIWindow *focusedWindow = [SIWindow focusedWindow];
+    
+    for (NSUInteger windowIndex = 0; windowIndex < self.windows.count; ++windowIndex) {
+        if (self.cancelled) {
+            return;
+        }
+        SIWindow *window = self.windows[windowIndex];
+        CGRect windowFrame;
+        
+        if (windowIndex < mainPaneCount) {
+            windowFrame.origin.x = screenFrame.origin.x;
+            windowFrame.origin.y = screenFrame.origin.y + (mainPaneWindowHeight * windowIndex);
+            windowFrame.size.width = mainPaneWindowWidth;
+            windowFrame.size.height = mainPaneWindowHeight;
+        } else {
+            windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth;
+            windowFrame.origin.y = screenFrame.origin.y + (secondaryPaneWindowHeight * (windowIndex - mainPaneCount));
+            windowFrame.size.width = secondaryPaneWindowWidth;
+            windowFrame.size.height = secondaryPaneWindowHeight;
+        }
+        
+        [self assignFrame:windowFrame toWindow:window focused:[window isEqualTo:focusedWindow] screenFrame:screenFrame];
+    }
 }
 
 @end

--- a/Amethyst/AMWideLayout.m
+++ b/Amethyst/AMWideLayout.m
@@ -8,7 +8,13 @@
 
 #import "AMWideLayout.h"
 
+#import "AMReflowOperation.h"
 #import "AMWindowManager.h"
+
+@interface AMWideReflowOperation : AMReflowOperation
+- (instancetype)initWithScreen:(NSScreen *)screen windows:(NSArray *)windows layout:(AMWideLayout *)layout;
+@property (nonatomic, strong) AMWideLayout *layout;
+@end
 
 @interface AMWideLayout ()
 // Ratio of screen height taken up by main pane.
@@ -37,42 +43,8 @@
     return @"Wide";
 }
 
-- (void)reflowScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
-    if (windows.count == 0) return;
-
-    NSUInteger mainPaneCount = MIN(windows.count, self.mainPaneCount);
-    
-    NSInteger secondaryPaneCount = windows.count - mainPaneCount;
-    BOOL hasSecondaryPane = (secondaryPaneCount > 0);
-    
-    CGRect screenFrame = [self adjustedFrameForLayout:screen];
-    
-    CGFloat mainPaneWindowWidth = round(screenFrame.size.width / mainPaneCount);
-    CGFloat secondaryPaneWindowWidth = (hasSecondaryPane ? round(screenFrame.size.width / secondaryPaneCount) : 0.0);
-
-    CGFloat mainPaneWindowHeight = round(screenFrame.size.height * (hasSecondaryPane ? self.mainPaneRatio : 1));
-    CGFloat secondaryPaneWindowHeight = screenFrame.size.height - mainPaneWindowHeight;
-    
-    SIWindow *focusedWindow = [SIWindow focusedWindow];
-
-    for (NSUInteger windowIndex = 0; windowIndex < windows.count; ++windowIndex) {
-        SIWindow *window = windows[windowIndex];
-        CGRect windowFrame;
-
-        if (windowIndex < mainPaneCount) {
-            windowFrame.origin.x = screenFrame.origin.x + (mainPaneWindowWidth * windowIndex);
-            windowFrame.origin.y = screenFrame.origin.y;
-            windowFrame.size.width = mainPaneWindowWidth;
-            windowFrame.size.height = mainPaneWindowHeight;
-        } else {
-            windowFrame.origin.x = screenFrame.origin.x + (secondaryPaneWindowWidth * (windowIndex - mainPaneCount));
-            windowFrame.origin.y = screenFrame.origin.y + mainPaneWindowHeight;
-            windowFrame.size.width = secondaryPaneWindowWidth;
-            windowFrame.size.height = secondaryPaneWindowHeight;
-        }
-
-        [self assignFrame:windowFrame toWindow:window focused:[window isEqualTo:focusedWindow] screenFrame:screenFrame];
-    }
+- (NSOperation *)reflowOperationForScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
+    return [[AMWideReflowOperation alloc] initWithScreen:screen windows:windows layout:self];
 }
 
 - (void)expandMainPane {
@@ -89,6 +61,59 @@
 
 - (void)decreaseMainPaneCount {
     self.mainPaneCount = MAX(1, self.mainPaneCount - 1);
+}
+
+@end
+
+@implementation AMWideReflowOperation
+
+- (instancetype)initWithScreen:(NSScreen *)screen windows:(NSArray *)windows layout:(AMWideLayout *)layout {
+    self = [super initWithScreen:screen windows:windows];
+    if (self) {
+        self.layout = layout;
+    }
+    return self;
+}
+
+- (void)main {
+    if (self.windows.count == 0) return;
+    
+    NSUInteger mainPaneCount = MIN(self.windows.count, self.layout.mainPaneCount);
+    
+    NSInteger secondaryPaneCount = self.windows.count - mainPaneCount;
+    BOOL hasSecondaryPane = (secondaryPaneCount > 0);
+    
+    CGRect screenFrame = [self adjustedFrameForLayout:self.screen];
+    
+    CGFloat mainPaneWindowWidth = round(screenFrame.size.width / mainPaneCount);
+    CGFloat secondaryPaneWindowWidth = (hasSecondaryPane ? round(screenFrame.size.width / secondaryPaneCount) : 0.0);
+    
+    CGFloat mainPaneWindowHeight = round(screenFrame.size.height * (hasSecondaryPane ? self.layout.mainPaneRatio : 1));
+    CGFloat secondaryPaneWindowHeight = screenFrame.size.height - mainPaneWindowHeight;
+    
+    SIWindow *focusedWindow = [SIWindow focusedWindow];
+    
+    for (NSUInteger windowIndex = 0; windowIndex < self.windows.count; ++windowIndex) {
+        if (self.cancelled) {
+            return;
+        }
+        SIWindow *window = self.windows[windowIndex];
+        CGRect windowFrame;
+        
+        if (windowIndex < mainPaneCount) {
+            windowFrame.origin.x = screenFrame.origin.x + (mainPaneWindowWidth * windowIndex);
+            windowFrame.origin.y = screenFrame.origin.y;
+            windowFrame.size.width = mainPaneWindowWidth;
+            windowFrame.size.height = mainPaneWindowHeight;
+        } else {
+            windowFrame.origin.x = screenFrame.origin.x + (secondaryPaneWindowWidth * (windowIndex - mainPaneCount));
+            windowFrame.origin.y = screenFrame.origin.y + mainPaneWindowHeight;
+            windowFrame.size.width = secondaryPaneWindowWidth;
+            windowFrame.size.height = secondaryPaneWindowHeight;
+        }
+        
+        [self assignFrame:windowFrame toWindow:window focused:[window isEqualTo:focusedWindow] screenFrame:screenFrame];
+    }
 }
 
 @end

--- a/Amethyst/AMWidescreenTallLayout.m
+++ b/Amethyst/AMWidescreenTallLayout.m
@@ -8,6 +8,13 @@
 
 #import "AMWidescreenTallLayout.h"
 
+#import "AMReflowOperation.h"
+
+@interface AMWidescreenReflowOperation : AMReflowOperation
+- (instancetype)initWithScreen:(NSScreen *)screen windows:(NSArray *)windows layout:(AMWidescreenTallLayout *)layout;
+@property (nonatomic, strong) AMWidescreenTallLayout *layout;
+@end
+
 @interface AMWidescreenTallLayout ()
 // Ratio of screen width taken up by main pane
 @property (nonatomic, assign) CGFloat mainPaneRatio;
@@ -32,42 +39,8 @@
     return @"Widescreen Tall";
 }
 
-- (void)reflowScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
-    if (windows.count == 0) return;
-
-    NSUInteger mainPaneCount = MIN(windows.count, self.mainPaneCount);
-
-    NSInteger secondaryPaneCount = windows.count - mainPaneCount;
-    BOOL hasSecondaryPane = (secondaryPaneCount > 0);
-
-    CGRect screenFrame = [self adjustedFrameForLayout:screen];
-
-    CGFloat mainPaneWindowHeight = screenFrame.size.height;
-    CGFloat secondaryPaneWindowHeight = (hasSecondaryPane ? round(screenFrame.size.height / secondaryPaneCount) : 0.0);
-
-    CGFloat mainPaneWindowWidth = round((screenFrame.size.width * (hasSecondaryPane ? self.mainPaneRatio : 1)) / mainPaneCount);
-    CGFloat secondaryPaneWindowWidth = screenFrame.size.width - mainPaneWindowWidth * mainPaneCount;
-
-    SIWindow *focusedWindow = [SIWindow focusedWindow];
-
-    for (NSUInteger windowIndex = 0; windowIndex < windows.count; ++windowIndex) {
-        SIWindow *window = windows[windowIndex];
-        CGRect windowFrame;
-
-        if (windowIndex < mainPaneCount) {
-            windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth * windowIndex;
-            windowFrame.origin.y = screenFrame.origin.y;
-            windowFrame.size.width = mainPaneWindowWidth;
-            windowFrame.size.height = mainPaneWindowHeight;
-        } else {
-            windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth * mainPaneCount;
-            windowFrame.origin.y = screenFrame.origin.y + (secondaryPaneWindowHeight * (windowIndex - mainPaneCount));
-            windowFrame.size.width = secondaryPaneWindowWidth;
-            windowFrame.size.height = secondaryPaneWindowHeight;
-        }
-
-        [self assignFrame:windowFrame toWindow:window focused:[window isEqualTo:focusedWindow] screenFrame:screenFrame];
-    }
+- (NSOperation *)reflowOperationForScreen:(NSScreen *)screen withWindows:(NSArray *)windows {
+    return [[AMWidescreenReflowOperation alloc] initWithScreen:screen windows:windows layout:self];
 }
 
 - (void)expandMainPane {
@@ -84,6 +57,56 @@
 
 - (void)decreaseMainPaneCount {
     self.mainPaneCount = MAX(1, self.mainPaneCount - 1);
+}
+
+@end
+
+@implementation AMWidescreenReflowOperation
+
+- (instancetype)initWithScreen:(NSScreen *)screen windows:(NSArray *)windows layout:(AMWidescreenTallLayout *)layout {
+    self = [super initWithScreen:screen windows:windows];
+    if (self) {
+        self.layout = layout;
+    }
+    return self;
+}
+
+- (void)main {
+    if (self.windows.count == 0) return;
+    
+    NSUInteger mainPaneCount = MIN(self.windows.count, self.layout.mainPaneCount);
+    
+    NSInteger secondaryPaneCount = self.windows.count - mainPaneCount;
+    BOOL hasSecondaryPane = (secondaryPaneCount > 0);
+    
+    CGRect screenFrame = [self adjustedFrameForLayout:self.screen];
+    
+    CGFloat mainPaneWindowHeight = screenFrame.size.height;
+    CGFloat secondaryPaneWindowHeight = (hasSecondaryPane ? round(screenFrame.size.height / secondaryPaneCount) : 0.0);
+    
+    CGFloat mainPaneWindowWidth = round((screenFrame.size.width * (hasSecondaryPane ? self.layout.mainPaneRatio : 1)) / mainPaneCount);
+    CGFloat secondaryPaneWindowWidth = screenFrame.size.width - mainPaneWindowWidth * mainPaneCount;
+    
+    SIWindow *focusedWindow = [SIWindow focusedWindow];
+    
+    for (NSUInteger windowIndex = 0; windowIndex < self.windows.count; ++windowIndex) {
+        SIWindow *window = self.windows[windowIndex];
+        CGRect windowFrame;
+        
+        if (windowIndex < mainPaneCount) {
+            windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth * windowIndex;
+            windowFrame.origin.y = screenFrame.origin.y;
+            windowFrame.size.width = mainPaneWindowWidth;
+            windowFrame.size.height = mainPaneWindowHeight;
+        } else {
+            windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth * mainPaneCount;
+            windowFrame.origin.y = screenFrame.origin.y + (secondaryPaneWindowHeight * (windowIndex - mainPaneCount));
+            windowFrame.size.width = secondaryPaneWindowWidth;
+            windowFrame.size.height = secondaryPaneWindowHeight;
+        }
+        
+        [self assignFrame:windowFrame toWindow:window focused:[window isEqualTo:focusedWindow] screenFrame:screenFrame];
+    }
 }
 
 @end


### PR DESCRIPTION
Moving to NSOperation gives much more flexibility in stopping reflows as they
become obsolete. This lets you do useful things like prevent reflows that
started on one space and finished on another, getting windows for both. It's
also just generally a cleaner interface.
