### PR TITLE
Update setup script

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -30,7 +30,7 @@ else
     if [ $ACTUAL = $EXPECTED ] ; then
 	printf "Correct ruby version is already installed, without rbenv\n"
     else
-	printf "WARNING: You have ruby $ACTUAL, we want ruby $EXPECTED, and and rbenv is not installed.\n"
+	printf "WARNING: You have ruby $ACTUAL, we want ruby $EXPECTED, and rbenv is not installed.\n"
 	printf "If you encounter setup problems, Try running:\n\tbrew install rbenv\n"
     fi
 fi

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
-# Check for Carthage
-printf "Checking for Carthage: "
-carthage version >/dev/null 2>&1 || { printf >&2 "nope!\nCarthage must be installed. Try running:\n\tbrew install carthage\n"; exit 1; }
-printf "found!\n"
+# Check Xcode version (TODO: semver)
+OUR_XCODE=9.0
+printf "Checking if xcode-select points to the Xcode version we use ($OUR_XCODE): "
+if [ `xcodebuild -version | grep Xcode | awk '{print $2}'` = $OUR_XCODE ] ; then
+    printf "found!\n"
+else
+    printf "nope!\n"
+    printf "WARNING: Xcode $OUR_XCODE is used to develop this project.\n"
+fi
 
 # Check for swiftlint
 printf "Checking for swiftlint: "
@@ -12,11 +17,23 @@ printf "found!\n"
 
 # Check for installed ruby version
 printf "Checking for rbenv: "
-rbenv version >/dev/null 2>&1 || { printf >&2 "nope!\nrbenv must be installed. Try running:\n\tbrew install rbenv\n"; exit 1; }
-printf "found!\n"
-printf "Ensuring correct ruby version is installed:\n"
-rbenv install -s
-printf "Correct ruby version installed!\n"
+if rbenv version >/dev/null 2>&1 ; then
+    printf "found!\n"
+    printf "Ensuring correct ruby version is installed:\n"
+    rbenv install -s
+    printf "Correct ruby version installed!\n"
+
+else
+    printf "nope!\n"
+    ACTUAL=`ruby -v | awk '{print $2}' | awk -Fp '{print $1}' | tr -d '\n'`
+    EXPECTED=`cat .ruby-version | tr -d '\n'`
+    if [ $ACTUAL = $EXPECTED ] ; then
+	printf "Correct ruby version is already installed, without rbenv\n"
+    else
+	printf "WARNING: You have ruby $ACTUAL, we want ruby $EXPECTED, and and rbenv is not installed.\n"
+	printf "If you encounter setup problems, Try running:\n\tbrew install rbenv\n"
+    fi
+fi
 
 # Install CocoaPods via bundler
 printf "Checking for bundler: "
@@ -28,9 +45,5 @@ bundle exec pod --version >/dev/null 2>&1 || { echo >&2 "CocoaPods failed to ins
 # Install pods
 printf "Installing Pods:\n"
 bundle exec pod install
-
-# Build Carthage dependencies
-printf "Building Carthage frameworks:\n"
-carthage bootstrap --platform mac --cache-builds
 
 printf "\n\nDone! Now you can open Amethyst.xcworkspace and build\n"


### PR DESCRIPTION
* Carthage isn't used, so don't check for it
* Xcode 9 is required, so print a warning if it's not `xcode-select`ed
* Relax the check on `rbenv` to just a warning if it doesn't exist

I relaxed the check on `rbenv` because it works on my machine without installing `rbenv`.  It looks like the only real purpose of rbenv is to install bundler, and the only real purpose of bundler is to install Cocoapods.  So if the correct version of Cocoapods is available, then the other steps are (in my opinion) somewhat optional.  