### PR TITLE
Animate windows clean branch

### DIFF
--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -188,6 +188,10 @@ open class HotKeyManager: NSObject {
         constructCommandWithCommandKey(CommandKey.ToggleFocusFollowsMouse.rawValue) {
             self.userConfiguration.toggleFocusFollowsMouse()
         }
+        
+        constructCommandWithCommandKey(CommandKey.ToggleAnimateWindows.rawValue) {
+            self.userConfiguration.toggleAnimateWindows()
+        }
 
         let layoutStrings: [String] = userConfiguration.layoutStrings()
         layoutStrings.forEach { layoutString in

--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -188,7 +188,7 @@ open class HotKeyManager: NSObject {
         constructCommandWithCommandKey(CommandKey.ToggleFocusFollowsMouse.rawValue) {
             self.userConfiguration.toggleFocusFollowsMouse()
         }
-        
+
         constructCommandWithCommandKey(CommandKey.ToggleAnimateWindows.rawValue) {
             self.userConfiguration.toggleAnimateWindows()
         }

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -54,64 +54,60 @@ open class ReflowOperation: Operation {
                 return
             }
         }
-
-        if UserConfiguration.shared.animateWindows() {
-            for i in stride(from:0,to:101,by:10) {
+        
+		//Set intermediate positions for the windows
+        if UserConfiguration.shared.animateWindows(){
+            let step: CGFloat = CGFloat(0.05)
+            for i in stride(from:step, to:1.0, by:step) {
                 for frameAssignment in frameAssignments {
-                    LogManager.log?.debug("Screen: \(screen.screenIdentifier()) -- Frame Assignment: \(frameAssignment)")
-                
-                    let dx = frameAssignment.frame.origin.x - frameAssignment.window.frame().origin.x
-                    let x = Float(frameAssignment.window.frame().origin.x) + (Float(i)/100.0)*Float(dx)
-                    let dy = frameAssignment.frame.origin.y - frameAssignment.window.frame().origin.y
-                    let y = Float(frameAssignment.window.frame().origin.y) + (Float(i)/100.0)*Float(dy)
-                    let dw = frameAssignment.frame.width - frameAssignment.window.frame().width
-                    let width = Float(frameAssignment.window.frame().width) + (Float(i)/100.0)*Float(dw)
-                    let dh = frameAssignment.frame.height - frameAssignment.window.frame().height
-                    let height = Float(frameAssignment.window.frame().height) + (Float(i)/100.0)*Float(dh)
-                    self.assignFrame(CGRect(x:CGFloat(x),y:CGFloat(y),width:CGFloat(width),height:CGFloat(height)), toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
-                }
-                //usleep(10000)
-            }
-            
-        }
-        else{
-            for frameAssignment in frameAssignments {
-                LogManager.log?.debug("Screen: \(screen.screenIdentifier()) -- Frame Assignment: \(frameAssignment)")
+                    LogManager.log?.debug("Intermediate Screen: \(screen.screenIdentifier()) -- Frame Assignment: \(frameAssignment)")
 
-                self.assignFrame(frameAssignment.frame,toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
+                    let dx = frameAssignment.frame.origin.x - frameAssignment.window.frame().origin.x
+                    let x = frameAssignment.window.frame().origin.x + i*dx
+                    let dy = frameAssignment.frame.origin.y - frameAssignment.window.frame().origin.y
+                    let y = frameAssignment.window.frame().origin.y + i*dy
+                    let dw = frameAssignment.frame.width - frameAssignment.window.frame().width
+                    let width = frameAssignment.window.frame().width + i*dw
+                    let dh = frameAssignment.frame.height - frameAssignment.window.frame().height
+                    let height = frameAssignment.window.frame().height + i*dh
+                    if x != frameAssignment.window.frame().origin.x ||
+                       y != frameAssignment.window.frame().origin.y ||
+                       width != frameAssignment.window.frame().width ||
+                       height != frameAssignment.window.frame().height {
+                        self.assignFrame(CGRect(x: x,
+                                                y: y,
+                                            width: width,
+                                           height: height),
+                                         toWindow: frameAssignment.window,
+									      focused: frameAssignment.focused,
+								      screenFrame: frameAssignment.screenFrame)
+                    }
+                }
             }
+        }
+
+        //Set the final position for the windows
+        for frameAssignment in frameAssignments {
+            LogManager.log?.debug("Screen: \(screen.screenIdentifier()) -- Frame Assignment: \(frameAssignment)")
+
+            self.assignFrame(frameAssignment.frame,toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
         }
     }
 
     fileprivate func assignFrame(_ frame: CGRect, toWindow window: SIWindow, focused: Bool, screenFrame: CGRect) {
         var padding = UserConfiguration.shared.windowMarginSize()
-        var finalFrame = frame
+        var correctedFrame = frame
 
-        if UserConfiguration.shared.windowMargins() {
+        //If there is padding to do....
+        if UserConfiguration.shared.windowMargins() && padding > CGFloat(0.0) {
             padding = floor(padding / 2)
 
-            finalFrame.origin.x += padding
-            finalFrame.origin.y += padding
-            finalFrame.size.width -= 2 * padding
-            finalFrame.size.height -= 2 * padding
+            correctedFrame.origin.x += padding
+            correctedFrame.origin.y += padding
+            correctedFrame.size.width -= 2 * padding
+            correctedFrame.size.height -= 2 * padding
+            
         }
-
-        var finalPosition = finalFrame.origin
-
-        // Just resize the window
-        finalFrame.origin = window.frame().origin
-        window.setFrame(finalFrame)
-
-        if focused {
-            finalFrame.size = CGSize(width: max(window.frame().size.width, finalFrame.size.width), height: max(window.frame().size.height, finalFrame.size.height))
-            if !screenFrame.contains(finalFrame) {
-                finalPosition.x = min(finalPosition.x, screenFrame.maxX - finalFrame.size.width)
-                finalPosition.y = min(finalPosition.y, screenFrame.maxY - finalFrame.size.height)
-            }
-        }
-
-        // Move the window to its final frame
-        finalFrame.origin = finalPosition
-        window.setFrame(finalFrame)
+        window.setFrame(correctedFrame)
     }
 }

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -54,9 +54,9 @@ open class ReflowOperation: Operation {
                 return
             }
         }
-        
+
 		//Set intermediate positions for the windows
-        if UserConfiguration.shared.animateWindows(){
+        if UserConfiguration.shared.animateWindows() {
             let step: CGFloat = CGFloat(0.05)
             for i in stride(from:step, to:1.0, by:step) {
                 for frameAssignment in frameAssignments {
@@ -106,7 +106,6 @@ open class ReflowOperation: Operation {
             correctedFrame.origin.y += padding
             correctedFrame.size.width -= 2 * padding
             correctedFrame.size.height -= 2 * padding
-            
         }
         window.setFrame(correctedFrame)
     }

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -90,7 +90,7 @@ open class ReflowOperation: Operation {
         for frameAssignment in frameAssignments {
             LogManager.log?.debug("Screen: \(screen.screenIdentifier()) -- Frame Assignment: \(frameAssignment)")
 
-            self.assignFrame(frameAssignment.frame,toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
+            self.assignFrame(frameAssignment.frame, toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
         }
     }
 

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -55,10 +55,31 @@ open class ReflowOperation: Operation {
             }
         }
 
-        for frameAssignment in frameAssignments {
-            LogManager.log?.debug("Screen: \(screen.screenIdentifier()) -- Frame Assignment: \(frameAssignment)")
+        if UserConfiguration.shared.animateWindows() {
+            for i in stride(from:0,to:101,by:10) {
+                for frameAssignment in frameAssignments {
+                    LogManager.log?.debug("Screen: \(screen.screenIdentifier()) -- Frame Assignment: \(frameAssignment)")
+                
+                    let dx = frameAssignment.frame.origin.x - frameAssignment.window.frame().origin.x
+                    let x = Float(frameAssignment.window.frame().origin.x) + (Float(i)/100.0)*Float(dx)
+                    let dy = frameAssignment.frame.origin.y - frameAssignment.window.frame().origin.y
+                    let y = Float(frameAssignment.window.frame().origin.y) + (Float(i)/100.0)*Float(dy)
+                    let dw = frameAssignment.frame.width - frameAssignment.window.frame().width
+                    let width = Float(frameAssignment.window.frame().width) + (Float(i)/100.0)*Float(dw)
+                    let dh = frameAssignment.frame.height - frameAssignment.window.frame().height
+                    let height = Float(frameAssignment.window.frame().height) + (Float(i)/100.0)*Float(dh)
+                    self.assignFrame(CGRect(x:CGFloat(x),y:CGFloat(y),width:CGFloat(width),height:CGFloat(height)), toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
+                }
+                //usleep(10000)
+            }
+            
+        }
+        else{
+            for frameAssignment in frameAssignments {
+                LogManager.log?.debug("Screen: \(screen.screenIdentifier()) -- Frame Assignment: \(frameAssignment)")
 
-            self.assignFrame(frameAssignment.frame, toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
+                self.assignFrame(frameAssignment.frame,toWindow: frameAssignment.window, focused: frameAssignment.focused, screenFrame: frameAssignment.screenFrame)
+            }
         }
     }
 

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -39,6 +39,9 @@ open class ScreenManager: NSObject {
 
             changingSpace = true
             currentLayoutIndex = currentLayoutIndexBySpaceIdentifier[spaceIdentifier] ?? 0
+            if(currentLayoutIndex >= layouts.count){
+                currentLayoutIndex = 0
+            }
 
             if let layouts = layoutsBySpaceIdentifier[spaceIdentifier] {
                 self.layouts = layouts
@@ -135,7 +138,7 @@ open class ScreenManager: NSObject {
     }
 
     open func cycleLayoutBackward() {
-        currentLayoutIndex = (currentLayoutIndex == 0 ? layouts.count : currentLayoutIndex) - 1
+        currentLayoutIndex = (currentLayoutIndex - 1) % layouts.count
         setNeedsReflowWithWindowChange(.unknown)
     }
 
@@ -145,8 +148,13 @@ open class ScreenManager: NSObject {
             return
         }
 
-        currentLayoutIndex = layoutIndex
-        setNeedsReflowWithWindowChange(.unknown)
+        if((layoutIndex < 0 ) || (layoutIndex >= layouts.count)){
+            return
+        }
+        else{
+            currentLayoutIndex = layoutIndex
+            setNeedsReflowWithWindowChange(.unknown)
+        }
     }
 
     open func shrinkMainPane() {

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -39,7 +39,7 @@ open class ScreenManager: NSObject {
 
             changingSpace = true
             currentLayoutIndex = currentLayoutIndexBySpaceIdentifier[spaceIdentifier] ?? 0
-            if(currentLayoutIndex >= layouts.count){
+            if currentLayoutIndex >= layouts.count {
                 currentLayoutIndex = 0
             }
 
@@ -148,10 +148,10 @@ open class ScreenManager: NSObject {
             return
         }
 
-        if((layoutIndex < 0 ) || (layoutIndex >= layouts.count)){
+        if (layoutIndex < 0 ) || (layoutIndex >= layouts.count) {
             return
         }
-        else{
+        else {
             currentLayoutIndex = layoutIndex
             setNeedsReflowWithWindowChange(.unknown)
         }

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,11 +16,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="LsO-9M-hEw" userLabel="General Preferences">
-            <rect key="frame" x="0.0" y="0.0" width="468" height="593"/>
+            <rect key="frame" x="0.0" y="0.0" width="468" height="627"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9hq-U6-t9B">
-                    <rect key="frame" x="170" y="422" width="148" height="18"/>
+                    <rect key="frame" x="170" y="456" width="148" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Float small windows" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="phj-M8-HfQ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -31,7 +31,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jbq-77-1YW">
-                    <rect key="frame" x="170" y="314" width="142" height="18"/>
+                    <rect key="frame" x="170" y="348" width="142" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable Layout HUD" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="UVr-KG-wFB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -42,7 +42,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ej5-FV-H6Q">
-                    <rect key="frame" x="170" y="294" width="255" height="18"/>
+                    <rect key="frame" x="170" y="328" width="255" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable Layout HUD on Space Change" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="o6e-e0-t64">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -53,7 +53,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wg4-Ew-VOi">
-                    <rect key="frame" x="107" y="423" width="59" height="17"/>
+                    <rect key="frame" x="107" y="457" width="59" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Floating:" id="H0k-aA-syT">
                         <font key="font" metaFont="system"/>
@@ -62,7 +62,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MKd-ZG-j26">
-                    <rect key="frame" x="83" y="315" width="83" height="17"/>
+                    <rect key="frame" x="83" y="349" width="83" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Layout HUD:" id="dFS-Je-lML">
                         <font key="font" metaFont="system"/>
@@ -71,7 +71,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G9A-P1-Ks1">
-                    <rect key="frame" x="126" y="271" width="40" height="17"/>
+                    <rect key="frame" x="126" y="305" width="40" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Misc.:" id="SoK-X5-vwJ">
                         <font key="font" metaFont="system"/>
@@ -80,7 +80,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pGc-zn-uC7">
-                    <rect key="frame" x="170" y="270" width="133" height="18"/>
+                    <rect key="frame" x="170" y="304" width="133" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Ignore menu bars" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="LKn-n5-1ay">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -91,7 +91,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Eb-EJ-evb">
-                    <rect key="frame" x="170" y="250" width="223" height="18"/>
+                    <rect key="frame" x="170" y="284" width="223" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Mouse follows focused windows" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="6fy-Pu-AhI">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -102,7 +102,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xay-gW-zGw">
-                    <rect key="frame" x="170" y="230" width="223" height="18"/>
+                    <rect key="frame" x="170" y="264" width="223" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Send new windows to main pane" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="stG-cM-1bg">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -112,8 +112,19 @@
                         <binding destination="XhK-Tn-zrU" name="value" keyPath="values.new-windows-to-main" id="c0g-Ta-qOE"/>
                     </connections>
                 </button>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ghe-m0-qa1">
+                    <rect key="frame" x="170" y="244" width="223" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Animate window movements" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Hrg-1b-i2Y">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="value" keyPath="values.animate-windows" id="0HI-vC-meB"/>
+                    </connections>
+                </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mtD-Sc-koj">
-                    <rect key="frame" x="170" y="210" width="243" height="18"/>
+                    <rect key="frame" x="170" y="222" width="243" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Focus follows mouse" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="u5m-jH-xzU">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -124,7 +135,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vRo-Ax-vKh">
-                    <rect key="frame" x="170" y="155" width="280" height="18"/>
+                    <rect key="frame" x="170" y="167" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Get development builds" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="5v8-xo-EWM">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -135,7 +146,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MGP-cm-WTe">
-                    <rect key="frame" x="170" y="115" width="280" height="18"/>
+                    <rect key="frame" x="170" y="127" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable crash reporting" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="T33-wB-9cH">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -146,7 +157,7 @@
                     </connections>
                 </button>
                 <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U6O-Ka-pXq">
-                    <rect key="frame" x="172" y="360" width="251" height="56"/>
+                    <rect key="frame" x="172" y="394" width="251" height="56"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" ambiguous="YES" id="RT8-fN-JDO">
                         <rect key="frame" x="1" y="1" width="249" height="54"/>
@@ -181,16 +192,16 @@
                         </subviews>
                     </clipView>
                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="IwH-cx-YkX">
-                        <rect key="frame" x="1" y="-15" width="0.0" height="16"/>
+                        <rect key="frame" x="-7" y="-14" width="0.0" height="15"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="eCG-Tq-r9K">
-                        <rect key="frame" x="-15" y="1" width="16" height="0.0"/>
+                        <rect key="frame" x="-14" y="-7" width="15" height="0.0"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZH0-nz-Yiv">
-                    <rect key="frame" x="172" y="339" width="27" height="23"/>
+                    <rect key="frame" x="172" y="373" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ok9-1r-DwF">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -201,7 +212,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cfp-8K-Cdt">
-                    <rect key="frame" x="198" y="339" width="27" height="23"/>
+                    <rect key="frame" x="198" y="373" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Xif-lH-IK0">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -212,7 +223,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c03-Jd-KsK">
-                    <rect key="frame" x="223" y="339" width="200" height="23"/>
+                    <rect key="frame" x="223" y="373" width="200" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="w8y-WB-Ax2">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -220,7 +231,7 @@
                     </buttonCell>
                 </button>
                 <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kgh-Mo-aGF">
-                    <rect key="frame" x="172" y="488" width="251" height="85"/>
+                    <rect key="frame" x="172" y="522" width="251" height="85"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" ambiguous="YES" id="NPi-lT-8Xb">
                         <rect key="frame" x="1" y="1" width="249" height="83"/>
@@ -255,16 +266,16 @@
                         </subviews>
                     </clipView>
                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="ldJ-I2-SGG">
-                        <rect key="frame" x="1" y="-15" width="0.0" height="16"/>
+                        <rect key="frame" x="-7" y="-14" width="0.0" height="15"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="URc-2W-nZo">
-                        <rect key="frame" x="-15" y="1" width="16" height="0.0"/>
+                        <rect key="frame" x="-14" y="-7" width="15" height="0.0"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AUR-i7-d99">
-                    <rect key="frame" x="172" y="467" width="27" height="23"/>
+                    <rect key="frame" x="172" y="501" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="v7u-4j-Gv9">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -275,7 +286,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="khH-XV-GhW">
-                    <rect key="frame" x="198" y="467" width="27" height="23"/>
+                    <rect key="frame" x="198" y="501" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="pcN-ET-p91">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -286,7 +297,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="A8V-CN-miB">
-                    <rect key="frame" x="223" y="467" width="200" height="23"/>
+                    <rect key="frame" x="223" y="501" width="200" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="8al-n7-kkn">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -294,7 +305,7 @@
                     </buttonCell>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M7e-Dw-sVZ">
-                    <rect key="frame" x="110" y="556" width="56" height="17"/>
+                    <rect key="frame" x="110" y="590" width="56" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Layouts:" id="tof-Wx-pYR">
                         <font key="font" metaFont="system"/>
@@ -303,7 +314,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fBD-ab-yJQ">
-                    <rect key="frame" x="170" y="139" width="280" height="15"/>
+                    <rect key="frame" x="170" y="151" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must restart for changes to take effect" id="Cak-aF-OC2">
                         <font key="font" metaFont="smallSystem"/>
@@ -312,7 +323,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4eN-rj-3bX">
-                    <rect key="frame" x="170" y="448" width="280" height="15"/>
+                    <rect key="frame" x="170" y="482" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must restart for changes to take effect" id="jJZ-0G-DUC">
                         <font key="font" metaFont="smallSystem"/>
@@ -321,7 +332,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e6w-YL-rzU">
-                    <rect key="frame" x="170" y="181" width="280" height="28"/>
+                    <rect key="frame" x="170" y="193" width="280" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="This feature is still experimental and may be unstable or have unexpected behavior" id="em1-tY-3zU">
                         <font key="font" metaFont="smallSystem"/>
@@ -330,7 +341,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ryf-WE-u7b">
-                    <rect key="frame" x="170" y="86" width="280" height="28"/>
+                    <rect key="frame" x="170" y="98" width="280" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Enabling this also sends some anonymous analytics" id="DiA-Hm-lgJ">
                         <font key="font" metaFont="smallSystem"/>
@@ -339,7 +350,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="l9P-32-7UB">
-                    <rect key="frame" x="170" y="85" width="280" height="15"/>
+                    <rect key="frame" x="170" y="97" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must restart for changes to take effect" id="2us-TJ-7M2">
                         <font key="font" metaFont="smallSystem"/>
@@ -348,7 +359,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="luh-Gm-ZV0">
-                    <rect key="frame" x="57" y="60" width="109" height="17"/>
+                    <rect key="frame" x="57" y="72" width="109" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Margins:" id="LnD-6G-RSL">
                         <font key="font" metaFont="system"/>
@@ -357,7 +368,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tXC-cK-Yql">
-                    <rect key="frame" x="170" y="59" width="265" height="18"/>
+                    <rect key="frame" x="170" y="71" width="265" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enabled" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="59W-1k-G1j">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -368,7 +379,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ric-uO-1Cb">
-                    <rect key="frame" x="244" y="57" width="40" height="22"/>
+                    <rect key="frame" x="244" y="69" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" usesSingleLineMode="YES" id="Qi6-Bv-Yh1">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="gi8-52-60I">
@@ -387,7 +398,7 @@
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tGv-Wn-caL" userLabel="step size field">
-                    <rect key="frame" x="172" y="31" width="32" height="22"/>
+                    <rect key="frame" x="172" y="43" width="32" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="5" placeholderString="5" drawsBackground="YES" id="Ia5-T5-2gf">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="DNi-LX-9DG"/>
@@ -404,7 +415,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pwW-SE-wmY">
-                    <rect key="frame" x="299" y="60" width="19" height="17"/>
+                    <rect key="frame" x="299" y="97" width="19" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="Qfs-D0-k4Z">
                         <font key="font" metaFont="system"/>
@@ -413,7 +424,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oRH-MS-UAd">
-                    <rect key="frame" x="18" y="33" width="148" height="17"/>
+                    <rect key="frame" x="18" y="45" width="148" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Resize Interval:" id="nKR-ho-85Z">
                         <font key="font" metaFont="system"/>
@@ -422,7 +433,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g66-QF-Hrs">
-                    <rect key="frame" x="202" y="28" width="19" height="27"/>
+                    <rect key="frame" x="202" y="40" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="100" doubleValue="1" id="sPZ-B7-TQF"/>
                     <connections>
@@ -430,7 +441,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SGf-OP-a9f">
-                    <rect key="frame" x="218" y="33" width="15" height="17"/>
+                    <rect key="frame" x="218" y="45" width="15" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="%" id="Dpb-P9-t0R">
                         <font key="font" metaFont="system"/>
@@ -439,16 +450,16 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VsK-s4-pep">
-                    <rect key="frame" x="282" y="54" width="19" height="27"/>
+                    <rect key="frame" x="282" y="66" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="100" doubleValue="1" id="kSN-EK-HUy"/>
                     <connections>
-                        <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.window-margins" id="TKt-Pl-ye5"/>
                         <binding destination="N2H-cZ-f1m" name="value" keyPath="values.window-margin-size" id="3Yq-yI-KEa"/>
+                        <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.window-margins" id="TKt-Pl-ye5"/>
                     </connections>
                 </stepper>
             </subviews>
-            <point key="canvasLocation" x="562" y="320"/>
+            <point key="canvasLocation" x="562" y="336.5"/>
         </customView>
         <userDefaultsController id="XhK-Tn-zrU"/>
         <userDefaultsController representsSharedInstance="YES" id="N2H-cZ-f1m"/>

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -36,6 +36,7 @@ internal enum ConfigurationKey: String {
     case FloatSmallWindows = "float-small-windows"
     case MouseFollowsFocus = "mouse-follows-focus"
     case FocusFollowsMouse = "focus-follows-mouse"
+    case AnimateWindows = "animate-windows"
     case LayoutHUD = "enables-layout-hud"
     case LayoutHUDOnSpaceChange = "enables-layout-hud-on-space-change"
     case UseCanaryBuild = "use-canary-build"
@@ -51,6 +52,7 @@ internal enum ConfigurationKey: String {
             .FloatSmallWindows,
             .MouseFollowsFocus,
             .FocusFollowsMouse,
+            .AnimateWindows,
             .LayoutHUD,
             .LayoutHUDOnSpaceChange,
             .UseCanaryBuild,
@@ -78,6 +80,7 @@ public enum CommandKey: String {
     case SwapMain = "swap-main"
     case ThrowSpacePrefix = "throw-space"
     case FocusScreenPrefix = "focus-screen"
+    case ToggleAnimateWindows = "toggle-animate-windows"
     case ThrowScreenPrefix = "throw-screen"
     case ThrowSpaceLeft = "throw-space-left"
     case ThrowSpaceRight = "throw-space-right"
@@ -325,6 +328,14 @@ public class UserConfiguration: NSObject {
 
     open func toggleFocusFollowsMouse() {
         storage.set(!focusFollowsMouse(), forKey: ConfigurationKey.FocusFollowsMouse.rawValue)
+    }
+    
+    open func animateWindows() -> Bool {
+        return storage.bool(forKey: ConfigurationKey.AnimateWindows.rawValue)
+    }
+    
+    open func toggleAnimateWindows() {
+        storage.set(!animateWindows(), forKey: ConfigurationKey.AnimateWindows.rawValue)
     }
 
     open func enablesLayoutHUD() -> Bool {

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -329,11 +329,11 @@ public class UserConfiguration: NSObject {
     open func toggleFocusFollowsMouse() {
         storage.set(!focusFollowsMouse(), forKey: ConfigurationKey.FocusFollowsMouse.rawValue)
     }
-    
+
     open func animateWindows() -> Bool {
         return storage.bool(forKey: ConfigurationKey.AnimateWindows.rawValue)
     }
-    
+
     open func toggleAnimateWindows() {
         storage.set(!animateWindows(), forKey: ConfigurationKey.AnimateWindows.rawValue)
     }

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
 
-gem 'cocoapods', '~> 1.1.0'
+gem 'cocoapods', '~> 1.2.0.beta.3'
 gem 'xcpretty'

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.10'
+platform :osx, '10.12'
 
 use_frameworks!
 
@@ -12,7 +12,7 @@ target 'Amethyst' do
   pod 'MASShortcut', :git => 'https://github.com/ianyh/MASShortcut'
   pod 'RxCocoa'
   pod 'RxSwift'
-  pod 'Silica', :git => 'https://github.com/ianyh/Silica'
+  pod 'Silica', :git => 'https://github.com/ianyh/Silica', :commit => 'a73415cd79ccee6e7c3dcb87ecf5d9889a6d85d2'
   pod 'SwiftyJSON'
   target 'AmethystTests' do
     inherit! :search_paths


### PR DESCRIPTION
This is a feature that adds a rough animation to the windows as they are repositioned.  This helps to keep track of where your windows are so that you don't waste time reorienting yourself after a window relayout event.

There is a check box in the preference pane which turns it on and off.

It animates whenever a reflow event occurs, so if a new window pops up, a window goes away, or a layout style shift is initiated.    

See attached video with demo.
[Terminal_ScreenShot_002.mp4.zip](https://github.com/ianyh/Amethyst/files/704492/Terminal_ScreenShot_002.mp4.zip)

I'm into it.


[Trello Card](https://trello.com/c/ZuLGfnYU/253-amethyst-animate-windows-clean-branch)