### PR TITLE
Fix dead Trans*H4CK link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,5 +124,5 @@ And a bunch of technology-oriented ones:
 * [National Center for Women & Information Technology](https://www.ncwit.org/donate)
 * [girls who code](http://girlswhocode.com/get-involved/)
 * [MotherCoders](https://www.indiegogo.com/projects/mothercoders-a-giant-hack-for-moms-who-want-in)
-* [Trans*H4CK](http://www.transhack.org/support/)
+* [Trans*H4CK](http://www.transhack.org/donate/)
 * [Black Girls CODE](http://www.blackgirlscode.com/)


### PR DESCRIPTION
Wasn't sure whether the homepage or donation page would be better, but I figure the donation page is more similar to the support page linked prior.