### PR TITLE
Attempt to add windows when they are deminimized

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -181,6 +181,12 @@ public class WindowManager: NSObject {
             self.floatingMap[window.windowID()] = floating
             self.addWindow(window)
         }
+        application.observeNotification(kAXWindowDeminiaturizedNotification, withElement: application) { accessibilityElement in
+            guard let window = accessibilityElement as? SIWindow else {
+                return
+            }
+            self.addWindow(window)
+        }
         application.observeNotification(kAXFocusedWindowChangedNotification, withElement:application) { accessibilityElement in
             guard let focusedWindow = SIWindow.focusedWindow() else {
                 return


### PR DESCRIPTION
The window APIs don't treat minimized windows as On Screen so when we do the initial push to grab windows at startup minimized windows get ignored. When they get brought back up they would never get pushed into the windows at all, so even attempting to float them wouldn't work. The app just didn't know it existed.

Closes #438