### PR TITLE
Animate window movement

### DIFF
--- a/Amethyst.xcodeproj/project.pbxproj
+++ b/Amethyst.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		402DB6FF1742E44E00D1C936 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 402DB6FE1742E44E00D1C936 /* Carbon.framework */; };
 		404A5FAE18442CD5009B86D3 /* icon-statusitem-disabled.png in Resources */ = {isa = PBXBuildFile; fileRef = 404A5FAC18442CD5009B86D3 /* icon-statusitem-disabled.png */; };
 		404A5FB018442CD5009B86D3 /* icon-statusitem-disabled@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 404A5FAD18442CD5009B86D3 /* icon-statusitem-disabled@2x.png */; };
-		404BE9CE1CFBB6E900D6C537 /* BinarySpacePartitioningLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404BE9CD1CFBB6E900D6C537 /* BinarySpacePartitioningLayout.swift */; };
+		404BE9CE1CFBB6E900D6C537 /* AutoBinarySpacePartitioningLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404BE9CD1CFBB6E900D6C537 /* AutoBinarySpacePartitioningLayout.swift */; };
 		404BE9D11CFBDF1900D6C537 /* BinarySpacePartitioningLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404BE9D01CFBDF1900D6C537 /* BinarySpacePartitioningLayoutTests.swift */; };
 		4058C46F1C4B119500B19D26 /* LayoutNameWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4058C46E1C4B119500B19D26 /* LayoutNameWindowController.swift */; };
 		4058C47A1C54113D00B19D26 /* GeneralPreferencesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4058C4791C54113D00B19D26 /* GeneralPreferencesViewController.xib */; };
@@ -66,6 +66,7 @@
 		40C3F9251BD1B36C00F58660 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 40C3F9241BD1B36C00F58660 /* libz.tbd */; };
 		40CEF4301C2B8D21004C3297 /* ScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CEF42F1C2B8D21004C3297 /* ScreenManager.swift */; };
 		40E705D8176EAD7800850DA6 /* default.amethyst in Resources */ = {isa = PBXBuildFile; fileRef = 40E705D7176EAD7800850DA6 /* default.amethyst */; };
+		90D680781E1CCCF40088F922 /* BinarySpacePartitioningLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D680771E1CCCF40088F922 /* BinarySpacePartitioningLayout.swift */; };
 		E0813042EE80CAF5D47073B9 /* Pods_AmethystTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C01DB57398AF21D123FD290F /* Pods_AmethystTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -134,7 +135,7 @@
 		402DB6FE1742E44E00D1C936 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		404A5FAC18442CD5009B86D3 /* icon-statusitem-disabled.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-statusitem-disabled.png"; sourceTree = "<group>"; };
 		404A5FAD18442CD5009B86D3 /* icon-statusitem-disabled@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-statusitem-disabled@2x.png"; sourceTree = "<group>"; };
-		404BE9CD1CFBB6E900D6C537 /* BinarySpacePartitioningLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinarySpacePartitioningLayout.swift; sourceTree = "<group>"; };
+		404BE9CD1CFBB6E900D6C537 /* AutoBinarySpacePartitioningLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoBinarySpacePartitioningLayout.swift; sourceTree = "<group>"; };
 		404BE9D01CFBDF1900D6C537 /* BinarySpacePartitioningLayoutTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinarySpacePartitioningLayoutTests.swift; sourceTree = "<group>"; };
 		4058C46E1C4B119500B19D26 /* LayoutNameWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutNameWindowController.swift; sourceTree = "<group>"; };
 		4058C4791C54113D00B19D26 /* GeneralPreferencesViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = GeneralPreferencesViewController.xib; sourceTree = "<group>"; };
@@ -163,6 +164,7 @@
 		40E705D7176EAD7800850DA6 /* default.amethyst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = default.amethyst; sourceTree = "<group>"; };
 		48A04C08B79381F097271198 /* Pods-Amethyst.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amethyst.release.xcconfig"; path = "Pods/Target Support Files/Pods-Amethyst/Pods-Amethyst.release.xcconfig"; sourceTree = "<group>"; };
 		6441E51294FF4505E05F6810 /* Pods-Amethyst.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amethyst.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Amethyst/Pods-Amethyst.debug.xcconfig"; sourceTree = "<group>"; };
+		90D680771E1CCCF40088F922 /* BinarySpacePartitioningLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinarySpacePartitioningLayout.swift; sourceTree = "<group>"; };
 		C01DB57398AF21D123FD290F /* Pods_AmethystTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AmethystTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB7CA49CFB92C8A1862B5852 /* Pods_Amethyst.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Amethyst.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -328,7 +330,8 @@
 		40B337E11745CE340001D8FC /* Layout */ = {
 			isa = PBXGroup;
 			children = (
-				404BE9CD1CFBB6E900D6C537 /* BinarySpacePartitioningLayout.swift */,
+				404BE9CD1CFBB6E900D6C537 /* AutoBinarySpacePartitioningLayout.swift */,
+				90D680771E1CCCF40088F922 /* BinarySpacePartitioningLayout.swift */,
 				4062AD321C1FA48C00DB612B /* ColumnLayout.swift */,
 				4062AD2A1C1F99EA00DB612B /* FloatingLayout.swift */,
 				4062AD2C1C1F9B8B00DB612B /* FullscreenLayout.swift */,
@@ -444,11 +447,11 @@
 				CLASSPREFIX = AM;
 				LastSwiftUpdateCheck = 0730;
 				LastTestingUpgradeCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = "Ian Ynda-Hummel";
 				TargetAttributes = {
 					402DB6DD1742E41A00D1C936 = {
-						DevelopmentTeam = 82P2XLB4UH;
+						DevelopmentTeam = 825E5U7JWP;
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Automatic;
 					};
@@ -659,12 +662,13 @@
 				401BC8A61CE8E65D00F89B3F /* LayoutNameWindow.swift in Sources */,
 				401BC8B41CE9250800F89B3F /* HotKeyRegistrar.swift in Sources */,
 				40CEF4301C2B8D21004C3297 /* ScreenManager.swift in Sources */,
-				404BE9CE1CFBB6E900D6C537 /* BinarySpacePartitioningLayout.swift in Sources */,
+				404BE9CE1CFBB6E900D6C537 /* AutoBinarySpacePartitioningLayout.swift in Sources */,
 				4062AD3B1C206EA900DB612B /* WidescreenTallLayout.swift in Sources */,
 				4058C46F1C4B119500B19D26 /* LayoutNameWindowController.swift in Sources */,
 				4062AD311C1FA29600DB612B /* TallRightLayout.swift in Sources */,
 				401BC8B61CE9259000F89B3F /* LayoutManager.swift in Sources */,
 				4006CF8A1CDFF695004CA512 /* SIApplication+Amethyst.swift in Sources */,
+				90D680781E1CCCF40088F922 /* BinarySpacePartitioningLayout.swift in Sources */,
 				4062AD371C1FA83300DB612B /* RowLayout.swift in Sources */,
 				4006CF8E1CDFFE90004CA512 /* AppDelegate.swift in Sources */,
 				4006CF901CE017BA004CA512 /* UserConfiguration.swift in Sources */,
@@ -736,18 +740,24 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -756,9 +766,11 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
@@ -772,23 +784,32 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -800,7 +821,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 82P2XLB4UH;
+				DEVELOPMENT_TEAM = 825E5U7JWP;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/Amethyst-hayuzxrdmhaqmverzffhmryaexfi/Build/Products/Debug",
@@ -831,7 +852,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 82P2XLB4UH;
+				DEVELOPMENT_TEAM = 825E5U7JWP;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/Amethyst-hayuzxrdmhaqmverzffhmryaexfi/Build/Products/Debug",

--- a/Amethyst.xcodeproj/xcshareddata/xcschemes/Amethyst.xcscheme
+++ b/Amethyst.xcodeproj/xcshareddata/xcschemes/Amethyst.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A1ADEC71540445EB1A623A59353C7FBB"
+               BlueprintIdentifier = "1A5E82937796E5F980D8E64E56F947A3"
                BuildableName = "Pods_Amethyst.framework"
                BlueprintName = "Pods-Amethyst"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -42,7 +42,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8D929359D2669AF2B3EC020CE8B8A4DD"
+               BlueprintIdentifier = "F4EC363BF222A75BBDE9D8AE885EAA12"
                BuildableName = "Pods_AmethystTests.framework"
                BlueprintName = "Pods-AmethystTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -188,6 +188,10 @@ open class HotKeyManager: NSObject {
         constructCommandWithCommandKey(CommandKey.ToggleFocusFollowsMouse.rawValue) {
             self.userConfiguration.toggleFocusFollowsMouse()
         }
+        
+        constructCommandWithCommandKey(CommandKey.ToggleAnimateWindows.rawValue) {
+            self.userConfiguration.toggleAnimateWindows()
+        }
 
         let layoutStrings: [String] = userConfiguration.layoutStrings()
         layoutStrings.forEach { layoutString in

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -27,14 +27,14 @@ private class AutoBSPReflowOperation: ReflowOperation {
         if windows_count == 0 {
             return
         }
-        
+
         // Create an array to hold all the candidate frames
         var binaryFrames = [CGRect]()
-        
+
         // Add the first frame which is the whole screen
         let screenFrame = adjustedFrameForLayout(screen)
         binaryFrames.append(screenFrame)
-        
+
         // Split until we have the right number of frames to hold the windows
         while binaryFrames.count < windows_count {
             //Find the frame with the largest area and then split it
@@ -94,7 +94,7 @@ private class AutoBSPReflowOperation: ReflowOperation {
         if isCancelled {
             return
         }
-        
+
         //Assign windows to binaryFrames
         assignWindowsToFramesBasedOnDistance(candidateFrames: binaryFrames)
     }

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -28,46 +28,46 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
         binaryFrames.append(screenFrame)
 
         // Split until we have the right number of frames to hold the windows
-        while(binaryFrames.count < windows.count){
+        while binaryFrames.count < windows.count {
             //Find the frame with the largest area and then split it
-            var largestArea:Float = -1.0
+            var largestArea: Float = -1.0
             var largestAreaIndex = -1
             for index in 0...(binaryFrames.count-1) {
-                let candidate:CGRect = binaryFrames[index]
+                let candidate: CGRect = binaryFrames[index]
 
                 let area = Float(candidate.size.width) * Float(candidate.size.height)
-                if(area >= largestArea){ //Prefer later matches
+                if area >= largestArea { //Prefer later matches
                     largestArea = area
                     largestAreaIndex = index
                 }
             }
 
             //Sanity check solution
-            if(largestAreaIndex < 0){
+            if largestAreaIndex < 0  {
                 NSLog("Unable to find a window to split: Index of window of -1 is invalid")
                 return
             }
-            if(largestArea <= 0){
+            if largestArea <= 0  {
                 NSLog("Unable to find a window to split: Largest window area of < 1 is invalid")
                 return
             }
 
             //Calculate two child frames
             let splittableFrame = binaryFrames[largestAreaIndex]
-            var childFrame1:CGRect
-            var childFrame2:CGRect
+            var childFrame1: CGRect
+            var childFrame2: CGRect
 
             //Figure out how to split the frame
-            if(splittableFrame.size.width > splittableFrame.size.height){
+            if splittableFrame.size.width > splittableFrame.size.height  {
                 //split vertically x | x
                 let newWidth1 = floor(splittableFrame.size.width * layout.mainPaneRatio)
                 let newWidth2 = ceil(splittableFrame.size.width - newWidth1)
                 let newHeight1 = floor(splittableFrame.size.height)
                 let newHeight2 = ceil(splittableFrame.size.height)
                 childFrame1 = CGRect(x:splittableFrame.origin.x, y:splittableFrame.origin.y, width:newWidth1, height:newHeight1)
-                childFrame2 = CGRect(x:(splittableFrame.origin.x + newWidth1), y:splittableFrame.origin.y,width:newWidth2, height:newHeight2)
+                childFrame2 = CGRect(x:(splittableFrame.origin.x + newWidth1), y:splittableFrame.origin.y, width:newWidth2, height:newHeight2)
             }
-            else{
+            else {
                 //split horizontally  x
                 //                    -
                 //                    x
@@ -133,4 +133,3 @@ open class AutoBinarySpacePartitioningLayout: Layout {
         mainPaneCount = max(1, mainPaneCount - 1)
     }
 }
-

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -11,12 +11,12 @@ import Silica
 
 private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
     fileprivate let layout: AutoBinarySpacePartitioningLayout
-    
+
     fileprivate init(screen: NSScreen, windows: [SIWindow], layout: AutoBinarySpacePartitioningLayout, windowActivityCache: WindowActivityCache) {
         self.layout = layout
         super.init(screen: screen, windows: windows, windowActivityCache: windowActivityCache)
     }
-    
+
     fileprivate override func main() {
         if windows.count == 0 {
             return
@@ -26,7 +26,7 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
         // Add the first frame which is the whole screen
         let screenFrame = adjustedFrameForLayout(screen)
         binaryFrames.append(screenFrame)
-        
+
         // Split until we have the right number of frames to hold the windows
         while(binaryFrames.count < windows.count){
             //Find the frame with the largest area and then split it
@@ -34,14 +34,14 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
             var largestAreaIndex = -1
             for index in 0...(binaryFrames.count-1) {
                 let candidate:CGRect = binaryFrames[index]
-                
+
                 let area = Float(candidate.size.width) * Float(candidate.size.height)
                 if(area >= largestArea){ //Prefer later matches
                     largestArea = area
                     largestAreaIndex = index
                 }
             }
-            
+
             //Sanity check solution
             if(largestAreaIndex < 0){
                 NSLog("Unable to find a window to split: Index of window of -1 is invalid")
@@ -51,13 +51,12 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
                 NSLog("Unable to find a window to split: Largest window area of < 1 is invalid")
                 return
             }
-            
+
             //Calculate two child frames
             let splittableFrame = binaryFrames[largestAreaIndex]
             var childFrame1:CGRect
             var childFrame2:CGRect
-            
-            
+
             //Figure out how to split the frame
             if(splittableFrame.size.width > splittableFrame.size.height){
                 //split vertically x | x
@@ -83,26 +82,26 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
             binaryFrames[largestAreaIndex] = childFrame1
             binaryFrames.append(childFrame2)
         }
-        
+
         //Assign windows to binaryFrames
         let focusedWindow = SIWindow.focused()
-        
+
         let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
-            
+
             let windowFrame = binaryFrames[frameAssignments.count]
-            
+
             let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
-            
+
             assignments.append(frameAssignment)
-            
+
             return assignments
         }
-        
+
         if isCancelled {
             return
         }
-        
+
         performFrameAssignments(frameAssignments)
     }
 }
@@ -110,26 +109,26 @@ private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
 open class AutoBinarySpacePartitioningLayout: Layout {
     override open class var layoutName: String { return "Auto Binary Space Partition" }
     override open class var layoutKey: String { return "absp" }
-    
+
     fileprivate var mainPaneCount: Int = 1
     fileprivate var mainPaneRatio: CGFloat = 0.5
-    
+
     override open func reflowOperationForScreen(_ screen: NSScreen, withWindows windows: [SIWindow]) -> ReflowOperation {
         return AutoBinarySpacePartitioningReflowOperation(screen: screen, windows: windows, layout: self, windowActivityCache: windowActivityCache)
     }
-    
+
     override open func expandMainPane() {
         mainPaneRatio = min(1, mainPaneRatio + UserConfiguration.shared.windowResizeStep())
     }
-    
+
     override open func shrinkMainPane() {
         mainPaneRatio = max(0, mainPaneRatio - UserConfiguration.shared.windowResizeStep())
     }
-    
+
     override open func increaseMainPaneCount() {
         mainPaneCount = mainPaneCount + 1
     }
-    
+
     override open func decreaseMainPaneCount() {
         mainPaneCount = max(1, mainPaneCount - 1)
     }

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -8,8 +8,7 @@
 
 import Silica
 
-
-private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
+private class AutoBSPReflowOperation: ReflowOperation {
     fileprivate let layout: AutoBinarySpacePartitioningLayout
 
     fileprivate init(screen: NSScreen, windows: [SIWindow], layout: AutoBinarySpacePartitioningLayout, windowActivityCache: WindowActivityCache) {
@@ -114,7 +113,7 @@ open class AutoBinarySpacePartitioningLayout: Layout {
     fileprivate var mainPaneRatio: CGFloat = 0.5
 
     override open func reflowOperationForScreen(_ screen: NSScreen, withWindows windows: [SIWindow]) -> ReflowOperation {
-        return AutoBinarySpacePartitioningReflowOperation(screen: screen, windows: windows, layout: self, windowActivityCache: windowActivityCache)
+        return AutoBSPReflowOperation(screen: screen, windows: windows, layout: self, windowActivityCache: windowActivityCache)
     }
 
     override open func expandMainPane() {

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -1,0 +1,137 @@
+//
+//  AutoBinarySpacePartitioningLayout.swift
+//  Amethyst
+//
+//  Created by Donald J Patterson on 1/3/17.
+//  Copyright © 2017 Donald J Patterson. All rights reserved.
+//
+
+import Silica
+
+
+private class AutoBinarySpacePartitioningReflowOperation: ReflowOperation {
+    fileprivate let layout: AutoBinarySpacePartitioningLayout
+    
+    fileprivate init(screen: NSScreen, windows: [SIWindow], layout: AutoBinarySpacePartitioningLayout, windowActivityCache: WindowActivityCache) {
+        self.layout = layout
+        super.init(screen: screen, windows: windows, windowActivityCache: windowActivityCache)
+    }
+    
+    fileprivate override func main() {
+        if windows.count == 0 {
+            return
+        }
+        // Create an array to hold all the window frames
+        var binaryFrames = [CGRect]()
+        // Add the first frame which is the whole screen
+        let screenFrame = adjustedFrameForLayout(screen)
+        binaryFrames.append(screenFrame)
+        
+        // Split until we have the right number of frames to hold the windows
+        while(binaryFrames.count < windows.count){
+            //Find the frame with the largest area and then split it
+            var largestArea:Float = -1.0
+            var largestAreaIndex = -1
+            for index in 0...(binaryFrames.count-1) {
+                let candidate:CGRect = binaryFrames[index]
+                
+                let area = Float(candidate.size.width) * Float(candidate.size.height)
+                if(area >= largestArea){ //Prefer later matches
+                    largestArea = area
+                    largestAreaIndex = index
+                }
+            }
+            
+            //Sanity check solution
+            if(largestAreaIndex < 0){
+                NSLog("Unable to find a window to split: Index of window of -1 is invalid")
+                return
+            }
+            if(largestArea <= 0){
+                NSLog("Unable to find a window to split: Largest window area of < 1 is invalid")
+                return
+            }
+            
+            //Calculate two child frames
+            let splittableFrame = binaryFrames[largestAreaIndex]
+            var childFrame1:CGRect
+            var childFrame2:CGRect
+            
+            
+            //Figure out how to split the frame
+            if(splittableFrame.size.width > splittableFrame.size.height){
+                //split vertically x | x
+                let newWidth1 = floor(splittableFrame.size.width * layout.mainPaneRatio)
+                let newWidth2 = ceil(splittableFrame.size.width - newWidth1)
+                let newHeight1 = floor(splittableFrame.size.height)
+                let newHeight2 = ceil(splittableFrame.size.height)
+                childFrame1 = CGRect(x:splittableFrame.origin.x, y:splittableFrame.origin.y, width:newWidth1, height:newHeight1)
+                childFrame2 = CGRect(x:(splittableFrame.origin.x + newWidth1), y:splittableFrame.origin.y,width:newWidth2, height:newHeight2)
+            }
+            else{
+                //split horizontally  x
+                //                    -
+                //                    x
+                let newWidth1 = floor(splittableFrame.size.width)
+                let newWidth2 = ceil(splittableFrame.size.width)
+                let newHeight1 = floor(splittableFrame.size.height * layout.mainPaneRatio)
+                let newHeight2 = ceil(splittableFrame.size.height - newHeight1)
+                childFrame1 = CGRect(x:splittableFrame.origin.x, y:splittableFrame.origin.y, width:newWidth1, height:newHeight1)
+                childFrame2 = CGRect(x:splittableFrame.origin.x, y:splittableFrame.origin.y+newHeight1, width:newWidth2, height:newHeight2)
+            }
+            //Insert them in the list, replacing the parent
+            binaryFrames[largestAreaIndex] = childFrame1
+            binaryFrames.append(childFrame2)
+        }
+        
+        //Assign windows to binaryFrames
+        let focusedWindow = SIWindow.focused()
+        
+        let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
+            var assignments = frameAssignments
+            
+            let windowFrame = binaryFrames[frameAssignments.count]
+            
+            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+            
+            assignments.append(frameAssignment)
+            
+            return assignments
+        }
+        
+        if isCancelled {
+            return
+        }
+        
+        performFrameAssignments(frameAssignments)
+    }
+}
+
+open class AutoBinarySpacePartitioningLayout: Layout {
+    override open class var layoutName: String { return "Auto Binary Space Partition" }
+    override open class var layoutKey: String { return "absp" }
+    
+    fileprivate var mainPaneCount: Int = 1
+    fileprivate var mainPaneRatio: CGFloat = 0.5
+    
+    override open func reflowOperationForScreen(_ screen: NSScreen, withWindows windows: [SIWindow]) -> ReflowOperation {
+        return AutoBinarySpacePartitioningReflowOperation(screen: screen, windows: windows, layout: self, windowActivityCache: windowActivityCache)
+    }
+    
+    override open func expandMainPane() {
+        mainPaneRatio = min(1, mainPaneRatio + UserConfiguration.shared.windowResizeStep())
+    }
+    
+    override open func shrinkMainPane() {
+        mainPaneRatio = max(0, mainPaneRatio - UserConfiguration.shared.windowResizeStep())
+    }
+    
+    override open func increaseMainPaneCount() {
+        mainPaneCount = mainPaneCount + 1
+    }
+    
+    override open func decreaseMainPaneCount() {
+        mainPaneCount = max(1, mainPaneCount - 1)
+    }
+}
+

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -19,8 +19,8 @@ private class AutoBSPReflowOperation: ReflowOperation {
     fileprivate override func main() {
         //Check to see how many legit windows we have
         var windows_count = 0
-        for window in self.windows{
-            if !isDegenerateWindow(window:window){
+        for window in self.windows {
+            if !isDegenerateWindow(window:window) {
                 windows_count = windows_count + 1
             }
         }

--- a/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/AutoBinarySpacePartitioningLayout.swift
@@ -42,11 +42,11 @@ private class AutoBSPReflowOperation: ReflowOperation {
             }
 
             //Sanity check solution
-            if largestAreaIndex < 0  {
+            if largestAreaIndex < 0 {
                 NSLog("Unable to find a window to split: Index of window of -1 is invalid")
                 return
             }
-            if largestArea <= 0  {
+            if largestArea <= 0 {
                 NSLog("Unable to find a window to split: Largest window area of < 1 is invalid")
                 return
             }
@@ -57,7 +57,7 @@ private class AutoBSPReflowOperation: ReflowOperation {
             var childFrame2: CGRect
 
             //Figure out how to split the frame
-            if splittableFrame.size.width > splittableFrame.size.height  {
+            if splittableFrame.size.width > splittableFrame.size.height {
                 //split vertically x | x
                 let newWidth1 = floor(splittableFrame.size.width * layout.mainPaneRatio)
                 let newWidth2 = ceil(splittableFrame.size.width - newWidth1)

--- a/Amethyst/Layout/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/BinarySpacePartitioningLayout.swift
@@ -13,58 +13,58 @@ internal class TreeNode {
     var left: TreeNode?
     var right: TreeNode?
     var windowID: CGWindowID?
-    
+
     var valid: Bool {
         return (left != nil && right != nil && windowID == nil) || (left == nil && right == nil && windowID != nil)
     }
-    
+
     func findWindowID(_ windowID: CGWindowID) -> TreeNode? {
         guard self.windowID == windowID else {
             return left?.findWindowID(windowID) ?? right?.findWindowID(windowID)
         }
-        
+
         return self
     }
-    
+
     func orderedWindowIDs() -> [CGWindowID] {
         guard let windowID = windowID else {
             let leftWindowIDs = left?.orderedWindowIDs() ?? []
             let rightWindowIDs = right?.orderedWindowIDs() ?? []
             return leftWindowIDs + rightWindowIDs
         }
-        
+
         return [windowID]
     }
-    
+
     func insertWindowIDAtEnd(_ windowID: CGWindowID) {
         guard left == nil && right == nil else {
             right?.insertWindowIDAtEnd(windowID)
             return
         }
-        
+
         insertWindowID(windowID)
     }
-    
+
     func insertWindowID(_ windowID: CGWindowID, atPoint insertionPoint: CGWindowID) {
         guard self.windowID == insertionPoint else {
             left?.insertWindowID(windowID, atPoint: insertionPoint)
             right?.insertWindowID(windowID, atPoint: insertionPoint)
             return
         }
-        
+
         insertWindowID(windowID)
     }
-    
+
     func removeWindowID(_ windowID: CGWindowID) {
         guard let node = findWindowID(windowID) else {
             LogManager.log?.error("Trying to remove window not in tree")
             return
         }
-        
+
         guard let parent = node.parent else {
             return
         }
-        
+
         guard let grandparent = parent.parent else {
             if node == parent.left {
                 parent.windowID = parent.right?.windowID

--- a/Amethyst/Layout/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/BinarySpacePartitioningLayout.swift
@@ -13,58 +13,58 @@ internal class TreeNode {
     var left: TreeNode?
     var right: TreeNode?
     var windowID: CGWindowID?
-
+    
     var valid: Bool {
         return (left != nil && right != nil && windowID == nil) || (left == nil && right == nil && windowID != nil)
     }
-
+    
     func findWindowID(_ windowID: CGWindowID) -> TreeNode? {
         guard self.windowID == windowID else {
             return left?.findWindowID(windowID) ?? right?.findWindowID(windowID)
         }
-
+        
         return self
     }
-
+    
     func orderedWindowIDs() -> [CGWindowID] {
         guard let windowID = windowID else {
             let leftWindowIDs = left?.orderedWindowIDs() ?? []
             let rightWindowIDs = right?.orderedWindowIDs() ?? []
             return leftWindowIDs + rightWindowIDs
         }
-
+        
         return [windowID]
     }
-
+    
     func insertWindowIDAtEnd(_ windowID: CGWindowID) {
         guard left == nil && right == nil else {
             right?.insertWindowIDAtEnd(windowID)
             return
         }
-
+        
         insertWindowID(windowID)
     }
-
+    
     func insertWindowID(_ windowID: CGWindowID, atPoint insertionPoint: CGWindowID) {
         guard self.windowID == insertionPoint else {
             left?.insertWindowID(windowID, atPoint: insertionPoint)
             right?.insertWindowID(windowID, atPoint: insertionPoint)
             return
         }
-
+        
         insertWindowID(windowID)
     }
-
+    
     func removeWindowID(_ windowID: CGWindowID) {
         guard let node = findWindowID(windowID) else {
             LogManager.log?.error("Trying to remove window not in tree")
             return
         }
-
+        
         guard let parent = node.parent else {
             return
         }
-
+        
         guard let grandparent = parent.parent else {
             if node == parent.left {
                 parent.windowID = parent.right?.windowID
@@ -75,7 +75,7 @@ internal class TreeNode {
             parent.right = nil
             return
         }
-
+        
         if parent == grandparent.left {
             if node == parent.left {
                 grandparent.left = parent.right
@@ -92,40 +92,40 @@ internal class TreeNode {
             grandparent.right?.parent = grandparent
         }
     }
-
+    
     internal func insertWindowID(_ windowID: CGWindowID) {
         guard parent != nil || self.windowID != nil else {
             self.windowID = windowID
             return
         }
-
+        
         if let parent = parent {
             let newParent = TreeNode()
             let newNode = TreeNode()
-
+            
             newNode.parent = newParent
             newNode.windowID = windowID
-
+            
             newParent.left = self
             newParent.right = newNode
             newParent.parent = parent
-
+            
             if self == parent.left {
                 parent.left = newParent
             } else {
                 parent.right = newParent
             }
-
+            
             self.parent = newParent
         } else {
             let newSelf = TreeNode()
             let newNode = TreeNode()
-
+            
             newSelf.windowID = self.windowID
             self.windowID = nil
-
+            
             newNode.windowID = windowID
-
+            
             left = newSelf
             left?.parent = self
             right = newNode
@@ -142,41 +142,41 @@ internal func == (lhs: TreeNode, rhs: TreeNode) -> Bool {
 
 private class BinarySpacePartitioningReflowOperation: ReflowOperation {
     fileprivate typealias TraversalNode = (node: TreeNode, frame: CGRect)
-
+    
     fileprivate let rootNode: TreeNode
-
+    
     fileprivate init(screen: NSScreen, windows: [SIWindow], rootNode: TreeNode, windowActivityCache: WindowActivityCache) {
         self.rootNode = rootNode
         super.init(screen: screen, windows: windows, windowActivityCache: windowActivityCache)
     }
-
+    
     fileprivate override func main() {
         if windows.count == 0 {
             return
         }
-
+        
         let windowIDMap: [CGWindowID: SIWindow] = windows.reduce([:]) { (windowMap, window) -> [CGWindowID: SIWindow] in
             var mutableWindowMap = windowMap
             mutableWindowMap[window.windowID()] = window
             return mutableWindowMap
         }
-
+        
         let focusedWindow = SIWindow.focused()
         let baseFrame = adjustedFrameForLayout(screen)
         var frameAssignments: [FrameAssignment] = []
         var traversalNodes: [TraversalNode] = [(node: rootNode, frame: baseFrame)]
-
+        
         while traversalNodes.count > 0 {
             let traversalNode = traversalNodes[0]
-
+            
             traversalNodes = [TraversalNode](traversalNodes.dropFirst(1))
-
+            
             if let windowID = traversalNode.node.windowID {
                 guard let window = windowIDMap[windowID] else {
                     LogManager.log?.warning("Could not find window for ID: \(windowID)")
                     continue
                 }
-
+                
                 let frameAssignment = FrameAssignment(frame: traversalNode.frame, window: window, focused: windowID == focusedWindow?.windowID(), screenFrame: baseFrame)
                 frameAssignments.append(frameAssignment)
             } else {
@@ -184,9 +184,9 @@ private class BinarySpacePartitioningReflowOperation: ReflowOperation {
                     LogManager.log?.error("Encountered an invalid node")
                     continue
                 }
-
+                
                 let frame = traversalNode.frame
-
+                
                 if frame.width > frame.height {
                     let leftFrame = CGRect(
                         x: frame.origin.x,
@@ -220,11 +220,11 @@ private class BinarySpacePartitioningReflowOperation: ReflowOperation {
                 }
             }
         }
-
+        
         if isCancelled {
             return
         }
-
+        
         performFrameAssignments(frameAssignments)
     }
 }
@@ -232,18 +232,18 @@ private class BinarySpacePartitioningReflowOperation: ReflowOperation {
 open class BinarySpacePartitioningLayout: Layout {
     override open class var layoutName: String { return "Binary Space Partitioning" }
     override open class var layoutKey: String { return "bsp" }
-
+    
     internal var rootNode = TreeNode()
     internal var lastKnownFocusedWindowID: CGWindowID?
-
+    
     open override func reflowOperationForScreen(_ screen: NSScreen, withWindows windows: [SIWindow]) -> ReflowOperation {
         if windows.count > 0 && !rootNode.valid {
             constructInitialTreeWithWindows(windows)
         }
-
+        
         return BinarySpacePartitioningReflowOperation(screen: screen, windows: windows, rootNode: rootNode, windowActivityCache: windowActivityCache)
     }
-
+    
     open override func updateWithChange(_ windowChange: WindowChange) {
         switch windowChange {
         case let .add(window):
@@ -251,7 +251,7 @@ open class BinarySpacePartitioningLayout: Layout {
                 LogManager.log?.warning("Trying to add a window already in the tree")
                 return
             }
-
+            
             if let insertionPoint = lastKnownFocusedWindowID, window.windowID() != insertionPoint {
                 LogManager.log?.info("insert \(window) - \(window.windowID()) at point: \(insertionPoint)")
                 rootNode.insertWindowID(window.windowID(), atPoint: insertionPoint)
@@ -267,57 +267,57 @@ open class BinarySpacePartitioningLayout: Layout {
         case let .windowSwap(window, otherWindow):
             let windowID = window.windowID()
             let otherWindowID = otherWindow.windowID()
-
+            
             guard let windowNode = rootNode.findWindowID(windowID), let otherWindowNode = rootNode.findWindowID(otherWindowID) else {
                 LogManager.log?.error("Tried to perform an unbalanced window swap: \(windowID) <-> \(otherWindowID)")
                 return
             }
-
+            
             windowNode.windowID = otherWindowID
             otherWindowNode.windowID = windowID
         case .unknown:
             break
         }
     }
-
+    
     open override func nextWindowIDCounterClockwise() -> CGWindowID? {
         guard let focusedWindow = SIWindow.focused() else {
             return nil
         }
-
+        
         let orderedIDs = rootNode.orderedWindowIDs()
-
+        
         guard let focusedWindowIndex = orderedIDs.index(of: focusedWindow.windowID()) else {
             return nil
         }
-
+        
         let nextWindowIndex = (focusedWindowIndex == 0 ? orderedIDs.count - 1 : focusedWindowIndex - 1)
-
+        
         return orderedIDs[nextWindowIndex]
     }
-
+    
     open override func nextWindowIDClockwise() -> CGWindowID? {
         guard let focusedWindow = SIWindow.focused() else {
             return nil
         }
-
+        
         let orderedIDs = rootNode.orderedWindowIDs()
-
+        
         guard let focusedWindowIndex = orderedIDs.index(of: focusedWindow.windowID()) else {
             return nil
         }
-
+        
         let nextWindowIndex = (focusedWindowIndex == orderedIDs.count - 1 ? 0 : focusedWindowIndex + 1)
-
+        
         return orderedIDs[nextWindowIndex]
     }
-
+    
     internal func constructInitialTreeWithWindows(_ windows: [SIWindow]) {
         for window in windows {
             guard rootNode.findWindowID(window.windowID()) == nil else {
                 continue
             }
-
+            
             rootNode.insertWindowIDAtEnd(window.windowID())
         }
     }

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -72,7 +72,7 @@ open class ReflowOperation: Operation {
 					                        y: CGFloat(y),
 										width: CGFloat(width),
 									   height: CGFloat(height)),
-									  oWindow: frameAssignment.window,
+                                     toWindow: frameAssignment.window,
 									  focused: frameAssignment.focused,
 								  screenFrame: frameAssignment.screenFrame)
                 }

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -94,7 +94,7 @@ open class ReflowOperation: Operation {
         }
         if window_frame.height <= 0.0 {
             return true
-        2
+        }
         if window_frame.height.isInfinite {
             return true
         }
@@ -104,7 +104,7 @@ open class ReflowOperation: Operation {
         return false
     }
 
-    fileprivate func categorizeWindows(candidateFrames: [CGRect]) -> ([SIWindow], [SIWindow]) {
+    private func categorizeWindows(candidateFrames: [CGRect]) -> ([SIWindow], [SIWindow]) {
 
         var displaced: [SIWindow] = []
         var aligned: [SIWindow] = []

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -62,7 +62,7 @@ open class ReflowOperation: Operation {
         }
     }
 
-    open func isDegenerateWindow(window:SIWindow) -> Bool {
+    open func isDegenerateWindow(window: SIWindow) -> Bool {
         let window_frame = window.frame()
         if window_frame.origin.x < 0.0 {
             return true
@@ -104,7 +104,7 @@ open class ReflowOperation: Operation {
         return false
     }
 
-    fileprivate func categorizeWindows(candidateFrames: [CGRect]) -> ([SIWindow],[SIWindow]) {
+    fileprivate func categorizeWindows(candidateFrames: [CGRect]) -> ([SIWindow], [SIWindow]) {
 
         var displaced: [SIWindow] = []
         var aligned: [SIWindow] = []
@@ -133,7 +133,7 @@ open class ReflowOperation: Operation {
                 }
             }
         }
-        return (displaced,aligned)
+        return (displaced, aligned)
 
     }
 
@@ -141,7 +141,7 @@ open class ReflowOperation: Operation {
 
         var candidateFramesMutable = candidateFrames
         //Find those windows that are not perfectly on top of a frame to assign first, because those are the ones that have been newly created or manually moved
-        let (displacedWindows,alignedWindows) = categorizeWindows(candidateFrames: candidateFrames)
+        let (displacedWindows, alignedWindows) = categorizeWindows(candidateFrames: candidateFrames)
 
         //Now preferentially assign displaced windows a location
         let screenFrame = adjustedFrameForLayout(screen)
@@ -156,7 +156,7 @@ open class ReflowOperation: Operation {
                 let window_frame = window.frame()
                 let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
                 let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
-                for (index,frame) in candidateFramesMutable.enumerated() {
+                for (index, frame) in candidateFramesMutable.enumerated() {
                     let frame_center_x = frame.origin.x + (frame.width/2.0)
                     let frame_center_y = frame.origin.y + (frame.height/2.0)
                     let distance_x = (frame_center_x - windows_center_x)
@@ -186,7 +186,7 @@ open class ReflowOperation: Operation {
                 let window_frame = window.frame()
                 let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
                 let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
-                for (index,frame) in candidateFramesMutable.enumerated() {
+                for (index, frame) in candidateFramesMutable.enumerated() {
                     let frame_center_x = frame.origin.x + (frame.width/2.0)
                     let frame_center_y = frame.origin.y + (frame.height/2.0)
                     let distance_x = (frame_center_x - windows_center_x)
@@ -218,7 +218,7 @@ open class ReflowOperation: Operation {
             if !isDegenerateWindow(window:window) {
                 let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
                 let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
-                for (index,frame) in candidateFramesMutable.enumerated() {
+                for (index, frame) in candidateFramesMutable.enumerated() {
                     let frame_center_x = frame.origin.x + (frame.width/2.0)
                     let frame_center_y = frame.origin.y + (frame.height/2.0)
                     let distance_x = (frame_center_x - windows_center_x)

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -64,16 +64,10 @@ open class ReflowOperation: Operation {
 
     open func isDegenerateWindow(window: SIWindow) -> Bool {
         let window_frame = window.frame()
-        if window_frame.origin.x < 0.0 {
-            return true
-        }
         if window_frame.origin.x.isInfinite {
             return true
         }
         if window_frame.origin.x.isNaN {
-            return true
-        }
-        if window_frame.origin.y < 0.0 {
             return true
         }
         if window_frame.origin.y.isInfinite {
@@ -82,7 +76,6 @@ open class ReflowOperation: Operation {
         if window_frame.origin.y.isNaN {
             return true
         }
-
         if window_frame.width <= 0.0 {
             return true
         }

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -61,6 +61,179 @@ open class ReflowOperation: Operation {
             self.assignFrame(frameAssignment.frame, toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
         }
     }
+    
+    open func isDegenerateWindow(window:SIWindow) -> Bool{
+        let window_frame = window.frame()
+        if window_frame.origin.x < 0.0 {
+            return true
+        }
+        if window_frame.origin.x.isInfinite{
+            return true
+        }
+        if window_frame.origin.x.isNaN{
+            return true
+        }
+        if window_frame.origin.y < 0.0 {
+            return true
+        }
+        if window_frame.origin.y.isInfinite{
+            return true
+        }
+        if window_frame.origin.y.isNaN{
+            return true
+        }
+    
+        if window_frame.width <= 0.0 {
+            return true
+        }
+        if window_frame.width.isInfinite{
+            return true
+        }
+        if window_frame.width.isNaN{
+            return true
+        }
+        if window_frame.height <= 0.0 {
+            return true
+        }
+        if window_frame.height.isInfinite{
+            return true
+        }
+        if window_frame.height.isNaN{
+            return true
+        }
+        return false
+    }
+    
+    open func assignWindowsToFramesBasedOnDistance(candidateFrames:[CGRect]) {
+        
+        var candidateFramesCopy = candidateFrames
+        
+        //Find those windows that are not perfectly on top of a frame to assign first, because those are the ones that have been newly created or manually moved
+        var displacedWindows: [SIWindow] = []
+        var alignedWindows: [SIWindow] = []
+
+        for window in self.windows{
+            //Sometimes the windows become degenerate for some reason, ignore them
+            if !isDegenerateWindow(window:window) {
+                var min_distance = FLT_MAX
+                let window_frame = window.frame()
+                let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
+                let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
+                for frame in candidateFramesCopy{
+                    let frame_center_x = frame.origin.x + (frame.width/2.0)
+                    let frame_center_y = frame.origin.y + (frame.height/2.0)
+                    let distance_x = (frame_center_x - windows_center_x)
+                    let distance_y = (frame_center_y - windows_center_y)
+                    let distance = sqrt(distance_x*distance_x + distance_y*distance_y)
+                    if(Float(distance) < min_distance){
+                        min_distance = Float(distance)
+                    }
+                }
+                if(min_distance < 1.0){
+                    alignedWindows.append(window)
+                }
+                else{
+                    displacedWindows.append(window)
+                }
+            }
+        }
+        
+        //Now preferentially assign displaced windows a location
+        let screenFrame = adjustedFrameForLayout(screen)
+        let focusedWindow = SIWindow.focused()
+        var frameAssignments: [FrameAssignment] = []
+        for window in displacedWindows{
+            var min_distance = FLT_MAX
+            var min_index = -1
+    
+            //Sometimes the windows become degenerate for some reason
+            if !isDegenerateWindow(window:window){
+                let window_frame = window.frame()
+                let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
+                let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
+                for (index,frame) in candidateFramesCopy.enumerated(){
+                    let frame_center_x = frame.origin.x + (frame.width/2.0)
+                    let frame_center_y = frame.origin.y + (frame.height/2.0)
+                    let distance_x = (frame_center_x - windows_center_x)
+                    let distance_y = (frame_center_y - windows_center_y)
+                    let distance = sqrt(distance_x*distance_x + distance_y*distance_y)
+                    if(Float(distance) < min_distance){
+                        min_distance = Float(distance)
+                        min_index = index
+                    }
+                }
+            }
+            if(min_index != -1){
+                let frameAssignment = FrameAssignment(frame: candidateFramesCopy[min_index], window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+                frameAssignments.append(frameAssignment)
+                candidateFramesCopy.remove(at: min_index)
+            }
+        }
+        
+        //Now assigned aligned windows that are still aligned a location
+        var alignedNoMoreWindows: [SIWindow] = []
+        for window in alignedWindows{
+            var min_distance = FLT_MAX
+            var min_index = -1
+    
+            //Sometimes the windows become degenerate for some reason, ignore them
+            if !isDegenerateWindow(window:window){
+                let window_frame = window.frame()
+                let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
+                let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
+                for (index,frame) in candidateFramesCopy.enumerated(){
+                    let frame_center_x = frame.origin.x + (frame.width/2.0)
+                    let frame_center_y = frame.origin.y + (frame.height/2.0)
+                    let distance_x = (frame_center_x - windows_center_x)
+                    let distance_y = (frame_center_y - windows_center_y)
+                    let distance = sqrt(distance_x*distance_x + distance_y*distance_y)
+                    if(Float(distance) < min_distance){
+                        min_distance = Float(distance)
+                        min_index = index
+                    }
+                }
+            }
+            //If a displaced window took the frame that the previously aligned window was aligned to, then it is no longer aligned
+            if(min_distance >= 1.0){
+                alignedNoMoreWindows.append(window)
+            }
+            else {
+                let frameAssignment = FrameAssignment(frame: candidateFramesCopy[min_index], window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+                frameAssignments.append(frameAssignment)
+                candidateFramesCopy.remove(at: min_index)
+            }
+        }
+        
+        //Now assigned anything that is left
+        for window in alignedNoMoreWindows{
+            var min_distance = FLT_MAX
+            var min_index = -1
+            let window_frame = window.frame()
+            //Sometimes the windows become degenerate for some reason, ignore them
+            if !isDegenerateWindow(window:window) {
+                let windows_center_x = window_frame.origin.x + (window_frame.width/2.0)
+                let windows_center_y = window_frame.origin.y + (window_frame.height/2.0)
+                for (index,frame) in candidateFramesCopy.enumerated(){
+                    let frame_center_x = frame.origin.x + (frame.width/2.0)
+                    let frame_center_y = frame.origin.y + (frame.height/2.0)
+                    let distance_x = (frame_center_x - windows_center_x)
+                    let distance_y = (frame_center_y - windows_center_y)
+                    let distance = sqrt(distance_x*distance_x + distance_y*distance_y)
+                    if(Float(distance) < min_distance){
+                        min_distance = Float(distance)
+                        min_index = index
+                    }
+                }
+            }
+            if(min_index != -1){
+                let frameAssignment = FrameAssignment(frame: candidateFramesCopy[min_index], window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+                frameAssignments.append(frameAssignment)
+                candidateFramesCopy.remove(at: min_index)
+            }
+        }
+    
+        performFrameAssignments(frameAssignments)
+    }
 
     fileprivate func assignFrame(_ frame: CGRect, toWindow window: SIWindow, focused: Bool, screenFrame: CGRect) {
         var padding = UserConfiguration.shared.windowMarginSize()

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -61,7 +61,7 @@ open class ReflowOperation: Operation {
             self.assignFrame(frameAssignment.frame, toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
         }
     }
-    
+
     open func isDegenerateWindow(window:SIWindow) -> Bool{
         let window_frame = window.frame()
         if window_frame.origin.x < 0.0 {
@@ -82,7 +82,7 @@ open class ReflowOperation: Operation {
         if window_frame.origin.y.isNaN{
             return true
         }
-    
+
         if window_frame.width <= 0.0 {
             return true
         }
@@ -103,11 +103,11 @@ open class ReflowOperation: Operation {
         }
         return false
     }
-    
+
     open func assignWindowsToFramesBasedOnDistance(candidateFrames:[CGRect]) {
-        
+
         var candidateFramesCopy = candidateFrames
-        
+
         //Find those windows that are not perfectly on top of a frame to assign first, because those are the ones that have been newly created or manually moved
         var displacedWindows: [SIWindow] = []
         var alignedWindows: [SIWindow] = []
@@ -137,7 +137,7 @@ open class ReflowOperation: Operation {
                 }
             }
         }
-        
+
         //Now preferentially assign displaced windows a location
         let screenFrame = adjustedFrameForLayout(screen)
         let focusedWindow = SIWindow.focused()
@@ -145,7 +145,7 @@ open class ReflowOperation: Operation {
         for window in displacedWindows{
             var min_distance = FLT_MAX
             var min_index = -1
-    
+
             //Sometimes the windows become degenerate for some reason
             if !isDegenerateWindow(window:window){
                 let window_frame = window.frame()
@@ -169,13 +169,13 @@ open class ReflowOperation: Operation {
                 candidateFramesCopy.remove(at: min_index)
             }
         }
-        
+
         //Now assigned aligned windows that are still aligned a location
         var alignedNoMoreWindows: [SIWindow] = []
         for window in alignedWindows{
             var min_distance = FLT_MAX
             var min_index = -1
-    
+
             //Sometimes the windows become degenerate for some reason, ignore them
             if !isDegenerateWindow(window:window){
                 let window_frame = window.frame()
@@ -203,7 +203,7 @@ open class ReflowOperation: Operation {
                 candidateFramesCopy.remove(at: min_index)
             }
         }
-        
+
         //Now assigned anything that is left
         for window in alignedNoMoreWindows{
             var min_distance = FLT_MAX
@@ -231,7 +231,7 @@ open class ReflowOperation: Operation {
                 candidateFramesCopy.remove(at: min_index)
             }
         }
-    
+
         performFrameAssignments(frameAssignments)
     }
 

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -55,10 +55,31 @@ open class ReflowOperation: Operation {
             }
         }
 
-        for frameAssignment in frameAssignments {
-            LogManager.log?.debug("Screen: \(screen.screenIdentifier()) -- Frame Assignment: \(frameAssignment)")
+        if UserConfiguration.shared.animateWindows() {
+            for i in stride(from:0,to:101,by:10) {
+                for frameAssignment in frameAssignments {
+                    LogManager.log?.debug("Screen: \(screen.screenIdentifier()) -- Frame Assignment: \(frameAssignment)")
+                
+                    let dx = frameAssignment.frame.origin.x - frameAssignment.window.frame().origin.x
+                    let x = Float(frameAssignment.window.frame().origin.x) + (Float(i)/100.0)*Float(dx)
+                    let dy = frameAssignment.frame.origin.y - frameAssignment.window.frame().origin.y
+                    let y = Float(frameAssignment.window.frame().origin.y) + (Float(i)/100.0)*Float(dy)
+                    let dw = frameAssignment.frame.width - frameAssignment.window.frame().width
+                    let width = Float(frameAssignment.window.frame().width) + (Float(i)/100.0)*Float(dw)
+                    let dh = frameAssignment.frame.height - frameAssignment.window.frame().height
+                    let height = Float(frameAssignment.window.frame().height) + (Float(i)/100.0)*Float(dh)
+                    self.assignFrame(CGRect(x:CGFloat(x),y:CGFloat(y),width:CGFloat(width),height:CGFloat(height)), toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
+                }
+                //usleep(10000)
+            }
+            
+        }
+        else{
+            for frameAssignment in frameAssignments {
+                LogManager.log?.debug("Screen: \(screen.screenIdentifier()) -- Frame Assignment: \(frameAssignment)")
 
-            self.assignFrame(frameAssignment.frame, toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
+                self.assignFrame(frameAssignment.frame,toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
+            }
         }
     }
 

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -94,7 +94,7 @@ open class ReflowOperation: Operation {
         }
         if window_frame.height <= 0.0 {
             return true
-        }
+        2
         if window_frame.height.isInfinite {
             return true
         }

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -103,9 +103,9 @@ open class ReflowOperation: Operation {
         }
         return false
     }
-    
+
     fileprivate func categorizeWindows(candidateFrames: [CGRect]) -> ([SIWindow],[SIWindow]) {
-        
+
         var displaced: [SIWindow] = []
         var aligned: [SIWindow] = []
         for window in self.windows {
@@ -134,7 +134,7 @@ open class ReflowOperation: Operation {
             }
         }
         return (displaced,aligned)
-        
+
     }
 
     open func assignWindowsToFramesBasedOnDistance(candidateFrames: [CGRect]) {
@@ -142,8 +142,6 @@ open class ReflowOperation: Operation {
         var candidateFramesMutable = candidateFrames
         //Find those windows that are not perfectly on top of a frame to assign first, because those are the ones that have been newly created or manually moved
         let (displacedWindows,alignedWindows) = categorizeWindows(candidateFrames: candidateFrames)
-
-        
 
         //Now preferentially assign displaced windows a location
         let screenFrame = adjustedFrameForLayout(screen)

--- a/Amethyst/Managers/LayoutManager.swift
+++ b/Amethyst/Managers/LayoutManager.swift
@@ -31,6 +31,8 @@ open class LayoutManager {
             return WidescreenTallLayout.self
         case "bsp":
             return BinarySpacePartitioningLayout.self
+        case "absp":
+            return AutoBinarySpacePartitioningLayout.self
         default:
             return nil
         }
@@ -51,7 +53,8 @@ open class LayoutManager {
             RowLayout.self,
             FloatingLayout.self,
             WidescreenTallLayout.self,
-            BinarySpacePartitioningLayout.self
+            BinarySpacePartitioningLayout.self,
+            AutoBinarySpacePartitioningLayout.self
         ]
 
         return layoutClasses.map { LayoutManager.stringForLayoutClass($0) }

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -39,6 +39,9 @@ open class ScreenManager: NSObject {
 
             changingSpace = true
             currentLayoutIndex = currentLayoutIndexBySpaceIdentifier[spaceIdentifier] ?? 0
+            if(currentLayoutIndex >= layouts.count){
+                currentLayoutIndex = 0
+            }
 
             if let layouts = layoutsBySpaceIdentifier[spaceIdentifier] {
                 self.layouts = layouts
@@ -135,7 +138,7 @@ open class ScreenManager: NSObject {
     }
 
     open func cycleLayoutBackward() {
-        currentLayoutIndex = (currentLayoutIndex == 0 ? layouts.count : currentLayoutIndex) - 1
+        currentLayoutIndex = (currentLayoutIndex - 1) % layouts.count
         setNeedsReflowWithWindowChange(.unknown)
     }
 
@@ -145,8 +148,13 @@ open class ScreenManager: NSObject {
             return
         }
 
-        currentLayoutIndex = layoutIndex
-        setNeedsReflowWithWindowChange(.unknown)
+        if((layoutIndex < 0 ) || (layoutIndex >= layouts.count)){
+            return
+        }
+        else{
+            currentLayoutIndex = layoutIndex
+            setNeedsReflowWithWindowChange(.unknown)
+        }
     }
 
     open func shrinkMainPane() {

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,11 +16,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="LsO-9M-hEw" userLabel="General Preferences">
-            <rect key="frame" x="0.0" y="0.0" width="468" height="593"/>
+            <rect key="frame" x="0.0" y="0.0" width="468" height="627"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9hq-U6-t9B">
-                    <rect key="frame" x="170" y="422" width="148" height="18"/>
+                    <rect key="frame" x="170" y="456" width="148" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Float small windows" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="phj-M8-HfQ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -31,7 +31,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jbq-77-1YW">
-                    <rect key="frame" x="170" y="314" width="142" height="18"/>
+                    <rect key="frame" x="170" y="348" width="142" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable Layout HUD" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="UVr-KG-wFB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -42,7 +42,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ej5-FV-H6Q">
-                    <rect key="frame" x="170" y="294" width="255" height="18"/>
+                    <rect key="frame" x="170" y="328" width="255" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable Layout HUD on Space Change" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="o6e-e0-t64">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -53,7 +53,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wg4-Ew-VOi">
-                    <rect key="frame" x="107" y="423" width="59" height="17"/>
+                    <rect key="frame" x="107" y="457" width="59" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Floating:" id="H0k-aA-syT">
                         <font key="font" metaFont="system"/>
@@ -62,7 +62,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MKd-ZG-j26">
-                    <rect key="frame" x="83" y="315" width="83" height="17"/>
+                    <rect key="frame" x="83" y="349" width="83" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Layout HUD:" id="dFS-Je-lML">
                         <font key="font" metaFont="system"/>
@@ -71,7 +71,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G9A-P1-Ks1">
-                    <rect key="frame" x="126" y="271" width="40" height="17"/>
+                    <rect key="frame" x="126" y="305" width="40" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Misc.:" id="SoK-X5-vwJ">
                         <font key="font" metaFont="system"/>
@@ -80,7 +80,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pGc-zn-uC7">
-                    <rect key="frame" x="170" y="270" width="133" height="18"/>
+                    <rect key="frame" x="170" y="304" width="133" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Ignore menu bars" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="LKn-n5-1ay">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -91,7 +91,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Eb-EJ-evb">
-                    <rect key="frame" x="170" y="250" width="223" height="18"/>
+                    <rect key="frame" x="170" y="284" width="223" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Mouse follows focused windows" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="6fy-Pu-AhI">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -102,7 +102,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xay-gW-zGw">
-                    <rect key="frame" x="170" y="230" width="223" height="18"/>
+                    <rect key="frame" x="170" y="264" width="223" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Send new windows to main pane" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="stG-cM-1bg">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -112,8 +112,19 @@
                         <binding destination="XhK-Tn-zrU" name="value" keyPath="values.new-windows-to-main" id="c0g-Ta-qOE"/>
                     </connections>
                 </button>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ghe-m0-qa1">
+                    <rect key="frame" x="170" y="244" width="223" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Animate window movements" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Hrg-1b-i2Y">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="value" keyPath="values.animate-windows" id="0HI-vC-meB"/>
+                    </connections>
+                </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mtD-Sc-koj">
-                    <rect key="frame" x="170" y="210" width="243" height="18"/>
+                    <rect key="frame" x="170" y="222" width="243" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Focus follows mouse" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="u5m-jH-xzU">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -124,7 +135,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vRo-Ax-vKh">
-                    <rect key="frame" x="170" y="155" width="280" height="18"/>
+                    <rect key="frame" x="170" y="167" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Get development builds" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="5v8-xo-EWM">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -135,7 +146,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MGP-cm-WTe">
-                    <rect key="frame" x="170" y="115" width="280" height="18"/>
+                    <rect key="frame" x="170" y="127" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable crash reporting" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="T33-wB-9cH">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -146,7 +157,7 @@
                     </connections>
                 </button>
                 <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U6O-Ka-pXq">
-                    <rect key="frame" x="172" y="360" width="251" height="56"/>
+                    <rect key="frame" x="172" y="394" width="251" height="56"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" ambiguous="YES" id="RT8-fN-JDO">
                         <rect key="frame" x="1" y="1" width="249" height="54"/>
@@ -181,16 +192,16 @@
                         </subviews>
                     </clipView>
                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="IwH-cx-YkX">
-                        <rect key="frame" x="1" y="-15" width="0.0" height="16"/>
+                        <rect key="frame" x="-7" y="-14" width="0.0" height="15"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="eCG-Tq-r9K">
-                        <rect key="frame" x="-15" y="1" width="16" height="0.0"/>
+                        <rect key="frame" x="-14" y="-7" width="15" height="0.0"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZH0-nz-Yiv">
-                    <rect key="frame" x="172" y="339" width="27" height="23"/>
+                    <rect key="frame" x="172" y="373" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ok9-1r-DwF">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -201,7 +212,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cfp-8K-Cdt">
-                    <rect key="frame" x="198" y="339" width="27" height="23"/>
+                    <rect key="frame" x="198" y="373" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Xif-lH-IK0">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -212,7 +223,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c03-Jd-KsK">
-                    <rect key="frame" x="223" y="339" width="200" height="23"/>
+                    <rect key="frame" x="223" y="373" width="200" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="w8y-WB-Ax2">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -220,7 +231,7 @@
                     </buttonCell>
                 </button>
                 <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kgh-Mo-aGF">
-                    <rect key="frame" x="172" y="488" width="251" height="85"/>
+                    <rect key="frame" x="172" y="522" width="251" height="85"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" ambiguous="YES" id="NPi-lT-8Xb">
                         <rect key="frame" x="1" y="1" width="249" height="83"/>
@@ -255,16 +266,16 @@
                         </subviews>
                     </clipView>
                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="ldJ-I2-SGG">
-                        <rect key="frame" x="1" y="-15" width="0.0" height="16"/>
+                        <rect key="frame" x="-7" y="-14" width="0.0" height="15"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="URc-2W-nZo">
-                        <rect key="frame" x="-15" y="1" width="16" height="0.0"/>
+                        <rect key="frame" x="-14" y="-7" width="15" height="0.0"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AUR-i7-d99">
-                    <rect key="frame" x="172" y="467" width="27" height="23"/>
+                    <rect key="frame" x="172" y="501" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="v7u-4j-Gv9">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -275,7 +286,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="khH-XV-GhW">
-                    <rect key="frame" x="198" y="467" width="27" height="23"/>
+                    <rect key="frame" x="198" y="501" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="pcN-ET-p91">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -286,7 +297,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="A8V-CN-miB">
-                    <rect key="frame" x="223" y="467" width="200" height="23"/>
+                    <rect key="frame" x="223" y="501" width="200" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="8al-n7-kkn">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -294,7 +305,7 @@
                     </buttonCell>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M7e-Dw-sVZ">
-                    <rect key="frame" x="110" y="556" width="56" height="17"/>
+                    <rect key="frame" x="110" y="590" width="56" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Layouts:" id="tof-Wx-pYR">
                         <font key="font" metaFont="system"/>
@@ -303,7 +314,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fBD-ab-yJQ">
-                    <rect key="frame" x="170" y="139" width="280" height="15"/>
+                    <rect key="frame" x="170" y="151" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must restart for changes to take effect" id="Cak-aF-OC2">
                         <font key="font" metaFont="smallSystem"/>
@@ -312,7 +323,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4eN-rj-3bX">
-                    <rect key="frame" x="170" y="448" width="280" height="15"/>
+                    <rect key="frame" x="170" y="482" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must restart for changes to take effect" id="jJZ-0G-DUC">
                         <font key="font" metaFont="smallSystem"/>
@@ -321,7 +332,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e6w-YL-rzU">
-                    <rect key="frame" x="170" y="181" width="280" height="28"/>
+                    <rect key="frame" x="170" y="193" width="280" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="This feature is still experimental and may be unstable or have unexpected behavior" id="em1-tY-3zU">
                         <font key="font" metaFont="smallSystem"/>
@@ -330,7 +341,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ryf-WE-u7b">
-                    <rect key="frame" x="170" y="86" width="280" height="28"/>
+                    <rect key="frame" x="170" y="98" width="280" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Enabling this also sends some anonymous analytics" id="DiA-Hm-lgJ">
                         <font key="font" metaFont="smallSystem"/>
@@ -339,7 +350,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="l9P-32-7UB">
-                    <rect key="frame" x="170" y="85" width="280" height="15"/>
+                    <rect key="frame" x="170" y="97" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must restart for changes to take effect" id="2us-TJ-7M2">
                         <font key="font" metaFont="smallSystem"/>
@@ -348,7 +359,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="luh-Gm-ZV0">
-                    <rect key="frame" x="57" y="60" width="109" height="17"/>
+                    <rect key="frame" x="57" y="72" width="109" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Margins:" id="LnD-6G-RSL">
                         <font key="font" metaFont="system"/>
@@ -357,7 +368,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tXC-cK-Yql">
-                    <rect key="frame" x="170" y="59" width="265" height="18"/>
+                    <rect key="frame" x="170" y="71" width="265" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enabled" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="59W-1k-G1j">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -368,7 +379,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ric-uO-1Cb">
-                    <rect key="frame" x="244" y="57" width="40" height="22"/>
+                    <rect key="frame" x="244" y="69" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" usesSingleLineMode="YES" id="Qi6-Bv-Yh1">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="gi8-52-60I">
@@ -387,7 +398,7 @@
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tGv-Wn-caL" userLabel="step size field">
-                    <rect key="frame" x="172" y="31" width="32" height="22"/>
+                    <rect key="frame" x="172" y="43" width="32" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="5" placeholderString="5" drawsBackground="YES" id="Ia5-T5-2gf">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="DNi-LX-9DG"/>
@@ -404,7 +415,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pwW-SE-wmY">
-                    <rect key="frame" x="299" y="60" width="19" height="17"/>
+                    <rect key="frame" x="299" y="97" width="19" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="Qfs-D0-k4Z">
                         <font key="font" metaFont="system"/>
@@ -413,7 +424,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oRH-MS-UAd">
-                    <rect key="frame" x="18" y="33" width="148" height="17"/>
+                    <rect key="frame" x="18" y="45" width="148" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Resize Interval:" id="nKR-ho-85Z">
                         <font key="font" metaFont="system"/>
@@ -422,7 +433,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g66-QF-Hrs">
-                    <rect key="frame" x="202" y="28" width="19" height="27"/>
+                    <rect key="frame" x="202" y="40" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="100" doubleValue="1" id="sPZ-B7-TQF"/>
                     <connections>
@@ -430,7 +441,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SGf-OP-a9f">
-                    <rect key="frame" x="218" y="33" width="15" height="17"/>
+                    <rect key="frame" x="218" y="45" width="15" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="%" id="Dpb-P9-t0R">
                         <font key="font" metaFont="system"/>
@@ -439,16 +450,16 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VsK-s4-pep">
-                    <rect key="frame" x="282" y="54" width="19" height="27"/>
+                    <rect key="frame" x="282" y="66" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="100" doubleValue="1" id="kSN-EK-HUy"/>
                     <connections>
-                        <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.window-margins" id="TKt-Pl-ye5"/>
                         <binding destination="N2H-cZ-f1m" name="value" keyPath="values.window-margin-size" id="3Yq-yI-KEa"/>
+                        <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.window-margins" id="TKt-Pl-ye5"/>
                     </connections>
                 </stepper>
             </subviews>
-            <point key="canvasLocation" x="562" y="320"/>
+            <point key="canvasLocation" x="562" y="336.5"/>
         </customView>
         <userDefaultsController id="XhK-Tn-zrU"/>
         <userDefaultsController representsSharedInstance="YES" id="N2H-cZ-f1m"/>

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -338,14 +338,6 @@ public class UserConfiguration: NSObject {
         storage.set(!animateWindows(), forKey: ConfigurationKey.AnimateWindows.rawValue)
     }
 
-    open func animateWindows() -> Bool {
-        return storage.bool(forKey: ConfigurationKey.AnimateWindows.rawValue)
-    }
-
-    open func toggleAnimateWindows() {
-        storage.set(!animateWindows(), forKey: ConfigurationKey.AnimateWindows.rawValue)
-    }
-
     open func enablesLayoutHUD() -> Bool {
         return storage.bool(forKey: ConfigurationKey.LayoutHUD.rawValue)
     }

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -36,6 +36,7 @@ internal enum ConfigurationKey: String {
     case FloatSmallWindows = "float-small-windows"
     case MouseFollowsFocus = "mouse-follows-focus"
     case FocusFollowsMouse = "focus-follows-mouse"
+    case AnimateWindows = "animate-windows"
     case LayoutHUD = "enables-layout-hud"
     case LayoutHUDOnSpaceChange = "enables-layout-hud-on-space-change"
     case UseCanaryBuild = "use-canary-build"
@@ -51,6 +52,7 @@ internal enum ConfigurationKey: String {
             .FloatSmallWindows,
             .MouseFollowsFocus,
             .FocusFollowsMouse,
+            .AnimateWindows,
             .LayoutHUD,
             .LayoutHUDOnSpaceChange,
             .UseCanaryBuild,
@@ -78,6 +80,7 @@ public enum CommandKey: String {
     case SwapMain = "swap-main"
     case ThrowSpacePrefix = "throw-space"
     case FocusScreenPrefix = "focus-screen"
+    case ToggleAnimateWindows = "toggle-animate-windows"
     case ThrowScreenPrefix = "throw-screen"
     case ThrowSpaceLeft = "throw-space-left"
     case ThrowSpaceRight = "throw-space-right"
@@ -325,6 +328,14 @@ public class UserConfiguration: NSObject {
 
     open func toggleFocusFollowsMouse() {
         storage.set(!focusFollowsMouse(), forKey: ConfigurationKey.FocusFollowsMouse.rawValue)
+    }
+    
+    open func animateWindows() -> Bool {
+        return storage.bool(forKey: ConfigurationKey.AnimateWindows.rawValue)
+    }
+    
+    open func toggleAnimateWindows() {
+        storage.set(!animateWindows(), forKey: ConfigurationKey.AnimateWindows.rawValue)
     }
 
     open func enablesLayoutHUD() -> Bool {

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
 
-gem 'cocoapods', '~> 1.1.0'
+gem 'cocoapods', '~> 1.2.0.beta.3'
 gem 'xcpretty'

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.10'
+platform :osx, '10.12'
 
 use_frameworks!
 
@@ -12,7 +12,7 @@ target 'Amethyst' do
   pod 'MASShortcut', :git => 'https://github.com/ianyh/MASShortcut'
   pod 'RxCocoa'
   pod 'RxSwift'
-  pod 'Silica', :git => 'https://github.com/ianyh/Silica'
+  pod 'Silica', :git => 'https://github.com/ianyh/Silica', :commit => 'a73415cd79ccee6e7c3dcb87ecf5d9889a6d85d2'
   pod 'SwiftyJSON'
   target 'AmethystTests' do
     inherit! :search_paths


### PR DESCRIPTION
This is a feature that adds a rough animation to the windows as they are repositioned.  This helps to keep track of where your windows are so that you don't waste time reorienting yourself after a window relayout event.

There is a check box in the preference pane which turns it on and off.

It animates whenever a reflow event occurs, so if a new window pops up, a window goes away, or a layout style shift is initiated.    

See attached video with demo.
[Terminal_ScreenShot_002.mp4.zip](https://github.com/ianyh/Amethyst/files/704492/Terminal_ScreenShot_002.mp4.zip)

I'm into it.