### PR TITLE
Actually set initial values for shortcuts

### DIFF
--- a/Amethyst/AMHotKeyManager.m
+++ b/Amethyst/AMHotKeyManager.m
@@ -188,7 +188,7 @@ AMKeyCode AMKeyCodeInvalid = 0xFF;
     return carbonModifiers;
 }
 
-- (void)registerHotKeyWithKeyString:(NSString *)string modifiers:(AMModifierFlags)modifiers handler:(AMHotKeyHandler)handler  defaultsKey:(NSString *)defaultsKey override:(BOOL)override {
+- (void)registerHotKeyWithKeyString:(NSString *)string modifiers:(AMModifierFlags)modifiers handler:(AMHotKeyHandler)handler defaultsKey:(NSString *)defaultsKey override:(BOOL)override {
     if ([[NSUserDefaults standardUserDefaults] objectForKey:defaultsKey] && !override) {
         [[MASShortcutBinder sharedBinder] bindShortcutWithDefaultsKey:defaultsKey toAction:handler];
         return;
@@ -204,6 +204,9 @@ AMKeyCode AMKeyCodeInvalid = 0xFF;
     MASShortcut *shortcut = [MASShortcut shortcutWithKeyCode:[keyCodes[0] unsignedShortValue] modifierFlags:modifiers];
     [[MASShortcutBinder sharedBinder] registerDefaultShortcuts:@{ defaultsKey: shortcut }];
     [[MASShortcutBinder sharedBinder] bindShortcutWithDefaultsKey:defaultsKey toAction:handler];
+
+    // Note that the shortcut binder above only sets the default value, not the stored value, so we explicitly store it here.
+    [[NSUserDefaults standardUserDefaults] setObject:[[NSUserDefaults standardUserDefaults] objectForKey:defaultsKey] forKey:defaultsKey];
 }
 
 @end


### PR DESCRIPTION
With how MASShortcut works they weren't actually being applied in a persisted way. Now that they are actually persisted we won't keep going to grab it from the key map. So starting up from a non-US keyboard will set things such that changing the keyboard shouldn't actually mess up the shortcuts.

Note that this doesn't solve the problem of *displaying* the correct characters given the device independent key codes.

This should actually close #389