### PR TITLE
Stop using NSCache for screen managers

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -16,7 +16,7 @@ public class WindowManager: NSObject {
     internal let windowModifier = WindowModifier()
 
     internal var screenManagers: [ScreenManager] = []
-    private let screenManagersCache: NSCache = NSCache()
+    private var screenManagersCache: [String: ScreenManager] = [:]
 
     private let focusFollowsMouseManager = FocusFollowsMouseManager()
 
@@ -89,8 +89,15 @@ public class WindowManager: NSObject {
 
         if NSScreen.screensHaveSeparateSpaces() {
             for screenDictionary in screenDictionaries {
-                let screenIdentifier = screenDictionary["Display Identifier"] as? String
-                let screenManager = screenManagersCache.objectForKey(screenIdentifier!) as! ScreenManager
+                guard let screenIdentifier = screenDictionary["Display Identifier"] as? String else {
+                    LogManager.log?.error("Could not identify screen with info: \(screenDictionary)")
+                    continue
+                }
+
+                guard let screenManager = screenManagersCache[screenIdentifier] else {
+                    LogManager.log?.error("Screen with identifier not managed: \(screenIdentifier)")
+                    continue
+                }
 
                 guard let spaceIdentifier = spaceIdentifierWithScreenDictionary(screenDictionary) where screenManager.currentSpaceIdentifier != spaceIdentifier else {
                     continue
@@ -318,11 +325,11 @@ public class WindowManager: NSObject {
 
         for screen in NSScreen.screens() ?? [] {
             let screenIdentifier = screen.screenIdentifier()
-            var screenManager: ScreenManager? = screenManagersCache.objectForKey(screenIdentifier) as? ScreenManager
+            var screenManager = screenManagersCache[screenIdentifier]
 
             if screenManager == nil {
-                screenManager = ScreenManager(screen:screen, screenIdentifier:screenIdentifier, delegate:self)
-                screenManagersCache.setObject(screenManager!, forKey:screenIdentifier)
+                screenManager = ScreenManager(screen: screen, screenIdentifier: screenIdentifier, delegate: self)
+                screenManagersCache[screenIdentifier] = screenManager
             }
 
             screenManager!.screen = screen


### PR DESCRIPTION
The cache gets cleared sometimes and then we try to assign space identifiers and hit an empty cache that we try to force open.