### PR TITLE
Auto Binary Space Partition

### DIFF
--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -27,14 +27,14 @@ private class AutoBSPReflowOperation: ReflowOperation {
         if windows_count == 0 {
             return
         }
-        
+
         // Create an array to hold all the candidate frames
         var binaryFrames = [CGRect]()
-        
+
         // Add the first frame which is the whole screen
         let screenFrame = adjustedFrameForLayout(screen)
         binaryFrames.append(screenFrame)
-        
+
         // Split until we have the right number of frames to hold the windows
         while binaryFrames.count < windows_count {
             //Find the frame with the largest area and then split it
@@ -94,7 +94,7 @@ private class AutoBSPReflowOperation: ReflowOperation {
         if isCancelled {
             return
         }
-        
+
         //Assign windows to binaryFrames
         assignWindowsToFramesBasedOnDistance(candidateFrames: binaryFrames)
     }

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -28,46 +28,46 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
         binaryFrames.append(screenFrame)
 
         // Split until we have the right number of frames to hold the windows
-        while(binaryFrames.count < windows.count){
+        while binaryFrames.count < windows.count {
             //Find the frame with the largest area and then split it
-            var largestArea:Float = -1.0
+            var largestArea: Float = -1.0
             var largestAreaIndex = -1
             for index in 0...(binaryFrames.count-1) {
-                let candidate:CGRect = binaryFrames[index]
+                let candidate: CGRect = binaryFrames[index]
 
                 let area = Float(candidate.size.width) * Float(candidate.size.height)
-                if(area >= largestArea){ //Prefer later matches
+                if area >= largestArea { //Prefer later matches
                     largestArea = area
                     largestAreaIndex = index
                 }
             }
 
             //Sanity check solution
-            if(largestAreaIndex < 0){
+            if largestAreaIndex < 0  {
                 NSLog("Unable to find a window to split: Index of window of -1 is invalid")
                 return
             }
-            if(largestArea <= 0){
+            if largestArea <= 0  {
                 NSLog("Unable to find a window to split: Largest window area of < 1 is invalid")
                 return
             }
 
             //Calculate two child frames
             let splittableFrame = binaryFrames[largestAreaIndex]
-            var childFrame1:CGRect
-            var childFrame2:CGRect
+            var childFrame1: CGRect
+            var childFrame2: CGRect
 
             //Figure out how to split the frame
-            if(splittableFrame.size.width > splittableFrame.size.height){
+            if splittableFrame.size.width > splittableFrame.size.height  {
                 //split vertically x | x
                 let newWidth1 = floor(splittableFrame.size.width * layout.mainPaneRatio)
                 let newWidth2 = ceil(splittableFrame.size.width - newWidth1)
                 let newHeight1 = floor(splittableFrame.size.height)
                 let newHeight2 = ceil(splittableFrame.size.height)
                 childFrame1 = CGRect(x:splittableFrame.origin.x, y:splittableFrame.origin.y, width:newWidth1, height:newHeight1)
-                childFrame2 = CGRect(x:(splittableFrame.origin.x + newWidth1), y:splittableFrame.origin.y,width:newWidth2, height:newHeight2)
+                childFrame2 = CGRect(x:(splittableFrame.origin.x + newWidth1), y:splittableFrame.origin.y, width:newWidth2, height:newHeight2)
             }
-            else{
+            else {
                 //split horizontally  x
                 //                    -
                 //                    x
@@ -133,4 +133,3 @@ open class AutoBinarySpacePartitioningLayout: Layout {
         mainPaneCount = max(1, mainPaneCount - 1)
     }
 }
-

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -11,12 +11,12 @@ import Silica
 
 private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
     fileprivate let layout: AutoBinarySpacePartitioningLayout
-    
+
     fileprivate init(screen: NSScreen, windows: [SIWindow], layout: AutoBinarySpacePartitioningLayout, windowActivityCache: WindowActivityCache) {
         self.layout = layout
         super.init(screen: screen, windows: windows, windowActivityCache: windowActivityCache)
     }
-    
+
     fileprivate override func main() {
         if windows.count == 0 {
             return
@@ -26,7 +26,7 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
         // Add the first frame which is the whole screen
         let screenFrame = adjustedFrameForLayout(screen)
         binaryFrames.append(screenFrame)
-        
+
         // Split until we have the right number of frames to hold the windows
         while(binaryFrames.count < windows.count){
             //Find the frame with the largest area and then split it
@@ -34,14 +34,14 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
             var largestAreaIndex = -1
             for index in 0...(binaryFrames.count-1) {
                 let candidate:CGRect = binaryFrames[index]
-                
+
                 let area = Float(candidate.size.width) * Float(candidate.size.height)
                 if(area >= largestArea){ //Prefer later matches
                     largestArea = area
                     largestAreaIndex = index
                 }
             }
-            
+
             //Sanity check solution
             if(largestAreaIndex < 0){
                 NSLog("Unable to find a window to split: Index of window of -1 is invalid")
@@ -51,13 +51,12 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
                 NSLog("Unable to find a window to split: Largest window area of < 1 is invalid")
                 return
             }
-            
+
             //Calculate two child frames
             let splittableFrame = binaryFrames[largestAreaIndex]
             var childFrame1:CGRect
             var childFrame2:CGRect
-            
-            
+
             //Figure out how to split the frame
             if(splittableFrame.size.width > splittableFrame.size.height){
                 //split vertically x | x
@@ -83,26 +82,26 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
             binaryFrames[largestAreaIndex] = childFrame1
             binaryFrames.append(childFrame2)
         }
-        
+
         //Assign windows to binaryFrames
         let focusedWindow = SIWindow.focused()
-        
+
         let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
-            
+
             let windowFrame = binaryFrames[frameAssignments.count]
-            
+
             let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
-            
+
             assignments.append(frameAssignment)
-            
+
             return assignments
         }
-        
+
         if isCancelled {
             return
         }
-        
+
         performFrameAssignments(frameAssignments)
     }
 }
@@ -110,26 +109,26 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
 open class AutoBinarySpacePartitioningLayout: Layout {
     override open class var layoutName: String { return "Auto Binary Space Partition" }
     override open class var layoutKey: String { return "absp" }
-    
+
     fileprivate var mainPaneCount: Int = 1
     fileprivate var mainPaneRatio: CGFloat = 0.5
-    
+
     override open func reflowOperationForScreen(_ screen: NSScreen, withWindows windows: [SIWindow]) -> ReflowOperation {
         return AutoBinarySpacePartitioningReflowOperation(screen: screen, windows: windows, layout: self, windowActivityCache: windowActivityCache)
     }
-    
+
     override open func expandMainPane() {
         mainPaneRatio = min(1, mainPaneRatio + UserConfiguration.shared.windowResizeStep())
     }
-    
+
     override open func shrinkMainPane() {
         mainPaneRatio = max(0, mainPaneRatio - UserConfiguration.shared.windowResizeStep())
     }
-    
+
     override open func increaseMainPaneCount() {
         mainPaneCount = mainPaneCount + 1
     }
-    
+
     override open func decreaseMainPaneCount() {
         mainPaneCount = max(1, mainPaneCount - 1)
     }

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -8,8 +8,7 @@
 
 import Silica
 
-
-private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
+private class AutoBSPReflowOperation: ReflowOperation {
     fileprivate let layout: AutoBinarySpacePartitioningLayout
 
     fileprivate init(screen: NSScreen, windows: [SIWindow], layout: AutoBinarySpacePartitioningLayout, windowActivityCache: WindowActivityCache) {
@@ -114,7 +113,7 @@ open class AutoBinarySpacePartitioningLayout: Layout {
     fileprivate var mainPaneRatio: CGFloat = 0.5
 
     override open func reflowOperationForScreen(_ screen: NSScreen, withWindows windows: [SIWindow]) -> ReflowOperation {
-        return AutoBinarySpacePartitioningReflowOperation(screen: screen, windows: windows, layout: self, windowActivityCache: windowActivityCache)
+        return AutoBSPReflowOperation(screen: screen, windows: windows, layout: self, windowActivityCache: windowActivityCache)
     }
 
     override open func expandMainPane() {

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -1,0 +1,137 @@
+//
+//  AutoBinarySpacePartitioningLayout.swift
+//  Amethyst
+//
+//  Created by Donald J Patterson on 1/3/17.
+//  Copyright © 2017 Donald J Patterson. All rights reserved.
+//
+
+import Silica
+
+
+private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
+    fileprivate let layout: AutoBinarySpacePartitioningLayout
+    
+    fileprivate init(screen: NSScreen, windows: [SIWindow], layout: AutoBinarySpacePartitioningLayout, windowActivityCache: WindowActivityCache) {
+        self.layout = layout
+        super.init(screen: screen, windows: windows, windowActivityCache: windowActivityCache)
+    }
+    
+    fileprivate override func main() {
+        if windows.count == 0 {
+            return
+        }
+        // Create an array to hold all the window frames
+        var binaryFrames = [CGRect]()
+        // Add the first frame which is the whole screen
+        let screenFrame = adjustedFrameForLayout(screen)
+        binaryFrames.append(screenFrame)
+        
+        // Split until we have the right number of frames to hold the windows
+        while(binaryFrames.count < windows.count){
+            //Find the frame with the largest area and then split it
+            var largestArea:Float = -1.0
+            var largestAreaIndex = -1
+            for index in 0...(binaryFrames.count-1) {
+                let candidate:CGRect = binaryFrames[index]
+                
+                let area = Float(candidate.size.width) * Float(candidate.size.height)
+                if(area >= largestArea){ //Prefer later matches
+                    largestArea = area
+                    largestAreaIndex = index
+                }
+            }
+            
+            //Sanity check solution
+            if(largestAreaIndex < 0){
+                NSLog("Unable to find a window to split: Index of window of -1 is invalid")
+                return
+            }
+            if(largestArea <= 0){
+                NSLog("Unable to find a window to split: Largest window area of < 1 is invalid")
+                return
+            }
+            
+            //Calculate two child frames
+            let splittableFrame = binaryFrames[largestAreaIndex]
+            var childFrame1:CGRect
+            var childFrame2:CGRect
+            
+            
+            //Figure out how to split the frame
+            if(splittableFrame.size.width > splittableFrame.size.height){
+                //split vertically x | x
+                let newWidth1 = floor(splittableFrame.size.width * layout.mainPaneRatio)
+                let newWidth2 = ceil(splittableFrame.size.width - newWidth1)
+                let newHeight1 = floor(splittableFrame.size.height)
+                let newHeight2 = ceil(splittableFrame.size.height)
+                childFrame1 = CGRect(x:splittableFrame.origin.x, y:splittableFrame.origin.y, width:newWidth1, height:newHeight1)
+                childFrame2 = CGRect(x:(splittableFrame.origin.x + newWidth1), y:splittableFrame.origin.y,width:newWidth2, height:newHeight2)
+            }
+            else{
+                //split horizontally  x
+                //                    -
+                //                    x
+                let newWidth1 = floor(splittableFrame.size.width)
+                let newWidth2 = ceil(splittableFrame.size.width)
+                let newHeight1 = floor(splittableFrame.size.height * layout.mainPaneRatio)
+                let newHeight2 = ceil(splittableFrame.size.height - newHeight1)
+                childFrame1 = CGRect(x:splittableFrame.origin.x, y:splittableFrame.origin.y, width:newWidth1, height:newHeight1)
+                childFrame2 = CGRect(x:splittableFrame.origin.x, y:splittableFrame.origin.y+newHeight1, width:newWidth2, height:newHeight2)
+            }
+            //Insert them in the list, replacing the parent
+            binaryFrames[largestAreaIndex] = childFrame1
+            binaryFrames.append(childFrame2)
+        }
+        
+        //Assign windows to binaryFrames
+        let focusedWindow = SIWindow.focused()
+        
+        let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
+            var assignments = frameAssignments
+            
+            let windowFrame = binaryFrames[frameAssignments.count]
+            
+            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+            
+            assignments.append(frameAssignment)
+            
+            return assignments
+        }
+        
+        if isCancelled {
+            return
+        }
+        
+        performFrameAssignments(frameAssignments)
+    }
+}
+
+open class AutoBinarySpacePartitioningLayout: Layout {
+    override open class var layoutName: String { return "Auto Binary Space Partition" }
+    override open class var layoutKey: String { return "absp" }
+    
+    fileprivate var mainPaneCount: Int = 1
+    fileprivate var mainPaneRatio: CGFloat = 0.5
+    
+    override open func reflowOperationForScreen(_ screen: NSScreen, withWindows windows: [SIWindow]) -> ReflowOperation {
+        return AutoBinarySpacePartitioningReflowOperation(screen: screen, windows: windows, layout: self, windowActivityCache: windowActivityCache)
+    }
+    
+    override open func expandMainPane() {
+        mainPaneRatio = min(1, mainPaneRatio + UserConfiguration.shared.windowResizeStep())
+    }
+    
+    override open func shrinkMainPane() {
+        mainPaneRatio = max(0, mainPaneRatio - UserConfiguration.shared.windowResizeStep())
+    }
+    
+    override open func increaseMainPaneCount() {
+        mainPaneCount = mainPaneCount + 1
+    }
+    
+    override open func decreaseMainPaneCount() {
+        mainPaneCount = max(1, mainPaneCount - 1)
+    }
+}
+

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -19,8 +19,8 @@ private class AutoBSPReflowOperation: ReflowOperation {
     fileprivate override func main() {
         //Check to see how many legit windows we have
         var windows_count = 0
-        for window in self.windows{
-            if !isDegenerateWindow(window:window){
+        for window in self.windows {
+            if !isDegenerateWindow(window:window) {
                 windows_count = windows_count + 1
             }
         }

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -42,11 +42,11 @@ private class AutoBSPReflowOperation: ReflowOperation {
             }
 
             //Sanity check solution
-            if largestAreaIndex < 0  {
+            if largestAreaIndex < 0 {
                 NSLog("Unable to find a window to split: Index of window of -1 is invalid")
                 return
             }
-            if largestArea <= 0  {
+            if largestArea <= 0 {
                 NSLog("Unable to find a window to split: Largest window area of < 1 is invalid")
                 return
             }
@@ -57,7 +57,7 @@ private class AutoBSPReflowOperation: ReflowOperation {
             var childFrame2: CGRect
 
             //Figure out how to split the frame
-            if splittableFrame.size.width > splittableFrame.size.height  {
+            if splittableFrame.size.width > splittableFrame.size.height {
                 //split vertically x | x
                 let newWidth1 = floor(splittableFrame.size.width * layout.mainPaneRatio)
                 let newWidth2 = ceil(splittableFrame.size.width - newWidth1)

--- a/Amethyst/Layout/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/BinarySpacePartitioningLayout.swift
@@ -13,58 +13,58 @@ internal class TreeNode {
     var left: TreeNode?
     var right: TreeNode?
     var windowID: CGWindowID?
-    
+
     var valid: Bool {
         return (left != nil && right != nil && windowID == nil) || (left == nil && right == nil && windowID != nil)
     }
-    
+
     func findWindowID(_ windowID: CGWindowID) -> TreeNode? {
         guard self.windowID == windowID else {
             return left?.findWindowID(windowID) ?? right?.findWindowID(windowID)
         }
-        
+
         return self
     }
-    
+
     func orderedWindowIDs() -> [CGWindowID] {
         guard let windowID = windowID else {
             let leftWindowIDs = left?.orderedWindowIDs() ?? []
             let rightWindowIDs = right?.orderedWindowIDs() ?? []
             return leftWindowIDs + rightWindowIDs
         }
-        
+
         return [windowID]
     }
-    
+
     func insertWindowIDAtEnd(_ windowID: CGWindowID) {
         guard left == nil && right == nil else {
             right?.insertWindowIDAtEnd(windowID)
             return
         }
-        
+
         insertWindowID(windowID)
     }
-    
+
     func insertWindowID(_ windowID: CGWindowID, atPoint insertionPoint: CGWindowID) {
         guard self.windowID == insertionPoint else {
             left?.insertWindowID(windowID, atPoint: insertionPoint)
             right?.insertWindowID(windowID, atPoint: insertionPoint)
             return
         }
-        
+
         insertWindowID(windowID)
     }
-    
+
     func removeWindowID(_ windowID: CGWindowID) {
         guard let node = findWindowID(windowID) else {
             LogManager.log?.error("Trying to remove window not in tree")
             return
         }
-        
+
         guard let parent = node.parent else {
             return
         }
-        
+
         guard let grandparent = parent.parent else {
             if node == parent.left {
                 parent.windowID = parent.right?.windowID

--- a/Amethyst/Layout/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/BinarySpacePartitioningLayout.swift
@@ -13,58 +13,58 @@ internal class TreeNode {
     var left: TreeNode?
     var right: TreeNode?
     var windowID: CGWindowID?
-
+    
     var valid: Bool {
         return (left != nil && right != nil && windowID == nil) || (left == nil && right == nil && windowID != nil)
     }
-
+    
     func findWindowID(_ windowID: CGWindowID) -> TreeNode? {
         guard self.windowID == windowID else {
             return left?.findWindowID(windowID) ?? right?.findWindowID(windowID)
         }
-
+        
         return self
     }
-
+    
     func orderedWindowIDs() -> [CGWindowID] {
         guard let windowID = windowID else {
             let leftWindowIDs = left?.orderedWindowIDs() ?? []
             let rightWindowIDs = right?.orderedWindowIDs() ?? []
             return leftWindowIDs + rightWindowIDs
         }
-
+        
         return [windowID]
     }
-
+    
     func insertWindowIDAtEnd(_ windowID: CGWindowID) {
         guard left == nil && right == nil else {
             right?.insertWindowIDAtEnd(windowID)
             return
         }
-
+        
         insertWindowID(windowID)
     }
-
+    
     func insertWindowID(_ windowID: CGWindowID, atPoint insertionPoint: CGWindowID) {
         guard self.windowID == insertionPoint else {
             left?.insertWindowID(windowID, atPoint: insertionPoint)
             right?.insertWindowID(windowID, atPoint: insertionPoint)
             return
         }
-
+        
         insertWindowID(windowID)
     }
-
+    
     func removeWindowID(_ windowID: CGWindowID) {
         guard let node = findWindowID(windowID) else {
             LogManager.log?.error("Trying to remove window not in tree")
             return
         }
-
+        
         guard let parent = node.parent else {
             return
         }
-
+        
         guard let grandparent = parent.parent else {
             if node == parent.left {
                 parent.windowID = parent.right?.windowID
@@ -75,7 +75,7 @@ internal class TreeNode {
             parent.right = nil
             return
         }
-
+        
         if parent == grandparent.left {
             if node == parent.left {
                 grandparent.left = parent.right
@@ -92,40 +92,40 @@ internal class TreeNode {
             grandparent.right?.parent = grandparent
         }
     }
-
+    
     internal func insertWindowID(_ windowID: CGWindowID) {
         guard parent != nil || self.windowID != nil else {
             self.windowID = windowID
             return
         }
-
+        
         if let parent = parent {
             let newParent = TreeNode()
             let newNode = TreeNode()
-
+            
             newNode.parent = newParent
             newNode.windowID = windowID
-
+            
             newParent.left = self
             newParent.right = newNode
             newParent.parent = parent
-
+            
             if self == parent.left {
                 parent.left = newParent
             } else {
                 parent.right = newParent
             }
-
+            
             self.parent = newParent
         } else {
             let newSelf = TreeNode()
             let newNode = TreeNode()
-
+            
             newSelf.windowID = self.windowID
             self.windowID = nil
-
+            
             newNode.windowID = windowID
-
+            
             left = newSelf
             left?.parent = self
             right = newNode
@@ -142,41 +142,41 @@ internal func == (lhs: TreeNode, rhs: TreeNode) -> Bool {
 
 private class BinarySpacePartitioningReflowOperation: ReflowOperation {
     fileprivate typealias TraversalNode = (node: TreeNode, frame: CGRect)
-
+    
     fileprivate let rootNode: TreeNode
-
+    
     fileprivate init(screen: NSScreen, windows: [SIWindow], rootNode: TreeNode, windowActivityCache: WindowActivityCache) {
         self.rootNode = rootNode
         super.init(screen: screen, windows: windows, windowActivityCache: windowActivityCache)
     }
-
+    
     fileprivate override func main() {
         if windows.count == 0 {
             return
         }
-
+        
         let windowIDMap: [CGWindowID: SIWindow] = windows.reduce([:]) { (windowMap, window) -> [CGWindowID: SIWindow] in
             var mutableWindowMap = windowMap
             mutableWindowMap[window.windowID()] = window
             return mutableWindowMap
         }
-
+        
         let focusedWindow = SIWindow.focused()
         let baseFrame = adjustedFrameForLayout(screen)
         var frameAssignments: [FrameAssignment] = []
         var traversalNodes: [TraversalNode] = [(node: rootNode, frame: baseFrame)]
-
+        
         while traversalNodes.count > 0 {
             let traversalNode = traversalNodes[0]
-
+            
             traversalNodes = [TraversalNode](traversalNodes.dropFirst(1))
-
+            
             if let windowID = traversalNode.node.windowID {
                 guard let window = windowIDMap[windowID] else {
                     LogManager.log?.warning("Could not find window for ID: \(windowID)")
                     continue
                 }
-
+                
                 let frameAssignment = FrameAssignment(frame: traversalNode.frame, window: window, focused: windowID == focusedWindow?.windowID(), screenFrame: baseFrame)
                 frameAssignments.append(frameAssignment)
             } else {
@@ -184,9 +184,9 @@ private class BinarySpacePartitioningReflowOperation: ReflowOperation {
                     LogManager.log?.error("Encountered an invalid node")
                     continue
                 }
-
+                
                 let frame = traversalNode.frame
-
+                
                 if frame.width > frame.height {
                     let leftFrame = CGRect(
                         x: frame.origin.x,
@@ -220,11 +220,11 @@ private class BinarySpacePartitioningReflowOperation: ReflowOperation {
                 }
             }
         }
-
+        
         if isCancelled {
             return
         }
-
+        
         performFrameAssignments(frameAssignments)
     }
 }
@@ -232,18 +232,18 @@ private class BinarySpacePartitioningReflowOperation: ReflowOperation {
 open class BinarySpacePartitioningLayout: Layout {
     override open class var layoutName: String { return "Binary Space Partitioning" }
     override open class var layoutKey: String { return "bsp" }
-
+    
     internal var rootNode = TreeNode()
     internal var lastKnownFocusedWindowID: CGWindowID?
-
+    
     open override func reflowOperationForScreen(_ screen: NSScreen, withWindows windows: [SIWindow]) -> ReflowOperation {
         if windows.count > 0 && !rootNode.valid {
             constructInitialTreeWithWindows(windows)
         }
-
+        
         return BinarySpacePartitioningReflowOperation(screen: screen, windows: windows, rootNode: rootNode, windowActivityCache: windowActivityCache)
     }
-
+    
     open override func updateWithChange(_ windowChange: WindowChange) {
         switch windowChange {
         case let .add(window):
@@ -251,7 +251,7 @@ open class BinarySpacePartitioningLayout: Layout {
                 LogManager.log?.warning("Trying to add a window already in the tree")
                 return
             }
-
+            
             if let insertionPoint = lastKnownFocusedWindowID, window.windowID() != insertionPoint {
                 LogManager.log?.info("insert \(window) - \(window.windowID()) at point: \(insertionPoint)")
                 rootNode.insertWindowID(window.windowID(), atPoint: insertionPoint)
@@ -267,57 +267,57 @@ open class BinarySpacePartitioningLayout: Layout {
         case let .windowSwap(window, otherWindow):
             let windowID = window.windowID()
             let otherWindowID = otherWindow.windowID()
-
+            
             guard let windowNode = rootNode.findWindowID(windowID), let otherWindowNode = rootNode.findWindowID(otherWindowID) else {
                 LogManager.log?.error("Tried to perform an unbalanced window swap: \(windowID) <-> \(otherWindowID)")
                 return
             }
-
+            
             windowNode.windowID = otherWindowID
             otherWindowNode.windowID = windowID
         case .unknown:
             break
         }
     }
-
+    
     open override func nextWindowIDCounterClockwise() -> CGWindowID? {
         guard let focusedWindow = SIWindow.focused() else {
             return nil
         }
-
+        
         let orderedIDs = rootNode.orderedWindowIDs()
-
+        
         guard let focusedWindowIndex = orderedIDs.index(of: focusedWindow.windowID()) else {
             return nil
         }
-
+        
         let nextWindowIndex = (focusedWindowIndex == 0 ? orderedIDs.count - 1 : focusedWindowIndex - 1)
-
+        
         return orderedIDs[nextWindowIndex]
     }
-
+    
     open override func nextWindowIDClockwise() -> CGWindowID? {
         guard let focusedWindow = SIWindow.focused() else {
             return nil
         }
-
+        
         let orderedIDs = rootNode.orderedWindowIDs()
-
+        
         guard let focusedWindowIndex = orderedIDs.index(of: focusedWindow.windowID()) else {
             return nil
         }
-
+        
         let nextWindowIndex = (focusedWindowIndex == orderedIDs.count - 1 ? 0 : focusedWindowIndex + 1)
-
+        
         return orderedIDs[nextWindowIndex]
     }
-
+    
     internal func constructInitialTreeWithWindows(_ windows: [SIWindow]) {
         for window in windows {
             guard rootNode.findWindowID(window.windowID()) == nil else {
                 continue
             }
-
+            
             rootNode.insertWindowIDAtEnd(window.windowID())
         }
     }

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -94,7 +94,7 @@ open class ReflowOperation: Operation {
         }
         if window_frame.height <= 0.0 {
             return true
-        2
+        }
         if window_frame.height.isInfinite {
             return true
         }
@@ -104,7 +104,7 @@ open class ReflowOperation: Operation {
         return false
     }
 
-    fileprivate func categorizeWindows(candidateFrames: [CGRect]) -> ([SIWindow], [SIWindow]) {
+    private func categorizeWindows(candidateFrames: [CGRect]) -> ([SIWindow], [SIWindow]) {
 
         var displaced: [SIWindow] = []
         var aligned: [SIWindow] = []

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -62,7 +62,7 @@ open class ReflowOperation: Operation {
         }
     }
 
-    open func isDegenerateWindow(window:SIWindow) -> Bool {
+    open func isDegenerateWindow(window: SIWindow) -> Bool {
         let window_frame = window.frame()
         if window_frame.origin.x < 0.0 {
             return true
@@ -104,7 +104,7 @@ open class ReflowOperation: Operation {
         return false
     }
 
-    fileprivate func categorizeWindows(candidateFrames: [CGRect]) -> ([SIWindow],[SIWindow]) {
+    fileprivate func categorizeWindows(candidateFrames: [CGRect]) -> ([SIWindow], [SIWindow]) {
 
         var displaced: [SIWindow] = []
         var aligned: [SIWindow] = []
@@ -133,7 +133,7 @@ open class ReflowOperation: Operation {
                 }
             }
         }
-        return (displaced,aligned)
+        return (displaced, aligned)
 
     }
 
@@ -141,7 +141,7 @@ open class ReflowOperation: Operation {
 
         var candidateFramesMutable = candidateFrames
         //Find those windows that are not perfectly on top of a frame to assign first, because those are the ones that have been newly created or manually moved
-        let (displacedWindows,alignedWindows) = categorizeWindows(candidateFrames: candidateFrames)
+        let (displacedWindows, alignedWindows) = categorizeWindows(candidateFrames: candidateFrames)
 
         //Now preferentially assign displaced windows a location
         let screenFrame = adjustedFrameForLayout(screen)
@@ -156,7 +156,7 @@ open class ReflowOperation: Operation {
                 let window_frame = window.frame()
                 let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
                 let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
-                for (index,frame) in candidateFramesMutable.enumerated() {
+                for (index, frame) in candidateFramesMutable.enumerated() {
                     let frame_center_x = frame.origin.x + (frame.width/2.0)
                     let frame_center_y = frame.origin.y + (frame.height/2.0)
                     let distance_x = (frame_center_x - windows_center_x)
@@ -186,7 +186,7 @@ open class ReflowOperation: Operation {
                 let window_frame = window.frame()
                 let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
                 let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
-                for (index,frame) in candidateFramesMutable.enumerated() {
+                for (index, frame) in candidateFramesMutable.enumerated() {
                     let frame_center_x = frame.origin.x + (frame.width/2.0)
                     let frame_center_y = frame.origin.y + (frame.height/2.0)
                     let distance_x = (frame_center_x - windows_center_x)
@@ -218,7 +218,7 @@ open class ReflowOperation: Operation {
             if !isDegenerateWindow(window:window) {
                 let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
                 let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
-                for (index,frame) in candidateFramesMutable.enumerated() {
+                for (index, frame) in candidateFramesMutable.enumerated() {
                     let frame_center_x = frame.origin.x + (frame.width/2.0)
                     let frame_center_y = frame.origin.y + (frame.height/2.0)
                     let distance_x = (frame_center_x - windows_center_x)

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -64,16 +64,10 @@ open class ReflowOperation: Operation {
 
     open func isDegenerateWindow(window: SIWindow) -> Bool {
         let window_frame = window.frame()
-        if window_frame.origin.x < 0.0 {
-            return true
-        }
         if window_frame.origin.x.isInfinite {
             return true
         }
         if window_frame.origin.x.isNaN {
-            return true
-        }
-        if window_frame.origin.y < 0.0 {
             return true
         }
         if window_frame.origin.y.isInfinite {
@@ -82,7 +76,6 @@ open class ReflowOperation: Operation {
         if window_frame.origin.y.isNaN {
             return true
         }
-
         if window_frame.width <= 0.0 {
             return true
         }

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -61,6 +61,179 @@ open class ReflowOperation: Operation {
             self.assignFrame(frameAssignment.frame, toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
         }
     }
+    
+    open func isDegenerateWindow(window:SIWindow) -> Bool{
+        let window_frame = window.frame()
+        if window_frame.origin.x < 0.0 {
+            return true
+        }
+        if window_frame.origin.x.isInfinite{
+            return true
+        }
+        if window_frame.origin.x.isNaN{
+            return true
+        }
+        if window_frame.origin.y < 0.0 {
+            return true
+        }
+        if window_frame.origin.y.isInfinite{
+            return true
+        }
+        if window_frame.origin.y.isNaN{
+            return true
+        }
+    
+        if window_frame.width <= 0.0 {
+            return true
+        }
+        if window_frame.width.isInfinite{
+            return true
+        }
+        if window_frame.width.isNaN{
+            return true
+        }
+        if window_frame.height <= 0.0 {
+            return true
+        }
+        if window_frame.height.isInfinite{
+            return true
+        }
+        if window_frame.height.isNaN{
+            return true
+        }
+        return false
+    }
+    
+    open func assignWindowsToFramesBasedOnDistance(candidateFrames:[CGRect]) {
+        
+        var candidateFramesCopy = candidateFrames
+        
+        //Find those windows that are not perfectly on top of a frame to assign first, because those are the ones that have been newly created or manually moved
+        var displacedWindows: [SIWindow] = []
+        var alignedWindows: [SIWindow] = []
+
+        for window in self.windows{
+            //Sometimes the windows become degenerate for some reason, ignore them
+            if !isDegenerateWindow(window:window) {
+                var min_distance = FLT_MAX
+                let window_frame = window.frame()
+                let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
+                let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
+                for frame in candidateFramesCopy{
+                    let frame_center_x = frame.origin.x + (frame.width/2.0)
+                    let frame_center_y = frame.origin.y + (frame.height/2.0)
+                    let distance_x = (frame_center_x - windows_center_x)
+                    let distance_y = (frame_center_y - windows_center_y)
+                    let distance = sqrt(distance_x*distance_x + distance_y*distance_y)
+                    if(Float(distance) < min_distance){
+                        min_distance = Float(distance)
+                    }
+                }
+                if(min_distance < 1.0){
+                    alignedWindows.append(window)
+                }
+                else{
+                    displacedWindows.append(window)
+                }
+            }
+        }
+        
+        //Now preferentially assign displaced windows a location
+        let screenFrame = adjustedFrameForLayout(screen)
+        let focusedWindow = SIWindow.focused()
+        var frameAssignments: [FrameAssignment] = []
+        for window in displacedWindows{
+            var min_distance = FLT_MAX
+            var min_index = -1
+    
+            //Sometimes the windows become degenerate for some reason
+            if !isDegenerateWindow(window:window){
+                let window_frame = window.frame()
+                let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
+                let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
+                for (index,frame) in candidateFramesCopy.enumerated(){
+                    let frame_center_x = frame.origin.x + (frame.width/2.0)
+                    let frame_center_y = frame.origin.y + (frame.height/2.0)
+                    let distance_x = (frame_center_x - windows_center_x)
+                    let distance_y = (frame_center_y - windows_center_y)
+                    let distance = sqrt(distance_x*distance_x + distance_y*distance_y)
+                    if(Float(distance) < min_distance){
+                        min_distance = Float(distance)
+                        min_index = index
+                    }
+                }
+            }
+            if(min_index != -1){
+                let frameAssignment = FrameAssignment(frame: candidateFramesCopy[min_index], window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+                frameAssignments.append(frameAssignment)
+                candidateFramesCopy.remove(at: min_index)
+            }
+        }
+        
+        //Now assigned aligned windows that are still aligned a location
+        var alignedNoMoreWindows: [SIWindow] = []
+        for window in alignedWindows{
+            var min_distance = FLT_MAX
+            var min_index = -1
+    
+            //Sometimes the windows become degenerate for some reason, ignore them
+            if !isDegenerateWindow(window:window){
+                let window_frame = window.frame()
+                let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
+                let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
+                for (index,frame) in candidateFramesCopy.enumerated(){
+                    let frame_center_x = frame.origin.x + (frame.width/2.0)
+                    let frame_center_y = frame.origin.y + (frame.height/2.0)
+                    let distance_x = (frame_center_x - windows_center_x)
+                    let distance_y = (frame_center_y - windows_center_y)
+                    let distance = sqrt(distance_x*distance_x + distance_y*distance_y)
+                    if(Float(distance) < min_distance){
+                        min_distance = Float(distance)
+                        min_index = index
+                    }
+                }
+            }
+            //If a displaced window took the frame that the previously aligned window was aligned to, then it is no longer aligned
+            if(min_distance >= 1.0){
+                alignedNoMoreWindows.append(window)
+            }
+            else {
+                let frameAssignment = FrameAssignment(frame: candidateFramesCopy[min_index], window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+                frameAssignments.append(frameAssignment)
+                candidateFramesCopy.remove(at: min_index)
+            }
+        }
+        
+        //Now assigned anything that is left
+        for window in alignedNoMoreWindows{
+            var min_distance = FLT_MAX
+            var min_index = -1
+            let window_frame = window.frame()
+            //Sometimes the windows become degenerate for some reason, ignore them
+            if !isDegenerateWindow(window:window) {
+                let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
+                let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
+                for (index,frame) in candidateFramesCopy.enumerated(){
+                    let frame_center_x = frame.origin.x + (frame.width/2.0)
+                    let frame_center_y = frame.origin.y + (frame.height/2.0)
+                    let distance_x = (frame_center_x - windows_center_x)
+                    let distance_y = (frame_center_y - windows_center_y)
+                    let distance = sqrt(distance_x*distance_x + distance_y*distance_y)
+                    if(Float(distance) < min_distance){
+                        min_distance = Float(distance)
+                        min_index = index
+                    }
+                }
+            }
+            if(min_index != -1){
+                let frameAssignment = FrameAssignment(frame: candidateFramesCopy[min_index], window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+                frameAssignments.append(frameAssignment)
+                candidateFramesCopy.remove(at: min_index)
+            }
+        }
+    
+        performFrameAssignments(frameAssignments)
+    }
 
     fileprivate func assignFrame(_ frame: CGRect, toWindow window: SIWindow, focused: Bool, screenFrame: CGRect) {
         var padding = UserConfiguration.shared.windowMarginSize()

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -61,7 +61,7 @@ open class ReflowOperation: Operation {
             self.assignFrame(frameAssignment.frame, toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
         }
     }
-    
+
     open func isDegenerateWindow(window:SIWindow) -> Bool{
         let window_frame = window.frame()
         if window_frame.origin.x < 0.0 {
@@ -82,7 +82,7 @@ open class ReflowOperation: Operation {
         if window_frame.origin.y.isNaN{
             return true
         }
-    
+
         if window_frame.width <= 0.0 {
             return true
         }
@@ -103,11 +103,11 @@ open class ReflowOperation: Operation {
         }
         return false
     }
-    
+
     open func assignWindowsToFramesBasedOnDistance(candidateFrames:[CGRect]) {
-        
+
         var candidateFramesCopy = candidateFrames
-        
+
         //Find those windows that are not perfectly on top of a frame to assign first, because those are the ones that have been newly created or manually moved
         var displacedWindows: [SIWindow] = []
         var alignedWindows: [SIWindow] = []
@@ -137,7 +137,7 @@ open class ReflowOperation: Operation {
                 }
             }
         }
-        
+
         //Now preferentially assign displaced windows a location
         let screenFrame = adjustedFrameForLayout(screen)
         let focusedWindow = SIWindow.focused()
@@ -145,7 +145,7 @@ open class ReflowOperation: Operation {
         for window in displacedWindows{
             var min_distance = FLT_MAX
             var min_index = -1
-    
+
             //Sometimes the windows become degenerate for some reason
             if !isDegenerateWindow(window:window){
                 let window_frame = window.frame()
@@ -169,13 +169,13 @@ open class ReflowOperation: Operation {
                 candidateFramesCopy.remove(at: min_index)
             }
         }
-        
+
         //Now assigned aligned windows that are still aligned a location
         var alignedNoMoreWindows: [SIWindow] = []
         for window in alignedWindows{
             var min_distance = FLT_MAX
             var min_index = -1
-    
+
             //Sometimes the windows become degenerate for some reason, ignore them
             if !isDegenerateWindow(window:window){
                 let window_frame = window.frame()
@@ -203,7 +203,7 @@ open class ReflowOperation: Operation {
                 candidateFramesCopy.remove(at: min_index)
             }
         }
-        
+
         //Now assigned anything that is left
         for window in alignedNoMoreWindows{
             var min_distance = FLT_MAX
@@ -231,7 +231,7 @@ open class ReflowOperation: Operation {
                 candidateFramesCopy.remove(at: min_index)
             }
         }
-    
+
         performFrameAssignments(frameAssignments)
     }
 

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -94,7 +94,7 @@ open class ReflowOperation: Operation {
         }
         if window_frame.height <= 0.0 {
             return true
-        }
+        2
         if window_frame.height.isInfinite {
             return true
         }

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -103,9 +103,9 @@ open class ReflowOperation: Operation {
         }
         return false
     }
-    
+
     fileprivate func categorizeWindows(candidateFrames: [CGRect]) -> ([SIWindow],[SIWindow]) {
-        
+
         var displaced: [SIWindow] = []
         var aligned: [SIWindow] = []
         for window in self.windows {
@@ -134,7 +134,7 @@ open class ReflowOperation: Operation {
             }
         }
         return (displaced,aligned)
-        
+
     }
 
     open func assignWindowsToFramesBasedOnDistance(candidateFrames: [CGRect]) {
@@ -142,8 +142,6 @@ open class ReflowOperation: Operation {
         var candidateFramesMutable = candidateFrames
         //Find those windows that are not perfectly on top of a frame to assign first, because those are the ones that have been newly created or manually moved
         let (displacedWindows,alignedWindows) = categorizeWindows(candidateFrames: candidateFrames)
-
-        
 
         //Now preferentially assign displaced windows a location
         let screenFrame = adjustedFrameForLayout(screen)

--- a/Amethyst/Managers/LayoutManager.swift
+++ b/Amethyst/Managers/LayoutManager.swift
@@ -31,6 +31,8 @@ open class LayoutManager {
             return WidescreenTallLayout.self
         case "bsp":
             return BinarySpacePartitioningLayout.self
+        case "absp":
+            return AutoBinarySpacePartitioningLayout.self
         default:
             return nil
         }
@@ -51,7 +53,8 @@ open class LayoutManager {
             RowLayout.self,
             FloatingLayout.self,
             WidescreenTallLayout.self,
-            BinarySpacePartitioningLayout.self
+            BinarySpacePartitioningLayout.self,
+            AutoBinarySpacePartitioningLayout.self
         ]
 
         return layoutClasses.map { LayoutManager.stringForLayoutClass($0) }

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
 
-gem 'cocoapods', '~> 1.1.0'
+gem 'cocoapods', '~> 1.2.0.beta.3'
 gem 'xcpretty'

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.10'
+platform :osx, '10.12'
 
 use_frameworks!
 
@@ -12,7 +12,7 @@ target 'Amethyst' do
   pod 'MASShortcut', :git => 'https://github.com/ianyh/MASShortcut'
   pod 'RxCocoa'
   pod 'RxSwift'
-  pod 'Silica', :git => 'https://github.com/ianyh/Silica'
+  pod 'Silica', :git => 'https://github.com/ianyh/Silica', :commit => 'a73415cd79ccee6e7c3dcb87ecf5d9889a6d85d2'
   pod 'SwiftyJSON'
   target 'AmethystTests' do
     inherit! :search_paths


### PR DESCRIPTION
This adds an auto binary space partition ("absp")

When a new window appears, Amethyst will find whichever existing window has the most screen area and split its area into two equal halves.  One half will be given to the new window and one half to the window that was previously in that space.

 "auto" in this case means that the focus window doesn't have any bearing on the split like it does in the binary split partition scheme.

The window with the most area is split along the longest axis so that windows are biased toward being square.

absp also cleanly re-lays out the windows when the windows are closed so that all leftover space is reclaimed by the remaining windows.  If windows are added and removed in LIFO order then the layout will remain stable.

If a user moves a window and then forces a relayout, then the window that is moved will drop into the closest location.  Ideally the relayout would happen when the window stops being moved, but getting that callback from OSX seems non-trivial.  (At least I couldn't figure it out)

It also does a biased split if you use the hot key for increasing the main pane size.  Initially it's a binary split, but if you increase it the ratio changes.  

Here's a zipped up animation of the behavior:
[Terminal_ScreenShot_001.mp4.zip](https://github.com/ianyh/Amethyst/files/684107/Terminal_ScreenShot_001.mp4.zip)

![terminal_screenshot_002](https://cloud.githubusercontent.com/assets/121683/21634634/693763f2-d20d-11e6-8699-9db4d35387b2.jpg)




[Trello Card](https://trello.com/c/jYHChwRt/251-amethyst-auto-binary-space-partition)