### PR TITLE
Adds hotkey support for 10th space

### DIFF
--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -154,7 +154,7 @@ final class HotKeyManager: NSObject {
             }
         }
 
-        (1..<10).forEach { spaceNumber in
+        (1...10).forEach { spaceNumber in
             let commandKey = "\(CommandKey.throwSpacePrefix.rawValue)-\(spaceNumber)"
 
             self.constructCommandWithCommandKey(commandKey) {
@@ -323,8 +323,9 @@ final class HotKeyManager: NSObject {
         hotKeyNameToDefaultsKey.append(["Swap focused window with main window", CommandKey.swapMain.rawValue])
         hotKeyNameToDefaultsKey.append(["Force windows to be reevaluated", CommandKey.reevaluateWindows.rawValue])
 
-        (1..<10).forEach { spaceNumber in
+        (1...10).forEach { spaceNumber in
             let name = "Throw focused window to space \(spaceNumber)"
+
             hotKeyNameToDefaultsKey.append([name, "\(CommandKey.throwSpacePrefix.rawValue)-\(spaceNumber)"])
         }
 

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -157,6 +157,10 @@
         "mod": "mod2",
         "key": "9"
     },
+    "throw-space-10": {
+        "mod": "mod2",
+        "key": "0"
+    },
     "throw-space-left": {
         "mod": "mod2",
         "key": "left"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ of the Keyboard preferences pane. The shortcuts will be of the form `ctrl +
 
 ![Mission Control keyboard shortcuts](http://ianyh.com/amethyst/images/missioncontrol-shortcuts.png)
 
+Amethyst currently supports sending windows to up to 10 spaces, despite macOS' limit of 16 spaces per display.
+
 _Important note_: You will probably want to disable `Automatically rearrange Spaces based on most recent use` (found under Mission Control in System Preferences). This setting is enabled by default, and will cause your Spaces to swap places based on use. This makes keyboard navigation between Spaces unpredictable.
 
 Contributing


### PR DESCRIPTION
Closes #594.

Not the prettiest solution, as it mucks up the simple way of setting up the hotkeys from spaces 1-9. Open to suggestions on how to better map the `0` key to send `throw-space-10`.

### Observations
* Couldn't keep the loop simple using `0..<10` since it messes up the order of hotkey in the app's preferences, or without messing with `WindowModifier`. Figured it better to remap in `HotKeyManager` if we had to do it at all.