### PR TITLE
Readme: Use SVG badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Amethyst
 ========
 
-[![Build Status](https://travis-ci.org/ianyh/Amethyst.png?branch=master)](https://travis-ci.org/ianyh/Amethyst)
+[![Build Status](https://api.travis-ci.org/ianyh/Amethyst.svg?branch=master)](https://travis-ci.org/ianyh/Amethyst)
 
 Tiling window manager for OS X similar to xmonad, written in pure Objective-C.
 
@@ -182,7 +182,7 @@ Amethyst is free and always will be. That said, a couple of people have expresse
 * You can find a Patreon page [here](http://www.patreon.com/ianyh) if you would like to pledge money regularly for releases.
 * If you would like to do a one-time donation there's a PayPal button below. If there's some other method of donating that you would prefer open an issue and I'll try to add it!
 
-[![PayPal Donate](http://img.shields.io/paypal/donate.png?color=blue)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=ianynda%40gmail%2ecom&lc=US&item_name=Ian%20Ynda%2dHummel&item_number=Amethyst&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donate_LG%2egif%3aNonHosted)
+[![PayPal Donate](http://img.shields.io/badge/paypal-donate-blue.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=ianynda%40gmail%2ecom&lc=US&item_name=Ian%20Ynda%2dHummel&item_number=Amethyst&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donate_LG%2egif%3aNonHosted)
 
 If you are considering donating to me, you are more than welcome to. You should also consider donating that money to a charity in addition to or instead. Here's a very incomplete list of things that you might want to throw money at:
 


### PR DESCRIPTION
The paypal badge was actually deprecated. Using SVG gives better results, especially on retina screens or when zoomed (it stops being blurry).

Disclosure: I am the maintainer of Shields.io.

[Trello Card](https://trello.com/c/dlOjBY9u/107-amethyst-readme-use-svg-badges)
