### PR TITLE
Main pane adjustment in Row layout

### DIFF
--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -70,7 +70,6 @@ private class RowReflowOperation: ReflowOperation {
     }
 }
 
-// TODO(glib): there is quite a lot of this copied around between Layouts... probably should abstract
 public class RowLayout: Layout {
     override public class var layoutName: String { return "Row" }
     override public class var layoutKey: String { return "row" }

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -21,17 +21,41 @@ private class RowReflowOperation: ReflowOperation {
             return
         }
 
+        let mainPaneCount = min(windows.count, layout.mainPaneCount)
+        let secondaryPaneCount = windows.count - mainPaneCount
+        let hasSecondaryPane = secondaryPaneCount > 0
+
         let screenFrame = adjustedFrameForLayout(screen)
-        let windowHeight = screenFrame.height / CGFloat(windows.count)
+
+        let mainPaneWindowHeight = round(screenFrame.size.height * (hasSecondaryPane ? CGFloat(layout.mainPaneRatio) : 1.0))
+        let secondaryPaneWindowHeight = hasSecondaryPane ? round((screenFrame.size.height - mainPaneWindowHeight) / CGFloat(secondaryPaneCount)) : 0.0
 
         let focusedWindow = SIWindow.focusedWindow()
 
         let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
-            let originY = screenFrame.origin.y + CGFloat(frameAssignments.count) * windowHeight
-            let windowFrame = CGRect(x: screenFrame.origin.x, y: originY, width: screenFrame.width, height: windowHeight)
+            var windowFrame = CGRect.zero
 
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqualTo(focusedWindow), screenFrame: screenFrame)
+            // let windowFrame = CGRect(x: screenFrame.origin.x, y: originY, width: screenFrame.width, height: windowHeight)
+
+            if frameAssignments.count < mainPaneCount {
+                windowFrame.origin.x = screenFrame.origin.x
+                windowFrame.origin.y = screenFrame.origin.y + (mainPaneWindowHeight * CGFloat(frameAssignments.count))
+                windowFrame.size.width = screenFrame.width
+                windowFrame.size.height = mainPaneWindowHeight
+            } else {
+                windowFrame.origin.x = screenFrame.origin.x
+                windowFrame.origin.y = screenFrame.origin.y + mainPaneWindowHeight + (secondaryPaneWindowHeight * CGFloat(frameAssignments.count - mainPaneCount))
+                windowFrame.size.width = screenFrame.width
+                windowFrame.size.height = secondaryPaneWindowHeight
+            }
+
+            let frameAssignment = FrameAssignment(
+                frame: windowFrame,
+                window: window,
+                focused: window.isEqualTo(focusedWindow),
+                screenFrame: screenFrame
+            )
 
             assignments.append(frameAssignment)
 
@@ -46,11 +70,31 @@ private class RowReflowOperation: ReflowOperation {
     }
 }
 
+// TODO(glib): there is quite a lot of this copied around between Layouts... probably should abstract
 public class RowLayout: Layout {
     override public class var layoutName: String { return "Row" }
     override public class var layoutKey: String { return "row" }
 
+    private var mainPaneCount: Int = 1
+    private var mainPaneRatio: CGFloat = 0.5
+
     override public func reflowOperationForScreen(screen: NSScreen, withWindows windows: [SIWindow]) -> ReflowOperation {
         return RowReflowOperation(screen: screen, windows: windows, layout: self, windowActivityCache: windowActivityCache)
+    }
+
+    override public func expandMainPane() {
+        mainPaneRatio = max(0, mainPaneRatio + 0.05)
+    }
+
+    override public func shrinkMainPane() {
+        mainPaneRatio = max(0, mainPaneRatio - 0.05)
+    }
+
+    override public func increaseMainPaneCount() {
+        mainPaneCount = mainPaneCount + 1
+    }
+
+    override public func decreaseMainPaneCount() {
+        mainPaneCount = max(1, mainPaneCount - 1)
     }
 }


### PR DESCRIPTION
Allows the main pane shrink/expand in row layout. Very useful for things like a large web browser and a small terminal/mail/chat client at the bottom. Otherwise I've found Row layout to be a little tricky to use.

Still a lot of drying up can be done in the layout class, but that's to come in a little bit.

Screenshot in action:
![screenshot](https://cloud.githubusercontent.com/assets/199077/19756113/2f44b416-9bcf-11e6-9d6b-509a81870ba0.png)



[Trello Card](https://trello.com/c/4Bv1oOGE/240-amethyst-main-pane-adjustment-in-row-layout)