### PR TITLE
Update README to include mention of Spaces auto-rearrangement

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ of the Keyboard preferences pane. The shortcuts will be of the form `ctrl +
 
 ![Mission Control keyboard shortcuts](http://ianyh.com/amethyst/images/missioncontrol-shortcuts.png)
 
+_Important note_: You will probably want to disable `Automatically rearrange Spaces based on most recent use` (found under Mission Control in System Preferences). This setting is enabled by default, and will cause your Spaces to swap places based on use. This makes keyboard navigation between Spaces unpredictable.
+
 Contributing
 ============
 


### PR DESCRIPTION
I imagine this has bit more people than just myself, but I thought I was going crazy with my Spaces periodically not being where I expected them to be when I hit the `ctrl-[n]` hotkeys. I searched issues, read the README, and finally ended up just googling around before I found out that this is just a setting in Mission Control.  Seemed like it was worth explicitly calling out in the README.