### PR TITLE
Add shortcuts to move focused window left/right a space

### DIFF
--- a/Amethyst/AMConfiguration.m
+++ b/Amethyst/AMConfiguration.m
@@ -58,6 +58,8 @@ static NSString *const AMConfigurationCommandSwapCCWKey = @"swap-ccw";
 static NSString *const AMConfigurationCommandSwapCWKey = @"swap-cw";
 static NSString *const AMConfigurationCommandSwapMainKey = @"swap-main";
 static NSString *const AMConfigurationCommandThrowSpacePrefixKey = @"throw-space";
+static NSString *const AMConfigurationCommandThrowSpaceLeftKey = @"throw-space-left";
+static NSString *const AMConfigurationCommandThrowSpaceRightKey = @"throw-space-right";
 static NSString *const AMConfigurationCommandFocusScreenPrefixKey = @"focus-screen";
 static NSString *const AMConfigurationCommandThrowScreenPrefixKey = @"throw-screen";
 static NSString *const AMConfigurationCommandToggleFloatKey = @"toggle-float";
@@ -317,7 +319,7 @@ static NSString *const AMConfigurationUseCanaryBuild = @"use-canary-build";
     [self constructCommandWithHotKeyManager:hotKeyManager commandKey:AMConfigurationCommandDisplayCurrentLayoutKey handler:^{
         [windowManager displayCurrentLayout];
     }];
-    
+
     for (NSUInteger screenNumber = 1; screenNumber <= self.screens; ++screenNumber) {
         NSString *focusCommandKey = [AMConfigurationCommandFocusScreenPrefixKey stringByAppendingFormat:@"-%d", (unsigned int)screenNumber];
         NSString *throwCommandKey = [AMConfigurationCommandThrowScreenPrefixKey stringByAppendingFormat:@"-%d", (unsigned int)screenNumber];
@@ -338,6 +340,14 @@ static NSString *const AMConfigurationUseCanaryBuild = @"use-canary-build";
             [windowManager pushFocusedWindowToSpace:spaceNumber];
         }];
     }
+
+    [self constructCommandWithHotKeyManager:hotKeyManager commandKey:AMConfigurationCommandThrowSpaceLeftKey handler:^{
+        [windowManager pushFocusedWindowToSpaceLeft];
+    }];
+
+    [self constructCommandWithHotKeyManager:hotKeyManager commandKey:AMConfigurationCommandThrowSpaceRightKey handler:^{
+        [windowManager pushFocusedWindowToSpaceRight];
+    }];
 
     [self constructCommandWithHotKeyManager:hotKeyManager commandKey:AMConfigurationCommandToggleFloatKey handler:^{
         [windowManager toggleFloatForFocusedWindow];

--- a/Amethyst/AMWindowManager.h
+++ b/Amethyst/AMWindowManager.h
@@ -86,6 +86,16 @@
 // This method is a no-op if there is no focused window.
 - (void)pushFocusedWindowToSpace:(NSUInteger)space;
 
+// Moves the focused window left one space.
+//
+// This method is a no-op if there is no focused window.
+- (void)pushFocusedWindowToSpaceLeft;
+
+// Moves the focused window right one space.
+//
+// This method is a no-op if there is no focused window.
+- (void)pushFocusedWindowToSpaceRight;
+
 - (void)toggleFloatForFocusedWindow;
 
 - (void)displayCurrentLayout;

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -55,6 +55,8 @@
         "throw-space-7": "Throw the focused window to the seventh space",
         "throw-space-8": "Throw the focused window to the eighth space",
         "throw-space-9": "Throw the focused window to the ninth space",
+        "throw-space-left": "Throw the focused window left one space",
+        "throw-space-right": "Throw the focused window right one space",
         "toggle-float": "Toggle the focused window between being floating and tiled"
     },
 
@@ -195,6 +197,14 @@
     "throw-space-9": {
         "mod": "mod2",
         "key": "9"
+    },
+    "throw-space-left": {
+        "mod": "mod2",
+        "key": "left"
+    },
+    "throw-space-right": {
+        "mod": "mod2",
+        "key": "right"
     },
     "toggle-float": {
         "mod": "mod1",

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ And defines the following commands, mostly a mapping to xmonad key combinations.
 * `mod2 + e` - move focused window to 2nd screen
 * `mod2 + r` - move focused window to 3rd screen
 * `mod2 + [n]` - move focused window to nth space
+* `mod2 + left` - move focused window left one space
+* `mod2 + right` - move focused window right one space
 * `mod1 + h` - shrink the main pane
 * `mod1 + l` - expand the main pane
 * `mod1 + ,` - increase the number of windows in the main pane


### PR DESCRIPTION
# Shortcuts #

This changeset adds two shortcuts:
 * `mod2 + left`, and
 * `mod2 + right`

These act in a similar way to the existing `mod2 + [n]`, but in a relative, not absolute, fashion.

The behaviour mirrors symmetrically the OSX default `ctrl + [n]` vs. `ctrl + left`/`ctrl + right`
for space switching. The new keybindings are unlikely to clash, fit logically with existing
Amethyst/System keybindings, are idiomatic, and natural to use.

# Implementation #

The Spaces API seems to be undocumented/reverse-engineered, so I had to copy existing Amethyst
code.

I added four convenience functions for getting the current space, and for getting the number
of configured spaces.  These can be supplied a screen, or try to find the "currently focused" one.

Otherwise, I followed the implementation of `pushFocusedWindowToSpace`, and updated the README.

N.B. I return -1 from certain functions to signal failure.  Is this idiomatic Objective C?
N.B. I freely cast between `NSUInteger` and `CGSSpace`.  Is this acceptable?

# Testing #

I am unable to test the code, so __please compile and run the code before merging it anywhere
important!__


[Trello Card](https://trello.com/c/I4UPh7QB/198-amethyst-add-shortcuts-to-move-focused-window-left-right-a-space)