### PR TITLE
Revert the change to automatically focus top app on last window close

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -330,11 +330,6 @@ final class WindowManager: NSObject {
 
         regenerateActiveIDCache()
 
-        application?.dropWindowsCache()
-        if let applicationWindows = application?.visibleWindows(), applicationWindows.isEmpty {
-            focusScreen(at: 0)
-        }
-
         guard let windowIndex = windows.index(of: window) else {
             return
         }


### PR DESCRIPTION
Had an interesting report from a user who relied on the macOS behavior. Commands now respond correctly in this situation so it is still strictly improved.