### PR TITLE
Fix moving windows to screens clockwise past last screen

### DIFF
--- a/Amethyst/AMWindowManager.m
+++ b/Amethyst/AMWindowManager.m
@@ -351,7 +351,7 @@
         return NO;
     }];
 
-    screenIndex = screenIndex + 1 % self.screenManagers.count;
+    screenIndex = (screenIndex + 1) % self.screenManagers.count;
 
     NSScreen *screenToMoveTo = [self.screenManagers[screenIndex] screen];
     [focusedWindow moveToScreen:screenToMoveTo];


### PR DESCRIPTION
Operator precedence means that

  `screenIndex + 1 % self.screenManagers.count`

is equivalent to

  `screenIndex + (1 % self.screenManagers.count)`

when we want

  `(screenIndex + 1) % self.screenManagers.count`

:(

Closes #414