### PR TITLE
Fix for titleless windows -- AXDialog windows

### DIFF
--- a/Amethyst/SIWindow+Amethyst.m
+++ b/Amethyst/SIWindow+Amethyst.m
@@ -25,6 +25,7 @@ static void *SIWindowFloatingKey = &SIWindowFloatingKey;
 
     if (!subrole) return YES;
     if ([subrole isEqualToString:(__bridge NSString *)kAXStandardWindowSubrole]) return YES;
+    if ([subrole isEqualToString:(__bridge NSString *)kAXDialogSubrole]) return YES;
 
     return NO;
 }


### PR DESCRIPTION
This is still a WIP but opening to get some help from other people.

So I have been able to fix the issue where title-less windows were ignored by Amethyst.  The subrole that was needed was `AXDialog`.  The commit I added now makes Amethyst aware it needs to tile these windows.  A working version of this can be see below.  A blank space is shown because I used quicktime to record the video on my screen and it is also an `AXDialog` window.

![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/5855593/11923372/6d7ae240-a770-11e5-8628-69e623b03ed6.gif)


All shortcuts work as expected except for ones that deal with focus.  I will continue looking into the focus thing further but since I don't know much about the project I didn't know if someone would know where this additional change needs to be made.
