### PR TITLE
Move and Resize Windows Using The Mouse

### DIFF
--- a/Amethyst/Categories/NSScreen+Amethyst.swift
+++ b/Amethyst/Categories/NSScreen+Amethyst.swift
@@ -22,6 +22,9 @@ extension NSScreen {
         return screenDescriptions.map { JSON($0) }
     }
 
+    // Depending on the arrangement of multiple monitors, it's possible to get a height that's larger
+    // than any of the individual screens.  This function looks at each display frame's Y coordinates
+    // to calculate that height
     static func globalHeight() -> CGFloat {
         return (screens.map { $0.frame.maxY }.max() ?? 0) - (screens.map { $0.frame.minY }.min() ?? 0)
     }

--- a/Amethyst/Categories/NSScreen+Amethyst.swift
+++ b/Amethyst/Categories/NSScreen+Amethyst.swift
@@ -23,7 +23,7 @@ extension NSScreen {
     }
 
     static func globalHeight() -> CGFloat {
-        return screens.map { $0.frame.maxY }.max()! - screens.map { $0.frame.minY }.min()!
+        return (screens.map { $0.frame.maxY }.max() ?? 0) - (screens.map { $0.frame.minY }.min() ?? 0)
     }
 
     func screenIdentifier() -> String? {

--- a/Amethyst/Categories/NSScreen+Amethyst.swift
+++ b/Amethyst/Categories/NSScreen+Amethyst.swift
@@ -22,6 +22,10 @@ extension NSScreen {
         return screenDescriptions.map { JSON($0) }
     }
 
+    static func globalHeight() -> CGFloat {
+        return screens.map {$0.frame.origin.y + $0.frame.height}.max()!
+    }
+
     func screenIdentifier() -> String? {
         guard let managedDisplay = CGSCopyBestManagedDisplayForRect(_CGSDefaultConnection(), frameIncludingDockAndMenu()) else {
             return nil

--- a/Amethyst/Categories/NSScreen+Amethyst.swift
+++ b/Amethyst/Categories/NSScreen+Amethyst.swift
@@ -23,7 +23,7 @@ extension NSScreen {
     }
 
     static func globalHeight() -> CGFloat {
-        return screens.map {$0.frame.origin.y + $0.frame.height}.max()!
+        return screens.map { $0.frame.maxY }.max()! - screens.map { $0.frame.minY }.min()!
     }
 
     func screenIdentifier() -> String? {

--- a/Amethyst/Categories/SIWindow+Amethyst.swift
+++ b/Amethyst/Categories/SIWindow+Amethyst.swift
@@ -45,12 +45,12 @@ extension SIWindow {
     }
 
     static func topWindowForScreenAtPoint(_ point: CGPoint, withWindows windows: [SIWindow]) -> SIWindow? {
-        let info = windowInformation(windows)
-        guard let windowDescriptions = info.descriptions, !windowDescriptions.isEmpty else {
+        let (ids, maybeWindowDescriptions) = windowInformation(windows)
+        guard let windowDescriptions = maybeWindowDescriptions, !windowDescriptions.isEmpty else {
             return nil
         }
 
-        let windowsAtPoint = onScreenWindowsAtPoint(point, withIDs: info.IDs, withDescriptions: windowDescriptions)
+        let windowsAtPoint = onScreenWindowsAtPoint(point, withIDs: ids, withDescriptions: windowDescriptions)
 
         guard !windowsAtPoint.isEmpty else {
             return nil
@@ -86,20 +86,18 @@ extension SIWindow {
 
     static func alternateWindowForScreenAtPoint(_ point: CGPoint, withWindows windows: [SIWindow], butNot ignoreWindow: SIWindow?) -> SIWindow? {
         // only consider windows on this screen
-        let info = windowInformation(windows)
-        guard let windowDescriptions = info.descriptions, !windowDescriptions.isEmpty else {
+        let (ids, maybeWindowDescriptions) = windowInformation(windows)
+        guard let windowDescriptions = maybeWindowDescriptions, !windowDescriptions.isEmpty else {
             return nil
         }
 
-        let windowsAtPoint = onScreenWindowsAtPoint(point, withIDs: info.IDs, withDescriptions: windowDescriptions)
+        let windowsAtPoint = onScreenWindowsAtPoint(point, withIDs: ids, withDescriptions: windowDescriptions)
 
         for windowDescription in windowsAtPoint {
             if let window = windowInWindows(windows, withCGWindowDescription: windowDescription) {
                 if window != ignoreWindow {
                     return window
                 }
-            } else {
-                print("Couldn't get window \(windowDescription["kCGWindowName"])")
             }
         }
 

--- a/Amethyst/Categories/SIWindow+Amethyst.swift
+++ b/Amethyst/Categories/SIWindow+Amethyst.swift
@@ -46,13 +46,13 @@ extension SIWindow {
 
     static func topWindowForScreenAtPoint(_ point: CGPoint, withWindows windows: [SIWindow]) -> SIWindow? {
         let info = windowInformation(windows)
-        guard let windowDescriptions = info.descriptions, windowDescriptions.count > 0 else {
+        guard let windowDescriptions = info.descriptions, !windowDescriptions.isEmpty else {
             return nil
         }
 
         let windowsAtPoint = onScreenWindowsAtPoint(point, withIDs: info.IDs, withDescriptions: windowDescriptions)
 
-        guard windowsAtPoint.count > 0 else {
+        guard !windowsAtPoint.isEmpty else {
             return nil
         }
 
@@ -87,7 +87,7 @@ extension SIWindow {
     static func alternateWindowForScreenAtPoint(_ point: CGPoint, withWindows windows: [SIWindow], butNot ignoreWindow: SIWindow?) -> SIWindow? {
         // only consider windows on this screen
         let info = windowInformation(windows)
-        guard let windowDescriptions = info.descriptions, windowDescriptions.count > 0 else {
+        guard let windowDescriptions = info.descriptions, !windowDescriptions.isEmpty else {
             return nil
         }
 

--- a/Amethyst/Categories/SIWindow+Amethyst.swift
+++ b/Amethyst/Categories/SIWindow+Amethyst.swift
@@ -84,7 +84,7 @@ extension SIWindow {
         return windowInWindows(windows, withCGWindowDescription: windowDictionaryToFocus)
     }
 
-    static func secondWindowForScreenAtPoint(_ point: CGPoint, withWindows windows: [SIWindow]) -> SIWindow? {
+    static func alternateWindowForScreenAtPoint(_ point: CGPoint, withWindows windows: [SIWindow], butNot ignoreWindow: SIWindow?) -> SIWindow? {
         // only consider windows on this screen
         let info = windowInformation(windows)
         guard let windowDescriptions = info.descriptions, windowDescriptions.count > 0 else {
@@ -93,16 +93,17 @@ extension SIWindow {
 
         let windowsAtPoint = onScreenWindowsAtPoint(point, withIDs: info.IDs, withDescriptions: windowDescriptions)
 
-        // early exit for no 2 windows found
-        guard windowsAtPoint.count > 1 else {
-            return nil
+        for windowDescription in windowsAtPoint {
+            if let window = windowInWindows(windows, withCGWindowDescription: windowDescription) {
+                if window != ignoreWindow {
+                    return window
+                }
+            } else {
+                print("Couldn't get window \(windowDescription["kCGWindowName"])")
+            }
         }
 
-        // it's the one under the one we're dragging
-        guard let ret = windowInWindows(windows, withCGWindowDescription: windowsAtPoint[1]) else {
-            return nil
-        }
-        return ret
+        return nil
     }
 
     static func windowInWindows(_ windows: [SIWindow], withCGWindowDescription windowDescription: [String: AnyObject]) -> SIWindow? {

--- a/Amethyst/Categories/SIWindow+Amethyst.swift
+++ b/Amethyst/Categories/SIWindow+Amethyst.swift
@@ -11,6 +11,8 @@ import Foundation
 import Silica
 
 extension SIWindow {
+    // convert SIWindow objects to CGWindowIDs.
+    // additionally, return the full set of window descriptions (which is unsorted and may contain extra windows)
     fileprivate static func windowInformation(_ windows: [SIWindow]) -> (IDs: Set<CGWindowID>, descriptions: [[String: AnyObject]]?) {
         let ids = Set(windows.map { $0.windowID() })
         return (IDs: ids, descriptions: windowDescriptions(.optionOnScreenOnly, windowID: CGWindowID(0)))
@@ -44,6 +46,7 @@ extension SIWindow {
         return ret
     }
 
+    // if there are several windows at a given screen point, take the top one
     static func topWindowForScreenAtPoint(_ point: CGPoint, withWindows windows: [SIWindow]) -> SIWindow? {
         let (ids, maybeWindowDescriptions) = windowInformation(windows)
         guard let windowDescriptions = maybeWindowDescriptions, !windowDescriptions.isEmpty else {
@@ -84,6 +87,7 @@ extension SIWindow {
         return windowInWindows(windows, withCGWindowDescription: windowDictionaryToFocus)
     }
 
+    // get the first window at a certain point, excluding one specific window from consideration
     static func alternateWindowForScreenAtPoint(_ point: CGPoint, withWindows windows: [SIWindow], butNot ignoreWindow: SIWindow?) -> SIWindow? {
         // only consider windows on this screen
         let (ids, maybeWindowDescriptions) = windowInformation(windows)
@@ -104,6 +108,7 @@ extension SIWindow {
         return nil
     }
 
+    // find a window based on its window description within an array of SIWindow objects
     static func windowInWindows(_ windows: [SIWindow], withCGWindowDescription windowDescription: [String: AnyObject]) -> SIWindow? {
         for window in windows {
             guard
@@ -132,6 +137,8 @@ extension SIWindow {
         return nil
     }
 
+    // return an array of dictionaries of window information for all windows relative to windowID
+    // if windowID is 0, this will return all window information
     static func windowDescriptions(_ options: CGWindowListOption, windowID: CGWindowID) -> [[String: AnyObject]]? {
         guard let cfWindowDescriptions = CGWindowListCopyWindowInfo(options, windowID) else {
             return nil

--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -38,7 +38,7 @@ final class HotKeyManager: NSObject {
     private static func keyCodeForNumber(_ number: NSNumber) -> AMKeyCode {
         let string = "\(number)"
 
-        guard string.characters.count > 0 else {
+        guard !string.characters.isEmpty else {
             return AMKeyCodeInvalid
         }
 

--- a/Amethyst/Layout/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/BinarySpacePartitioningLayout.swift
@@ -149,7 +149,7 @@ final class BinarySpacePartitioningReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    var frameAssignments: [FrameAssignment] {
+    func frameAssignments() -> [FrameAssignment] {
         guard !windows.isEmpty else {
             return []
         }
@@ -229,7 +229,7 @@ final class BinarySpacePartitioningReflowOperation: ReflowOperation {
             return
         }
 
-        frameAssigner.performFrameAssignments(frameAssignments)
+        frameAssigner.performFrameAssignments(frameAssignments())
     }
 }
 
@@ -255,7 +255,7 @@ final class BinarySpacePartitioningLayout: Layout {
     }
 
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return BinarySpacePartitioningReflowOperation(screen: screen, windows: windows, rootNode: rootNode, frameAssigner: self).frameAssignments.first { $0.window == window }
+        return BinarySpacePartitioningReflowOperation(screen: screen, windows: windows, rootNode: rootNode, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 
     private func constructInitialTreeWithWindows(_ windows: [SIWindow]) {

--- a/Amethyst/Layout/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/BinarySpacePartitioningLayout.swift
@@ -253,8 +253,8 @@ final class BinarySpacePartitioningLayout: Layout {
         return BinarySpacePartitioningReflowOperation(screen: screen, windows: windows, rootNode: rootNode, frameAssigner: self)
     }
 
-    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
-        return BinarySpacePartitioningReflowOperation(screen: screen, windows: windows, rootNode: rootNode, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+        return BinarySpacePartitioningReflowOperation(screen: screen, windows: windows, rootNode: rootNode, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
 
     private func constructInitialTreeWithWindows(_ windows: [SIWindow]) {

--- a/Amethyst/Layout/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/BinarySpacePartitioningLayout.swift
@@ -176,7 +176,7 @@ final class BinarySpacePartitioningReflowOperation: ReflowOperation {
                     continue
                 }
 
-                let resizeRules = ResizeRules(isMain: true, scaleFactor: 1, unconstrainedDimension: .horizontal)
+                let resizeRules = ResizeRules(isMain: true, unconstrainedDimension: .horizontal, scaleFactor: 1)
                 let frameAssignment = FrameAssignment(frame: traversalNode.frame, window: window, focused: windowID == focusedWindow?.windowID(), screenFrame: baseFrame, resizeRules: resizeRules)
                 ret.append(frameAssignment)
             } else {

--- a/Amethyst/Layout/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/BinarySpacePartitioningLayout.swift
@@ -176,7 +176,8 @@ final class BinarySpacePartitioningReflowOperation: ReflowOperation {
                     continue
                 }
 
-                let frameAssignment = FrameAssignment(frame: traversalNode.frame, window: window, focused: windowID == focusedWindow?.windowID(), screenFrame: baseFrame)
+                let resizeRules = ResizeRules(isMain: true, scaleFactor: 1, unconstrainedDimension: .horizontal)
+                let frameAssignment = FrameAssignment(frame: traversalNode.frame, window: window, focused: windowID == focusedWindow?.windowID(), screenFrame: baseFrame, resizeRules: resizeRules)
                 ret.append(frameAssignment)
             } else {
                 guard let left = traversalNode.node.left, let right = traversalNode.node.right else {

--- a/Amethyst/Layout/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/BinarySpacePartitioningLayout.swift
@@ -165,7 +165,7 @@ final class BinarySpacePartitioningReflowOperation: ReflowOperation {
         var ret: [FrameAssignment] = []
         var traversalNodes: [TraversalNode] = [(node: rootNode, frame: baseFrame)]
 
-        while traversalNodes.count > 0 {
+        while !traversalNodes.isEmpty {
             let traversalNode = traversalNodes[0]
 
             traversalNodes = [TraversalNode](traversalNodes.dropFirst(1))

--- a/Amethyst/Layout/ColumnLayout.swift
+++ b/Amethyst/Layout/ColumnLayout.swift
@@ -34,20 +34,25 @@ final class ColumnReflowOperation: ReflowOperation {
         return windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
             var windowFrame: CGRect = .zero
+            let isMain = frameAssignments.count < mainPaneCount
+            var scaleFactor: CGFloat
 
-            if frameAssignments.count < mainPaneCount {
+            if isMain {
+                scaleFactor = screenFrame.width / mainPaneWindowWidth
                 windowFrame.origin.x = screenFrame.origin.x + (mainPaneWindowWidth * CGFloat(frameAssignments.count))
                 windowFrame.origin.y = screenFrame.origin.y
                 windowFrame.size.width = mainPaneWindowWidth
                 windowFrame.size.height = screenFrame.height
             } else {
+                scaleFactor = (screenFrame.width / secondaryPaneWindowWidth) / CGFloat(secondaryPaneCount)
                 windowFrame.origin.x = screenFrame.origin.x + (mainPaneWindowWidth * CGFloat(mainPaneCount)) + (secondaryPaneWindowWidth * CGFloat(frameAssignments.count - mainPaneCount))
                 windowFrame.origin.y = screenFrame.origin.y
                 windowFrame.size.width = secondaryPaneWindowWidth
                 windowFrame.size.height = screenFrame.height
             }
 
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
+            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)
 

--- a/Amethyst/Layout/ColumnLayout.swift
+++ b/Amethyst/Layout/ColumnLayout.swift
@@ -75,7 +75,7 @@ final class ColumnLayout: Layout {
 
     let windowActivityCache: WindowActivityCache
     fileprivate var mainPaneCount: Int = 1
-    internal var mainPaneRatio: CGFloat = 0.5
+    fileprivate(set) var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache

--- a/Amethyst/Layout/ColumnLayout.swift
+++ b/Amethyst/Layout/ColumnLayout.swift
@@ -41,7 +41,7 @@ final class ColumnReflowOperation: ReflowOperation {
                 windowFrame.size.width = mainPaneWindowWidth
                 windowFrame.size.height = screenFrame.height
             } else {
-                windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth + (secondaryPaneWindowWidth * CGFloat(frameAssignments.count - mainPaneCount))
+                windowFrame.origin.x = screenFrame.origin.x + (mainPaneWindowWidth * CGFloat(mainPaneCount)) + (secondaryPaneWindowWidth * CGFloat(frameAssignments.count - mainPaneCount))
                 windowFrame.origin.y = screenFrame.origin.y
                 windowFrame.size.width = secondaryPaneWindowWidth
                 windowFrame.size.height = screenFrame.height

--- a/Amethyst/Layout/ColumnLayout.swift
+++ b/Amethyst/Layout/ColumnLayout.swift
@@ -16,9 +16,9 @@ final class ColumnReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    override func main() {
+    var frameAssignments: [FrameAssignment] {
         guard !windows.isEmpty else {
-            return
+            return []
         }
 
         let mainPaneCount = min(windows.count, layout.mainPaneCount)
@@ -31,7 +31,7 @@ final class ColumnReflowOperation: ReflowOperation {
 
         let focusedWindow = SIWindow.focused()
 
-        let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
+        return windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
             var windowFrame: CGRect = .zero
 
@@ -53,7 +53,9 @@ final class ColumnReflowOperation: ReflowOperation {
 
             return assignments
         }
+    }
 
+    override func main() {
         guard !isCancelled else {
             return
         }
@@ -77,6 +79,11 @@ final class ColumnLayout: Layout {
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
         return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
+
+    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
+        return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    }
+
 }
 
 extension ColumnLayout: PanedLayout {

--- a/Amethyst/Layout/ColumnLayout.swift
+++ b/Amethyst/Layout/ColumnLayout.swift
@@ -51,7 +51,7 @@ final class ColumnReflowOperation: ReflowOperation {
                 windowFrame.size.height = screenFrame.height
             }
 
-            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
+            let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .horizontal, scaleFactor: scaleFactor)
             let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)

--- a/Amethyst/Layout/ColumnLayout.swift
+++ b/Amethyst/Layout/ColumnLayout.swift
@@ -70,7 +70,7 @@ final class ColumnLayout: Layout {
 
     let windowActivityCache: WindowActivityCache
     fileprivate var mainPaneCount: Int = 1
-    fileprivate var mainPaneRatio: CGFloat = 0.5
+    internal var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache
@@ -83,16 +83,11 @@ final class ColumnLayout: Layout {
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
         return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
-
 }
 
 extension ColumnLayout: PanedLayout {
-    func expandMainPane() {
-        mainPaneRatio = max(0, mainPaneRatio + UserConfiguration.shared.windowResizeStep())
-    }
-
-    func shrinkMainPane() {
-        mainPaneRatio = max(0, mainPaneRatio - UserConfiguration.shared.windowResizeStep())
+    func setMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
     func increaseMainPaneCount() {

--- a/Amethyst/Layout/ColumnLayout.swift
+++ b/Amethyst/Layout/ColumnLayout.swift
@@ -80,8 +80,8 @@ final class ColumnLayout: Layout {
         return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 
-    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
-        return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+        return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
 
 }

--- a/Amethyst/Layout/ColumnLayout.swift
+++ b/Amethyst/Layout/ColumnLayout.swift
@@ -91,7 +91,7 @@ final class ColumnLayout: Layout {
 }
 
 extension ColumnLayout: PanedLayout {
-    func setMainPaneRawRatio(rawRatio: CGFloat) {
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
         mainPaneRatio = rawRatio
     }
 

--- a/Amethyst/Layout/ColumnLayout.swift
+++ b/Amethyst/Layout/ColumnLayout.swift
@@ -16,7 +16,7 @@ final class ColumnReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    var frameAssignments: [FrameAssignment] {
+    func frameAssignments() -> [FrameAssignment] {
         guard !windows.isEmpty else {
             return []
         }
@@ -65,7 +65,7 @@ final class ColumnReflowOperation: ReflowOperation {
             return
         }
 
-        frameAssigner.performFrameAssignments(frameAssignments)
+        frameAssigner.performFrameAssignments(frameAssignments())
     }
 }
 
@@ -86,7 +86,7 @@ final class ColumnLayout: Layout {
     }
 
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
+        return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/FloatingLayout.swift
+++ b/Amethyst/Layout/FloatingLayout.swift
@@ -23,6 +23,11 @@ final class FloatingLayout: Layout {
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
         return FloatingReflowOperation(screen: screen, windows: windows, frameAssigner: self)
     }
+
+    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
+        return false
+    }
+
 }
 
 extension FloatingLayout: FrameAssigner {}

--- a/Amethyst/Layout/FloatingLayout.swift
+++ b/Amethyst/Layout/FloatingLayout.swift
@@ -24,8 +24,8 @@ final class FloatingLayout: Layout {
         return FloatingReflowOperation(screen: screen, windows: windows, frameAssigner: self)
     }
 
-    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
-        return false
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+        return nil
     }
 
 }

--- a/Amethyst/Layout/FullscreenLayout.swift
+++ b/Amethyst/Layout/FullscreenLayout.swift
@@ -20,7 +20,7 @@ final class FullscreenReflowOperation: ReflowOperation {
         let window: SIWindow
         let screenFrame = screen.adjustedFrame()
         return windows.map { window in
-            let resizeRules = ResizeRules(isMain: true, scaleFactor: 1, unconstrainedDimension: .horizontal)
+            let resizeRules = ResizeRules(isMain: true, unconstrainedDimension: .horizontal, scaleFactor: 1)
             return FrameAssignment(frame: screenFrame, window: window, focused: false, screenFrame: screenFrame, resizeRules: resizeRules)
         }
     }

--- a/Amethyst/Layout/FullscreenLayout.swift
+++ b/Amethyst/Layout/FullscreenLayout.swift
@@ -47,8 +47,8 @@ final class FullscreenLayout: Layout {
         return FullscreenReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 
-    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
-        return FullscreenReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+        return FullscreenReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/FullscreenLayout.swift
+++ b/Amethyst/Layout/FullscreenLayout.swift
@@ -20,7 +20,8 @@ final class FullscreenReflowOperation: ReflowOperation {
         let window: SIWindow
         let screenFrame = screen.adjustedFrame()
         return windows.map { window in
-            return FrameAssignment(frame: screenFrame, window: window, focused: false, screenFrame: screenFrame)
+            let resizeRules = ResizeRules(isMain: true, scaleFactor: 1, unconstrainedDimension: .horizontal)
+            return FrameAssignment(frame: screenFrame, window: window, focused: false, screenFrame: screenFrame, resizeRules: resizeRules)
         }
     }
 

--- a/Amethyst/Layout/FullscreenLayout.swift
+++ b/Amethyst/Layout/FullscreenLayout.swift
@@ -16,7 +16,7 @@ final class FullscreenReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    var frameAssignments: [FrameAssignment] {
+    func frameAssignments() -> [FrameAssignment] {
         let window: SIWindow
         let screenFrame = screen.adjustedFrame()
         return windows.map { window in
@@ -30,7 +30,7 @@ final class FullscreenReflowOperation: ReflowOperation {
             return
         }
 
-        frameAssigner.performFrameAssignments(frameAssignments)
+        frameAssigner.performFrameAssignments(frameAssignments())
     }
 }
 
@@ -49,7 +49,7 @@ final class FullscreenLayout: Layout {
     }
 
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return FullscreenReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
+        return FullscreenReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/FullscreenLayout.swift
+++ b/Amethyst/Layout/FullscreenLayout.swift
@@ -16,12 +16,15 @@ final class FullscreenReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    override func main() {
+    var frameAssignments: [FrameAssignment] {
+        let window: SIWindow
         let screenFrame = screen.adjustedFrame()
-        let frameAssignments: [FrameAssignment] = windows.map { window in
+        return windows.map { window in
             return FrameAssignment(frame: screenFrame, window: window, focused: false, screenFrame: screenFrame)
         }
+    }
 
+    override func main() {
         guard !isCancelled else {
             return
         }
@@ -42,6 +45,10 @@ final class FullscreenLayout: Layout {
 
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
         return FullscreenReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
+    }
+
+    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
+        return FullscreenReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -32,22 +32,7 @@ struct FrameAssignment {
             finalFrame.size.height -= 2 * padding
         }
 
-        var finalPosition = finalFrame.origin
-
-        // Just resize the window
-        finalFrame.origin = window.frame().origin
-        window.setFrame(finalFrame)
-
-        if focused {
-            finalFrame.size = CGSize(width: max(window.frame().size.width, finalFrame.size.width), height: max(window.frame().size.height, finalFrame.size.height))
-            if !screenFrame.contains(finalFrame) {
-                finalPosition.x = min(finalPosition.x, screenFrame.maxX - finalFrame.size.width)
-                finalPosition.y = min(finalPosition.y, screenFrame.maxY - finalFrame.size.height)
-            }
-        }
-
         // Move the window to its final frame
-        finalFrame.origin = finalPosition
         window.setFrame(finalFrame)
     }
 }

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -144,7 +144,15 @@ protocol PanedLayout {
 
 extension PanedLayout {
     func setMainPaneRatio(_ ratio: CGFloat) {
-        setMainPaneRawRatio(rawRatio: min(1, max(0, ratio)))
+        guard ratio >= 0 else {
+            LogManager.log?.warning("tried to setMainPaneRatio < 0:  \(ratio)")
+            return setMainPaneRawRatio(rawRatio: 0)
+        }
+        guard ratio <= 1 else {
+            LogManager.log?.warning("tried to setMainPaneRatio > 1: \(ratio)")
+            return setMainPaneRawRatio(rawRatio: 1)
+        }
+        setMainPaneRawRatio(rawRatio: ratio)
     }
 
     func expandMainPane() {

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -108,10 +108,26 @@ protocol Layout {
 }
 
 protocol PanedLayout {
+    var mainPaneRatio: CGFloat { get }
+    func setMainPaneRawRatio(rawRatio: CGFloat)
     func shrinkMainPane()
     func expandMainPane()
     func increaseMainPaneCount()
     func decreaseMainPaneCount()
+}
+
+extension PanedLayout {
+    func setMainPaneRatio(_ ratio: CGFloat) {
+        setMainPaneRawRatio(rawRatio: min(1, max(0, ratio)))
+    }
+
+    func expandMainPane() {
+        setMainPaneRatio(mainPaneRatio + UserConfiguration.shared.windowResizeStep())
+    }
+
+    func shrinkMainPane() {
+        setMainPaneRatio(mainPaneRatio - UserConfiguration.shared.windowResizeStep())
+    }
 }
 
 protocol StatefulLayout {

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -142,7 +142,7 @@ protocol Layout {
 
 protocol PanedLayout {
     var mainPaneRatio: CGFloat { get }
-    func setMainPaneRawRatio(rawRatio: CGFloat)
+    func recommendMainPaneRawRatio(rawRatio: CGFloat)
     func shrinkMainPane()
     func expandMainPane()
     func increaseMainPaneCount()
@@ -150,20 +150,20 @@ protocol PanedLayout {
 }
 
 extension PanedLayout {
-    func setMainPaneRatio(_ ratio: CGFloat) {
+    func recommendMainPaneRatio(_ ratio: CGFloat) {
         guard 0 <= ratio && ratio <= 1 else {
             LogManager.log?.warning("tried to setMainPaneRatio out of range [0-1]:  \(ratio)")
-            return setMainPaneRawRatio(rawRatio: max(min(ratio, 1), 0))
+            return recommendMainPaneRawRatio(rawRatio: max(min(ratio, 1), 0))
         }
-        setMainPaneRawRatio(rawRatio: ratio)
+        recommendMainPaneRawRatio(rawRatio: ratio)
     }
 
     func expandMainPane() {
-        setMainPaneRatio(mainPaneRatio + UserConfiguration.shared.windowResizeStep())
+        recommendMainPaneRatio(mainPaneRatio + UserConfiguration.shared.windowResizeStep())
     }
 
     func shrinkMainPane() {
-        setMainPaneRatio(mainPaneRatio - UserConfiguration.shared.windowResizeStep())
+        recommendMainPaneRatio(mainPaneRatio - UserConfiguration.shared.windowResizeStep())
     }
 }
 

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -63,7 +63,7 @@ struct FrameAssignment {
 
     fileprivate func perform() {
         // Move the window to its final frame
-        window.setFrame(finalFrame)
+        window.setFrame(finalFrame, withThreshold: CGSize(width: 1, height: 1))
     }
 }
 

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -18,6 +18,10 @@ enum UnconstrainedDimension: Int {
     case vertical
 }
 
+// Some window resizes reflect valid adjustments to the frame layout.
+// Some window resizes would not be allowed due to hard constraints.
+// This struct defines what adjustments to a particular window frame are allowed
+//  and tracks its size as a proportion of available space (for use in resize calculations)
 struct ResizeRules {
     let isMain: Bool
     let unconstrainedDimension: UnconstrainedDimension
@@ -44,6 +48,7 @@ struct FrameAssignment {
     let screenFrame: CGRect
     let resizeRules: ResizeRules
 
+    // the final frame is the desired frame, but shrunk to provide desired padding
     var finalFrame: CGRect {
         guard UserConfiguration.shared.windowMargins() else {
             return frame

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -23,10 +23,11 @@ struct ResizeRules {
     let scaleFactor: CGFloat    // how to scale up window width to pane width
     let unconstrainedDimension: UnconstrainedDimension
 
-    func scaledDimension(_ frame: CGRect, isPadded: Bool) -> CGFloat {
+    // given a new frame, decide which dimension will be honored and return its size
+    func scaledDimension(_ frame: CGRect, negatePadding: Bool) -> CGFloat {
         let dimension = unconstrainedDimension == .horizontal ? frame.width : frame.height
-        let padding = floor(UserConfiguration.shared.windowMarginSize() / 2)
-        return isPadded ? dimension + padding * 2 : dimension
+        let padding = UserConfiguration.shared.windowMargins() ? UserConfiguration.shared.windowMarginSize() : 0
+        return negatePadding ? dimension + padding : dimension
     }
 }
 
@@ -55,8 +56,8 @@ struct FrameAssignment {
     // Given a window frame and based on resizeRules, determine what the main pane ratio would be
     // this accounts for multiple main windows and primary vs non-primary being resized
     func impliedMainPaneRatio(windowFrame: CGRect) -> CGFloat {
-        let oldDimension = resizeRules.scaledDimension(frame, isPadded: false)
-        let newDimension = resizeRules.scaledDimension(windowFrame, isPadded: true)
+        let oldDimension = resizeRules.scaledDimension(frame, negatePadding: false)
+        let newDimension = resizeRules.scaledDimension(windowFrame, negatePadding: true)
         let implied =  (newDimension / oldDimension) / resizeRules.scaleFactor
         return resizeRules.isMain ? implied : 1 - implied
     }

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -100,6 +100,7 @@ protocol Layout {
     var windowActivityCache: WindowActivityCache { get }
 
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation
+    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool
 }
 
 protocol PanedLayout {

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -19,19 +19,23 @@ struct FrameAssignment {
     let focused: Bool
     let screenFrame: CGRect
 
-    fileprivate func perform() {
-        var padding = UserConfiguration.shared.windowMarginSize()
-        var finalFrame = frame
-
-        if UserConfiguration.shared.windowMargins() {
-            padding = floor(padding / 2)
-
-            finalFrame.origin.x += padding
-            finalFrame.origin.y += padding
-            finalFrame.size.width -= 2 * padding
-            finalFrame.size.height -= 2 * padding
+    var finalFrame: CGRect {
+        guard UserConfiguration.shared.windowMargins() else {
+            return frame
         }
 
+        var ret = frame
+        var padding = UserConfiguration.shared.windowMarginSize()
+        padding = floor(padding / 2)
+
+        ret.origin.x += padding
+        ret.origin.y += padding
+        ret.size.width -= 2 * padding
+        ret.size.height -= 2 * padding
+        return ret
+    }
+
+    fileprivate func perform() {
         // Move the window to its final frame
         window.setFrame(finalFrame)
     }
@@ -100,7 +104,7 @@ protocol Layout {
     var windowActivityCache: WindowActivityCache { get }
 
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation
-    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment?
 }
 
 protocol PanedLayout {

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -22,6 +22,12 @@ struct ResizeRules {
     let isMain: Bool
     let scaleFactor: CGFloat    // how to scale up window width to pane width
     let unconstrainedDimension: UnconstrainedDimension
+
+    func scaledDimension(_ frame: CGRect, isPadded: Bool) -> CGFloat {
+        let dimension = unconstrainedDimension == .horizontal ? frame.width : frame.height
+        let padding = floor(UserConfiguration.shared.windowMarginSize() / 2)
+        return isPadded ? dimension + padding * 2 : dimension
+    }
 }
 
 struct FrameAssignment {
@@ -37,8 +43,7 @@ struct FrameAssignment {
         }
 
         var ret = frame
-        var padding = UserConfiguration.shared.windowMarginSize()
-        padding = floor(padding / 2)
+        let padding = floor(UserConfiguration.shared.windowMarginSize() / 2)
 
         ret.origin.x += padding
         ret.origin.y += padding
@@ -50,10 +55,9 @@ struct FrameAssignment {
     // Given a window frame and based on resizeRules, determine what the main pane ratio would be
     // this accounts for multiple main windows and primary vs non-primary being resized
     func impliedMainPaneRatio(windowFrame: CGRect) -> CGFloat {
-        let padding = floor(UserConfiguration.shared.windowMarginSize() / 2)
-        let oldDimension = resizeRules.unconstrainedDimension == .horizontal ? frame.width : frame.height
-        let newDimension = resizeRules.unconstrainedDimension == .horizontal ? windowFrame.width : windowFrame.height
-        let implied =  (newDimension / (oldDimension + padding * 2)) / resizeRules.scaleFactor
+        let oldDimension = resizeRules.scaledDimension(frame, isPadded: false)
+        let newDimension = resizeRules.scaledDimension(windowFrame, isPadded: true)
+        let implied =  (newDimension / oldDimension) / resizeRules.scaleFactor
         return resizeRules.isMain ? implied : 1 - implied
     }
 

--- a/Amethyst/Layout/MiddleWideLayout.swift
+++ b/Amethyst/Layout/MiddleWideLayout.swift
@@ -103,7 +103,7 @@ final class MiddleWideLayout: Layout {
 
     let windowActivityCache: WindowActivityCache
 
-    internal var mainPaneRatio: CGFloat = 0.5
+    fileprivate(set) var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache

--- a/Amethyst/Layout/MiddleWideLayout.swift
+++ b/Amethyst/Layout/MiddleWideLayout.swift
@@ -16,9 +16,9 @@ final class MiddleWideReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    override func main() {
+    var frameAssignments: [FrameAssignment] {
         guard !windows.isEmpty else {
-            return
+            return []
         }
 
         let secondaryPaneCount = round(Double(windows.count - 1) / 2.0)
@@ -49,7 +49,7 @@ final class MiddleWideReflowOperation: ReflowOperation {
 
         let focusedWindow = SIWindow.focused()
 
-        let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
+        return windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
             var windowFrame = CGRect.zero
             let windowIndex = frameAssignments.count
@@ -77,6 +77,9 @@ final class MiddleWideReflowOperation: ReflowOperation {
 
             return assignments
         }
+    }
+
+    override func main() {
 
         guard !isCancelled else {
             return
@@ -100,6 +103,10 @@ final class MiddleWideLayout: Layout {
 
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
         return MiddleWideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
+    }
+
+    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
+        return MiddleWideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/MiddleWideLayout.swift
+++ b/Amethyst/Layout/MiddleWideLayout.swift
@@ -53,13 +53,18 @@ final class MiddleWideReflowOperation: ReflowOperation {
             var assignments = frameAssignments
             var windowFrame = CGRect.zero
             let windowIndex = frameAssignments.count
+            let isMain = windowIndex == 0
+            let hasTertiary = windowIndex > Int(secondaryPaneCount)
+            var scaleFactor: CGFloat
 
-            if windowIndex == 0 {
+            scaleFactor = (screenFrame.width / secondaryPaneWindowWidth) / (hasTertiaryPane ? 2.0 : 1.0)
+            if isMain {
+                scaleFactor = screenFrame.width / mainPaneWindowWidth
                 windowFrame.origin.x = screenFrame.origin.x + (hasSecondaryPane ? secondaryPaneWindowWidth : 0)
                 windowFrame.origin.y = screenFrame.origin.y
                 windowFrame.size.width = mainPaneWindowWidth
                 windowFrame.size.height = mainPaneWindowHeight
-            } else if windowIndex > Int(secondaryPaneCount) { // tertiary
+            } else if hasTertiary { // tertiary
                 windowFrame.origin.x = screenFrame.origin.x + secondaryPaneWindowWidth + mainPaneWindowWidth
                 windowFrame.origin.y = screenFrame.origin.y + (tertiaryPaneWindowHeight * CGFloat(Double(windowIndex) - (1 + secondaryPaneCount)))
                 windowFrame.size.width = tertiaryPaneWindowWidth
@@ -71,7 +76,8 @@ final class MiddleWideReflowOperation: ReflowOperation {
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
+            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)
 

--- a/Amethyst/Layout/MiddleWideLayout.swift
+++ b/Amethyst/Layout/MiddleWideLayout.swift
@@ -95,7 +95,7 @@ final class MiddleWideLayout: Layout {
 
     let windowActivityCache: WindowActivityCache
 
-    fileprivate var mainPaneRatio: CGFloat = 0.5
+    internal var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache
@@ -111,12 +111,8 @@ final class MiddleWideLayout: Layout {
 }
 
 extension MiddleWideLayout: PanedLayout {
-    func expandMainPane() {
-        mainPaneRatio = min(1, mainPaneRatio + UserConfiguration.shared.windowResizeStep())
-    }
-
-    func shrinkMainPane() {
-        mainPaneRatio = max(0, mainPaneRatio - UserConfiguration.shared.windowResizeStep())
+    func setMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
     func increaseMainPaneCount() {}

--- a/Amethyst/Layout/MiddleWideLayout.swift
+++ b/Amethyst/Layout/MiddleWideLayout.swift
@@ -119,7 +119,7 @@ final class MiddleWideLayout: Layout {
 }
 
 extension MiddleWideLayout: PanedLayout {
-    func setMainPaneRawRatio(rawRatio: CGFloat) {
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
         mainPaneRatio = rawRatio
     }
 

--- a/Amethyst/Layout/MiddleWideLayout.swift
+++ b/Amethyst/Layout/MiddleWideLayout.swift
@@ -57,7 +57,7 @@ final class MiddleWideReflowOperation: ReflowOperation {
             let hasTertiary = windowIndex > Int(secondaryPaneCount)
             var scaleFactor: CGFloat
 
-            scaleFactor = (screenFrame.width / secondaryPaneWindowWidth) / (hasTertiaryPane ? 2.0 : 1.0)
+            scaleFactor = (screenFrame.width / secondaryPaneWindowWidth)
             if isMain {
                 scaleFactor = screenFrame.width / mainPaneWindowWidth
                 windowFrame.origin.x = screenFrame.origin.x + (hasSecondaryPane ? secondaryPaneWindowWidth : 0)
@@ -76,7 +76,9 @@ final class MiddleWideReflowOperation: ReflowOperation {
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
+            let hackIsMain = (hasTertiaryPane ? isMain : !isMain)
+
+            let resizeRules = ResizeRules(isMain: hackIsMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
             let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)

--- a/Amethyst/Layout/MiddleWideLayout.swift
+++ b/Amethyst/Layout/MiddleWideLayout.swift
@@ -105,8 +105,8 @@ final class MiddleWideLayout: Layout {
         return MiddleWideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 
-    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
-        return MiddleWideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+        return MiddleWideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/MiddleWideLayout.swift
+++ b/Amethyst/Layout/MiddleWideLayout.swift
@@ -16,7 +16,7 @@ final class MiddleWideReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    var frameAssignments: [FrameAssignment] {
+    func frameAssignments() -> [FrameAssignment] {
         guard !windows.isEmpty else {
             return []
         }
@@ -93,7 +93,7 @@ final class MiddleWideReflowOperation: ReflowOperation {
             return
         }
 
-        layout.performFrameAssignments(frameAssignments)
+        layout.performFrameAssignments(frameAssignments())
     }
 }
 
@@ -114,7 +114,7 @@ final class MiddleWideLayout: Layout {
     }
 
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return MiddleWideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
+        return MiddleWideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/MiddleWideLayout.swift
+++ b/Amethyst/Layout/MiddleWideLayout.swift
@@ -76,9 +76,9 @@ final class MiddleWideReflowOperation: ReflowOperation {
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let hackIsMain = (hasTertiaryPane ? isMain : !isMain)
+            let isTertiaryMain = (hasTertiaryPane ? isMain : !isMain)
 
-            let resizeRules = ResizeRules(isMain: hackIsMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
+            let resizeRules = ResizeRules(isMain: isTertiaryMain, unconstrainedDimension: .horizontal, scaleFactor: scaleFactor)
             let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -35,24 +35,30 @@ final class RowReflowOperation: ReflowOperation {
         return windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
             var windowFrame: CGRect = .zero
+            let isMain = frameAssignments.count < mainPaneCount
+            var scaleFactor: CGFloat
 
-            if frameAssignments.count < mainPaneCount {
+            if isMain {
+                scaleFactor = screenFrame.size.height / mainPaneWindowHeight
                 windowFrame.origin.x = screenFrame.origin.x
                 windowFrame.origin.y = screenFrame.origin.y + (mainPaneWindowHeight * CGFloat(frameAssignments.count))
                 windowFrame.size.width = screenFrame.width
                 windowFrame.size.height = mainPaneWindowHeight
             } else {
+                scaleFactor = screenFrame.size.height / secondaryPaneWindowHeight / CGFloat(secondaryPaneCount)
                 windowFrame.origin.x = screenFrame.origin.x
                 windowFrame.origin.y = screenFrame.origin.y + (mainPaneWindowHeight * CGFloat(mainPaneCount)) + (secondaryPaneWindowHeight * CGFloat(frameAssignments.count - mainPaneCount))
                 windowFrame.size.width = screenFrame.width
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
+            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .vertical)
             let frameAssignment = FrameAssignment(
                 frame: windowFrame,
                 window: window,
                 focused: window.isEqual(to: focusedWindow),
-                screenFrame: screenFrame
+                screenFrame: screenFrame,
+                resizeRules: resizeRules
             )
 
             assignments.append(frameAssignment)

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -16,9 +16,9 @@ final class RowReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    override func main() {
+    var frameAssignments: [FrameAssignment] {
         guard !windows.isEmpty else {
-            return
+            return []
         }
 
         let mainPaneCount = min(windows.count, layout.mainPaneCount)
@@ -32,7 +32,7 @@ final class RowReflowOperation: ReflowOperation {
 
         let focusedWindow = SIWindow.focused()
 
-        let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
+        return windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
             var windowFrame: CGRect = .zero
 
@@ -59,7 +59,9 @@ final class RowReflowOperation: ReflowOperation {
 
             return assignments
         }
+    }
 
+    override func main() {
         guard !isCancelled else {
             return
         }
@@ -83,6 +85,10 @@ final class RowLayout: Layout {
 
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
         return RowReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
+    }
+
+    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
+        return RowReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -87,8 +87,8 @@ final class RowLayout: Layout {
         return RowReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 
-    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
-        return RowReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+        return RowReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -43,7 +43,7 @@ final class RowReflowOperation: ReflowOperation {
                 windowFrame.size.height = mainPaneWindowHeight
             } else {
                 windowFrame.origin.x = screenFrame.origin.x
-                windowFrame.origin.y = screenFrame.origin.y + mainPaneWindowHeight + (secondaryPaneWindowHeight * CGFloat(frameAssignments.count - mainPaneCount))
+                windowFrame.origin.y = screenFrame.origin.y + (mainPaneWindowHeight * CGFloat(mainPaneCount)) + (secondaryPaneWindowHeight * CGFloat(frameAssignments.count - mainPaneCount))
                 windowFrame.size.width = screenFrame.width
                 windowFrame.size.height = secondaryPaneWindowHeight
             }

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -83,7 +83,7 @@ final class RowLayout: Layout {
     let windowActivityCache: WindowActivityCache
 
     fileprivate var mainPaneCount: Int = 1
-    internal var mainPaneRatio: CGFloat = 0.5
+    fileprivate(set) var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -99,7 +99,7 @@ final class RowLayout: Layout {
 }
 
 extension RowLayout: PanedLayout {
-    func setMainPaneRawRatio(rawRatio: CGFloat) {
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
         mainPaneRatio = rawRatio
     }
 

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -52,7 +52,7 @@ final class RowReflowOperation: ReflowOperation {
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .vertical)
+            let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .vertical, scaleFactor: scaleFactor)
             let frameAssignment = FrameAssignment(
                 frame: windowFrame,
                 window: window,

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -77,7 +77,7 @@ final class RowLayout: Layout {
     let windowActivityCache: WindowActivityCache
 
     fileprivate var mainPaneCount: Int = 1
-    fileprivate var mainPaneRatio: CGFloat = 0.5
+    internal var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache
@@ -93,12 +93,8 @@ final class RowLayout: Layout {
 }
 
 extension RowLayout: PanedLayout {
-    func expandMainPane() {
-        mainPaneRatio = max(0, mainPaneRatio + UserConfiguration.shared.windowResizeStep())
-    }
-
-    func shrinkMainPane() {
-        mainPaneRatio = max(0, mainPaneRatio - UserConfiguration.shared.windowResizeStep())
+    func setMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
     func increaseMainPaneCount() {

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -16,7 +16,7 @@ final class RowReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    var frameAssignments: [FrameAssignment] {
+    func frameAssignments() -> [FrameAssignment] {
         guard !windows.isEmpty else {
             return []
         }
@@ -72,7 +72,7 @@ final class RowReflowOperation: ReflowOperation {
             return
         }
 
-        layout.performFrameAssignments(frameAssignments)
+        layout.performFrameAssignments(frameAssignments())
     }
 }
 
@@ -94,7 +94,7 @@ final class RowLayout: Layout {
     }
 
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return RowReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
+        return RowReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/TallLayout.swift
+++ b/Amethyst/Layout/TallLayout.swift
@@ -55,7 +55,7 @@ final class TallReflowOperation: ReflowOperation {
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
+            let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .horizontal, scaleFactor: scaleFactor)
             let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)

--- a/Amethyst/Layout/TallLayout.swift
+++ b/Amethyst/Layout/TallLayout.swift
@@ -51,7 +51,6 @@ final class TallReflowOperation: ReflowOperation {
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            print("Framing \(windowFrame)\thas \(window.title())")
             let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
 
             assignments.append(frameAssignment)
@@ -76,7 +75,7 @@ final class TallLayout: Layout {
     let windowActivityCache: WindowActivityCache
 
     fileprivate var mainPaneCount: Int = 1
-    fileprivate var mainPaneRatio: CGFloat = 0.5
+    internal var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache
@@ -89,16 +88,11 @@ final class TallLayout: Layout {
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
         return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
-
 }
 
 extension TallLayout: PanedLayout {
-    func expandMainPane() {
-        mainPaneRatio = min(1, mainPaneRatio + UserConfiguration.shared.windowResizeStep())
-    }
-
-    func shrinkMainPane() {
-        mainPaneRatio = max(0, mainPaneRatio - UserConfiguration.shared.windowResizeStep())
+    func setMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
     func increaseMainPaneCount() {

--- a/Amethyst/Layout/TallLayout.swift
+++ b/Amethyst/Layout/TallLayout.swift
@@ -16,7 +16,7 @@ final class TallReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    var frameAssignments: [FrameAssignment] {
+    func frameAssignments() -> [FrameAssignment] {
         guard !windows.isEmpty else {
             return []
         }
@@ -69,7 +69,7 @@ final class TallReflowOperation: ReflowOperation {
             return
         }
 
-        frameAssigner.performFrameAssignments(frameAssignments)
+        frameAssigner.performFrameAssignments(frameAssignments())
     }
 }
 
@@ -91,7 +91,7 @@ final class TallLayout: Layout {
     }
 
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
+        return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/TallLayout.swift
+++ b/Amethyst/Layout/TallLayout.swift
@@ -16,9 +16,9 @@ final class TallReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    override func main() {
+    var frameAssignments: [FrameAssignment] {
         guard !windows.isEmpty else {
-            return
+            return []
         }
 
         let mainPaneCount = min(windows.count, layout.mainPaneCount)
@@ -35,29 +35,32 @@ final class TallReflowOperation: ReflowOperation {
 
         let focusedWindow = SIWindow.focused()
 
-        let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
-            var assignments = frameAssignments
+        return windows.reduce([]) { acc, window -> [FrameAssignment] in
+            var assignments = acc
             var windowFrame = CGRect.zero
 
-            if frameAssignments.count < mainPaneCount {
+            if acc.count < mainPaneCount {
                 windowFrame.origin.x = screenFrame.origin.x
-                windowFrame.origin.y = screenFrame.origin.y + (mainPaneWindowHeight * CGFloat(frameAssignments.count))
+                windowFrame.origin.y = screenFrame.origin.y + (mainPaneWindowHeight * CGFloat(acc.count))
                 windowFrame.size.width = mainPaneWindowWidth
                 windowFrame.size.height = mainPaneWindowHeight
             } else {
                 windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth
-                windowFrame.origin.y = screenFrame.origin.y + (secondaryPaneWindowHeight * CGFloat(frameAssignments.count - mainPaneCount))
+                windowFrame.origin.y = screenFrame.origin.y + (secondaryPaneWindowHeight * CGFloat(acc.count - mainPaneCount))
                 windowFrame.size.width = secondaryPaneWindowWidth
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
+            print("Framing \(windowFrame)\thas \(window.title())")
             let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
 
             assignments.append(frameAssignment)
 
             return assignments
         }
+    }
 
+    override func main() {
         guard !isCancelled else {
             return
         }
@@ -82,6 +85,11 @@ final class TallLayout: Layout {
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
         return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
+
+    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
+        return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    }
+
 }
 
 extension TallLayout: PanedLayout {

--- a/Amethyst/Layout/TallLayout.swift
+++ b/Amethyst/Layout/TallLayout.swift
@@ -86,8 +86,8 @@ final class TallLayout: Layout {
         return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 
-    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
-        return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+        return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
 
 }

--- a/Amethyst/Layout/TallLayout.swift
+++ b/Amethyst/Layout/TallLayout.swift
@@ -96,7 +96,7 @@ final class TallLayout: Layout {
 }
 
 extension TallLayout: PanedLayout {
-    func setMainPaneRawRatio(rawRatio: CGFloat) {
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
         mainPaneRatio = rawRatio
     }
 

--- a/Amethyst/Layout/TallLayout.swift
+++ b/Amethyst/Layout/TallLayout.swift
@@ -38,20 +38,25 @@ final class TallReflowOperation: ReflowOperation {
         return windows.reduce([]) { acc, window -> [FrameAssignment] in
             var assignments = acc
             var windowFrame = CGRect.zero
+            let isMain = acc.count < mainPaneCount
+            var scaleFactor: CGFloat
 
-            if acc.count < mainPaneCount {
+            if isMain {
+                scaleFactor = screenFrame.size.width / mainPaneWindowWidth
                 windowFrame.origin.x = screenFrame.origin.x
                 windowFrame.origin.y = screenFrame.origin.y + (mainPaneWindowHeight * CGFloat(acc.count))
                 windowFrame.size.width = mainPaneWindowWidth
                 windowFrame.size.height = mainPaneWindowHeight
             } else {
+                scaleFactor = screenFrame.size.width / secondaryPaneWindowWidth
                 windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth
                 windowFrame.origin.y = screenFrame.origin.y + (secondaryPaneWindowHeight * CGFloat(acc.count - mainPaneCount))
                 windowFrame.size.width = secondaryPaneWindowWidth
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
+            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)
 

--- a/Amethyst/Layout/TallLayout.swift
+++ b/Amethyst/Layout/TallLayout.swift
@@ -80,7 +80,7 @@ final class TallLayout: Layout {
     let windowActivityCache: WindowActivityCache
 
     fileprivate var mainPaneCount: Int = 1
-    internal var mainPaneRatio: CGFloat = 0.5
+    fileprivate(set) var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache

--- a/Amethyst/Layout/TallRightLayout.swift
+++ b/Amethyst/Layout/TallRightLayout.swift
@@ -85,8 +85,8 @@ final class TallRightLayout: Layout {
         return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 
-    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
-        return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+        return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
 
 }

--- a/Amethyst/Layout/TallRightLayout.swift
+++ b/Amethyst/Layout/TallRightLayout.swift
@@ -16,9 +16,9 @@ final class TallRightReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    override func main() {
+    var frameAssignments: [FrameAssignment] {
         guard !windows.isEmpty else {
-            return
+            return []
         }
 
         let mainPaneCount = min(windows.count, layout.mainPaneCount)
@@ -35,7 +35,7 @@ final class TallRightReflowOperation: ReflowOperation {
 
         let focusedWindow = SIWindow.focused()
 
-        let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
+        return windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
             var windowFrame = CGRect.zero
 
@@ -57,8 +57,10 @@ final class TallRightReflowOperation: ReflowOperation {
 
             return assignments
         }
+    }
 
-        guard !isCancelled else {
+    override func main() {
+         guard !isCancelled else {
             return
         }
 
@@ -82,6 +84,11 @@ final class TallRightLayout: Layout {
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
         return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
+
+    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
+        return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    }
+
 }
 
 extension TallRightLayout: PanedLayout {

--- a/Amethyst/Layout/TallRightLayout.swift
+++ b/Amethyst/Layout/TallRightLayout.swift
@@ -55,7 +55,7 @@ final class TallRightReflowOperation: ReflowOperation {
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
+            let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .horizontal, scaleFactor: scaleFactor)
             let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)

--- a/Amethyst/Layout/TallRightLayout.swift
+++ b/Amethyst/Layout/TallRightLayout.swift
@@ -80,7 +80,7 @@ final class TallRightLayout: Layout {
     let windowActivityCache: WindowActivityCache
 
     fileprivate var mainPaneCount: Int = 1
-    internal var mainPaneRatio: CGFloat = 0.5
+    fileprivate(set) var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache

--- a/Amethyst/Layout/TallRightLayout.swift
+++ b/Amethyst/Layout/TallRightLayout.swift
@@ -16,7 +16,7 @@ final class TallRightReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    var frameAssignments: [FrameAssignment] {
+    func frameAssignments() -> [FrameAssignment] {
         guard !windows.isEmpty else {
             return []
         }
@@ -69,7 +69,7 @@ final class TallRightReflowOperation: ReflowOperation {
             return
         }
 
-        frameAssigner.performFrameAssignments(frameAssignments)
+        frameAssigner.performFrameAssignments(frameAssignments())
     }
 }
 
@@ -91,7 +91,7 @@ final class TallRightLayout: Layout {
     }
 
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
+        return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/TallRightLayout.swift
+++ b/Amethyst/Layout/TallRightLayout.swift
@@ -75,7 +75,7 @@ final class TallRightLayout: Layout {
     let windowActivityCache: WindowActivityCache
 
     fileprivate var mainPaneCount: Int = 1
-    fileprivate var mainPaneRatio: CGFloat = 0.5
+    internal var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache
@@ -88,16 +88,11 @@ final class TallRightLayout: Layout {
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
         return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
-
 }
 
 extension TallRightLayout: PanedLayout {
-    func expandMainPane() {
-        mainPaneRatio = min(1, mainPaneRatio + UserConfiguration.shared.windowResizeStep())
-    }
-
-    func shrinkMainPane() {
-        mainPaneRatio = max(0, mainPaneRatio - UserConfiguration.shared.windowResizeStep())
+    func setMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
     func increaseMainPaneCount() {

--- a/Amethyst/Layout/TallRightLayout.swift
+++ b/Amethyst/Layout/TallRightLayout.swift
@@ -38,20 +38,25 @@ final class TallRightReflowOperation: ReflowOperation {
         return windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
             var windowFrame = CGRect.zero
+            let isMain = frameAssignments.count < mainPaneCount
+            var scaleFactor: CGFloat
 
-            if frameAssignments.count < mainPaneCount {
+            if isMain {
+                scaleFactor = screenFrame.size.width / mainPaneWindowWidth
                 windowFrame.origin.x = screenFrame.origin.x + secondaryPaneWindowWidth
                 windowFrame.origin.y = screenFrame.origin.y + (mainPaneWindowHeight * CGFloat(frameAssignments.count))
                 windowFrame.size.width = mainPaneWindowWidth
                 windowFrame.size.height = mainPaneWindowHeight
             } else {
+                scaleFactor = screenFrame.size.width / secondaryPaneWindowWidth
                 windowFrame.origin.x = screenFrame.origin.x
                 windowFrame.origin.y = screenFrame.maxY - (secondaryPaneWindowHeight * CGFloat(frameAssignments.count - mainPaneCount + 1))
                 windowFrame.size.width = secondaryPaneWindowWidth
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
+            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)
 

--- a/Amethyst/Layout/TallRightLayout.swift
+++ b/Amethyst/Layout/TallRightLayout.swift
@@ -96,7 +96,7 @@ final class TallRightLayout: Layout {
 }
 
 extension TallRightLayout: PanedLayout {
-    func setMainPaneRawRatio(rawRatio: CGFloat) {
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
         mainPaneRatio = rawRatio
     }
 

--- a/Amethyst/Layout/WideLayout.swift
+++ b/Amethyst/Layout/WideLayout.swift
@@ -38,20 +38,25 @@ private final class WideReflowOperation: ReflowOperation {
         return windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
             var windowFrame = CGRect.zero
+            let isMain = frameAssignments.count < mainPaneCount
+            var scaleFactor: CGFloat
 
-            if frameAssignments.count < mainPaneCount {
+            if isMain {
+                scaleFactor = screenFrame.height / mainPaneWindowHeight
                 windowFrame.origin.x = screenFrame.origin.x + (mainPaneWindowWidth * CGFloat(frameAssignments.count))
                 windowFrame.origin.y = screenFrame.origin.y
                 windowFrame.size.width = mainPaneWindowWidth
                 windowFrame.size.height = mainPaneWindowHeight
             } else {
+                scaleFactor = screenFrame.height / secondaryPaneWindowHeight
                 windowFrame.origin.x = screenFrame.origin.x + (secondaryPaneWindowWidth * CGFloat(frameAssignments.count - mainPaneCount))
                 windowFrame.origin.y = screenFrame.origin.y + mainPaneWindowHeight
                 windowFrame.size.width = secondaryPaneWindowWidth
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .vertical)
+            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)
 

--- a/Amethyst/Layout/WideLayout.swift
+++ b/Amethyst/Layout/WideLayout.swift
@@ -55,7 +55,7 @@ private final class WideReflowOperation: ReflowOperation {
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .vertical)
+            let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .vertical, scaleFactor: scaleFactor)
             let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)

--- a/Amethyst/Layout/WideLayout.swift
+++ b/Amethyst/Layout/WideLayout.swift
@@ -16,7 +16,7 @@ private final class WideReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    var frameAssignments: [FrameAssignment] {
+    func frameAssignments() -> [FrameAssignment] {
         guard !windows.isEmpty else {
             return []
         }
@@ -70,7 +70,7 @@ private final class WideReflowOperation: ReflowOperation {
             return
         }
 
-        frameAssigner.performFrameAssignments(frameAssignments)
+        frameAssigner.performFrameAssignments(frameAssignments())
     }
 }
 
@@ -92,7 +92,7 @@ final class WideLayout: Layout {
     }
 
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return WideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
+        return WideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/WideLayout.swift
+++ b/Amethyst/Layout/WideLayout.swift
@@ -81,7 +81,7 @@ final class WideLayout: Layout {
     let windowActivityCache: WindowActivityCache
 
     fileprivate var mainPaneCount: Int = 1
-    internal var mainPaneRatio: CGFloat = 0.5
+    fileprivate(set) var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache

--- a/Amethyst/Layout/WideLayout.swift
+++ b/Amethyst/Layout/WideLayout.swift
@@ -76,7 +76,7 @@ final class WideLayout: Layout {
     let windowActivityCache: WindowActivityCache
 
     fileprivate var mainPaneCount: Int = 1
-    fileprivate var mainPaneRatio: CGFloat = 0.5
+    internal var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache
@@ -92,12 +92,8 @@ final class WideLayout: Layout {
 }
 
 extension WideLayout: PanedLayout {
-    func expandMainPane() {
-        mainPaneRatio = min(1, mainPaneRatio + UserConfiguration.shared.windowResizeStep())
-    }
-
-    func shrinkMainPane() {
-        mainPaneRatio = max(0, mainPaneRatio - UserConfiguration.shared.windowResizeStep())
+    func setMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
     func increaseMainPaneCount() {

--- a/Amethyst/Layout/WideLayout.swift
+++ b/Amethyst/Layout/WideLayout.swift
@@ -86,8 +86,8 @@ final class WideLayout: Layout {
         return WideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 
-    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
-        return WideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+        return WideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/WideLayout.swift
+++ b/Amethyst/Layout/WideLayout.swift
@@ -97,7 +97,7 @@ final class WideLayout: Layout {
 }
 
 extension WideLayout: PanedLayout {
-    func setMainPaneRawRatio(rawRatio: CGFloat) {
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
         mainPaneRatio = rawRatio
     }
 

--- a/Amethyst/Layout/WideLayout.swift
+++ b/Amethyst/Layout/WideLayout.swift
@@ -16,9 +16,9 @@ private final class WideReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    override func main() {
+    var frameAssignments: [FrameAssignment] {
         guard !windows.isEmpty else {
-            return
+            return []
         }
 
         let mainPaneCount = min(windows.count, layout.mainPaneCount)
@@ -35,7 +35,7 @@ private final class WideReflowOperation: ReflowOperation {
 
         let focusedWindow = SIWindow.focused()
 
-        let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
+        return windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
             var windowFrame = CGRect.zero
 
@@ -57,6 +57,9 @@ private final class WideReflowOperation: ReflowOperation {
 
             return assignments
         }
+    }
+
+    override func main() {
 
         guard !isCancelled else {
             return
@@ -81,6 +84,10 @@ final class WideLayout: Layout {
 
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
         return WideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
+    }
+
+    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
+        return WideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/WidescreenTallLayout.swift
+++ b/Amethyst/Layout/WidescreenTallLayout.swift
@@ -57,7 +57,7 @@ final class WidescreenTallReflowOperation: ReflowOperation {
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
+            let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .horizontal, scaleFactor: scaleFactor)
             let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)

--- a/Amethyst/Layout/WidescreenTallLayout.swift
+++ b/Amethyst/Layout/WidescreenTallLayout.swift
@@ -40,20 +40,25 @@ final class WidescreenTallReflowOperation: ReflowOperation {
             var assignments = frameAssignments
             var windowFrame = CGRect.zero
             let windowIndex = frameAssignments.count
+            let isMain = windowIndex < mainPaneCount
+            var scaleFactor: CGFloat
 
-            if windowIndex < mainPaneCount {
+            if isMain {
+                scaleFactor = CGFloat(screenFrame.size.width / mainPaneWindowWidth)
                 windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth * CGFloat(windowIndex)
                 windowFrame.origin.y = screenFrame.origin.y
                 windowFrame.size.width = mainPaneWindowWidth
                 windowFrame.size.height = mainPaneWindowHeight
             } else {
+                scaleFactor = CGFloat(screenFrame.size.width / secondaryPaneWindowWidth)
                 windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth * CGFloat(mainPaneCount)
                 windowFrame.origin.y = screenFrame.origin.y + (secondaryPaneWindowHeight * CGFloat(windowIndex - mainPaneCount))
                 windowFrame.size.width = secondaryPaneWindowWidth
                 windowFrame.size.height = secondaryPaneWindowHeight
             }
 
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame)
+            let resizeRules = ResizeRules(isMain: isMain, scaleFactor: scaleFactor, unconstrainedDimension: .horizontal)
+            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isEqual(to: focusedWindow), screenFrame: screenFrame, resizeRules: resizeRules)
 
             assignments.append(frameAssignment)
 

--- a/Amethyst/Layout/WidescreenTallLayout.swift
+++ b/Amethyst/Layout/WidescreenTallLayout.swift
@@ -83,7 +83,7 @@ final class WidescreenTallLayout: Layout {
     let windowActivityCache: WindowActivityCache
 
     fileprivate var mainPaneCount: Int = 1
-    internal var mainPaneRatio: CGFloat = 0.5
+    fileprivate(set) var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache

--- a/Amethyst/Layout/WidescreenTallLayout.swift
+++ b/Amethyst/Layout/WidescreenTallLayout.swift
@@ -16,7 +16,7 @@ final class WidescreenTallReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    var frameAssignments: [FrameAssignment] {
+    func frameAssignments() -> [FrameAssignment] {
         if windows.count == 0 {
             return []
         }
@@ -72,7 +72,7 @@ final class WidescreenTallReflowOperation: ReflowOperation {
             return
         }
 
-        frameAssigner.performFrameAssignments(frameAssignments)
+        frameAssigner.performFrameAssignments(frameAssignments())
     }
 }
 
@@ -94,7 +94,7 @@ final class WidescreenTallLayout: Layout {
     }
 
     func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return WidescreenTallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
+        return WidescreenTallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/WidescreenTallLayout.swift
+++ b/Amethyst/Layout/WidescreenTallLayout.swift
@@ -44,7 +44,7 @@ final class WidescreenTallReflowOperation: ReflowOperation {
             var scaleFactor: CGFloat
 
             if isMain {
-                scaleFactor = CGFloat(screenFrame.size.width / mainPaneWindowWidth)
+                scaleFactor = CGFloat(screenFrame.size.width / mainPaneWindowWidth) / CGFloat(mainPaneCount)
                 windowFrame.origin.x = screenFrame.origin.x + mainPaneWindowWidth * CGFloat(windowIndex)
                 windowFrame.origin.y = screenFrame.origin.y
                 windowFrame.size.width = mainPaneWindowWidth

--- a/Amethyst/Layout/WidescreenTallLayout.swift
+++ b/Amethyst/Layout/WidescreenTallLayout.swift
@@ -99,7 +99,7 @@ final class WidescreenTallLayout: Layout {
 }
 
 extension WidescreenTallLayout: PanedLayout {
-    func setMainPaneRawRatio(rawRatio: CGFloat) {
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
         mainPaneRatio = rawRatio
     }
 

--- a/Amethyst/Layout/WidescreenTallLayout.swift
+++ b/Amethyst/Layout/WidescreenTallLayout.swift
@@ -16,9 +16,9 @@ final class WidescreenTallReflowOperation: ReflowOperation {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    override func main() {
+    var frameAssignments: [FrameAssignment] {
         if windows.count == 0 {
-            return
+            return []
         }
 
         let mainPaneCount = min(windows.count, layout.mainPaneCount)
@@ -36,7 +36,7 @@ final class WidescreenTallReflowOperation: ReflowOperation {
 
         let focusedWindow = SIWindow.focused()
 
-        let frameAssignments = windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
+        return windows.reduce([]) { frameAssignments, window -> [FrameAssignment] in
             var assignments = frameAssignments
             var windowFrame = CGRect.zero
             let windowIndex = frameAssignments.count
@@ -59,6 +59,9 @@ final class WidescreenTallReflowOperation: ReflowOperation {
 
             return assignments
         }
+    }
+
+    override func main() {
 
         if isCancelled {
             return
@@ -83,6 +86,10 @@ final class WidescreenTallLayout: Layout {
 
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
         return WidescreenTallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
+    }
+
+    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
+        return WidescreenTallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/WidescreenTallLayout.swift
+++ b/Amethyst/Layout/WidescreenTallLayout.swift
@@ -88,8 +88,8 @@ final class WidescreenTallLayout: Layout {
         return WidescreenTallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 
-    func windowHasAssignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> Bool {
-        return WidescreenTallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.contains { $0.window == window }
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+        return WidescreenTallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments.first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/WidescreenTallLayout.swift
+++ b/Amethyst/Layout/WidescreenTallLayout.swift
@@ -78,7 +78,7 @@ final class WidescreenTallLayout: Layout {
     let windowActivityCache: WindowActivityCache
 
     fileprivate var mainPaneCount: Int = 1
-    fileprivate var mainPaneRatio: CGFloat = 0.5
+    internal var mainPaneRatio: CGFloat = 0.5
 
     init(windowActivityCache: WindowActivityCache) {
         self.windowActivityCache = windowActivityCache
@@ -94,12 +94,8 @@ final class WidescreenTallLayout: Layout {
 }
 
 extension WidescreenTallLayout: PanedLayout {
-    func expandMainPane() {
-        mainPaneRatio = min(1, mainPaneRatio + UserConfiguration.shared.windowResizeStep())
-    }
-
-    func shrinkMainPane() {
-        mainPaneRatio = max(0, mainPaneRatio - UserConfiguration.shared.windowResizeStep())
+    func setMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
     func increaseMainPaneCount() {

--- a/Amethyst/Managers/FocusFollowsMouseManager.swift
+++ b/Amethyst/Managers/FocusFollowsMouseManager.swift
@@ -37,7 +37,7 @@ final class FocusFollowsMouseManager {
         }
 
         var mousePoint = NSPointToCGPoint(event.locationInWindow)
-        mousePoint.y = NSScreen.main!.frame.size.height - mousePoint.y
+        mousePoint.y = NSScreen.globalHeight() - mousePoint.y
 
         if let focusedWindow = SIWindow.focused() {
             // If the point is already in the frame of the focused window do nothing.

--- a/Amethyst/Managers/HotKeyRegistrar.swift
+++ b/Amethyst/Managers/HotKeyRegistrar.swift
@@ -25,7 +25,7 @@ extension HotKeyManager: HotKeyRegistrar {
 
         // If a command is specified, set it as the default shortcut
         if let string = string, let modifiers = modifiers {
-            if let keyCodes = stringToKeyCodes[string.lowercased()], keyCodes.count > 0 {
+            if let keyCodes = stringToKeyCodes[string.lowercased()], !keyCodes.isEmpty {
                 let shortcut = MASShortcut(keyCode: UInt(keyCodes[0]), modifierFlags: modifiers)
                 MASShortcutBinder.shared().registerDefaultShortcuts([ defaultsKey: shortcut as Any ])
             } else {

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -63,7 +63,7 @@ final class ScreenManager: NSObject {
             }
         }
     }
-    private var currentLayout: Layout? {
+    var currentLayout: Layout? {
         guard !layouts.isEmpty else {
             return nil
         }

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -91,7 +91,7 @@ final class ScreenManager: NSObject {
         layouts = LayoutManager.layoutsWithConfiguration(userConfiguration, windowActivityCache: self)
     }
 
-    func setNeedsReflowWithWindowChange(_ windowChange: WindowChange) {
+    func setNeedsReflowWithWindowChange(_ windowChange: WindowChange, windowFilter isWindowIncluded: @escaping (SIWindow) -> Bool) {
         reflowOperation?.cancel()
 
         LogManager.log?.debug("Screen: \(screenIdentifier) -- Window Change: \(windowChange)")
@@ -104,16 +104,21 @@ final class ScreenManager: NSObject {
             // The 0.4 is disgustingly tied to the space change animation time.
             // This should get burned to the ground when space changes don't rely on the mouse click trick.
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(UInt64(0.4) * NSEC_PER_SEC)) / Double(NSEC_PER_SEC)) {
-                self.reflow(windowChange)
+                self.reflow(windowChange, windowFilter: isWindowIncluded)
             }
         } else {
             DispatchQueue.main.async {
-                self.reflow(windowChange)
+                self.reflow(windowChange, windowFilter: isWindowIncluded)
             }
         }
     }
 
-    private func reflow(_ change: WindowChange) {
+    func setNeedsReflowWithWindowChange(_ windowChange: WindowChange) {
+        setNeedsReflowWithWindowChange(windowChange) { _ in true }
+    }
+
+    // reflow some windows, according to filter
+    private func reflow(_ change: WindowChange, windowFilter isWindowIncluded: (SIWindow) -> Bool) {
         guard currentSpaceIdentifier != nil &&
             currentLayoutIndex < layouts.count &&
             userConfiguration.tilingEnabled &&
@@ -123,10 +128,15 @@ final class ScreenManager: NSObject {
             return
         }
 
-        let windows = delegate?.activeWindowsForScreenManager(self) ?? []
+        let windows = (delegate?.activeWindowsForScreenManager(self) ?? []).filter(isWindowIncluded)
         changingSpace = false
         reflowOperation = currentLayout?.reflow(windows, on: screen)
         OperationQueue.main.addOperation(reflowOperation!)
+    }
+
+    // reflow all windows
+    private func reflow(_ change: WindowChange) {
+        reflow(change) { _ in true }
     }
 
     func updateCurrentLayout(_ updater: (Layout) -> Void) {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -13,7 +13,7 @@ import RxSwiftExt
 import Silica
 import SwiftyJSON
 
-fileprivate let mouseDragRaceThresholdSeconds = 0.15
+private let mouseDragRaceThresholdSeconds = 0.15
 
 enum WindowChange {
     case add(window: SIWindow)

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -78,6 +78,10 @@ private struct ObserveApplicationNotifications {
             }
 
             application.observeNotification(kAXWindowMovedNotification as CFString!, with: application) { accessibilityElement in
+                guard windowManager.userConfiguration.mouseSwapsWindows() else {
+                    return
+                }
+
                 guard accessibilityElement is SIWindow else {
                     return
                 }

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -183,15 +183,8 @@ private class ObserveApplicationNotifications {
                     return
                 }
 
-                guard let screen = movedWindow.screen() else {
-                    return
-                }
-
-                guard windowManager.activeWindows(on: screen).contains(movedWindow) else {
-                    return
-                }
-
-                guard !windowManager.windowIsFloating(movedWindow) else {
+                guard let screen = movedWindow.screen(),
+                    windowManager.activeWindows(on: screen).contains(movedWindow) else {
                     return
                 }
 

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -31,7 +31,7 @@ enum MouseState {
 }
 
 protocol MouseStateKeeperDelegate: class {
-	func focusedScreenManager() -> ScreenManager?
+    func focusedScreenManager() -> ScreenManager?
     func windows(on screen: NSScreen) -> [SIWindow]
     func switchWindow(_ window: SIWindow, with otherWindow: SIWindow)
 }

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -208,7 +208,7 @@ private class ObserveApplicationNotifications {
 
             application.observeNotification(kAXWindowResizedNotification as CFString!, with: application) { accessibilityElement in
 
-                guard windowManager.userConfiguration.mouseSwapsWindows() else {
+                guard windowManager.userConfiguration.mouseResizesWindows() else {
                     return
                 }
 

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -456,10 +456,14 @@ final class WindowManager: NSObject {
         markAllScreensForReflowWithChange(.unknown)
     }
 
-    func markAllScreensForReflowWithChange(_ windowChange: WindowChange) {
+    func markAllScreensForReflowWithChange(_ windowChange: WindowChange, windowFilter isWindowIncluded: @escaping (SIWindow) -> Bool) {
         for screenManager in screenManagers {
-            screenManager.setNeedsReflowWithWindowChange(windowChange)
+            screenManager.setNeedsReflowWithWindowChange(windowChange, windowFilter: isWindowIncluded)
         }
+    }
+
+    func markAllScreensForReflowWithChange(_ windowChange: WindowChange) {
+        markAllScreensForReflowWithChange(windowChange) { _ in true }
     }
 
     func displayCurrentLayout() {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -62,8 +62,8 @@ class MouseStateKeeper {
                 case .leftMouseDragged:
                     switch self.state {
                     case .moving, .resizing:
-                        () // ignore - we have what we need
-                    default:
+                        break // ignore - we have what we need
+                    case .pointing, .clicking, .dragging, .doneDragging:
                         self.state = .dragging
                     }
 
@@ -79,7 +79,7 @@ class MouseStateKeeper {
                         self.state = .pointing
                     case .doneDragging:
                         self.state = .doneDragging(atTime: NSDate()) // reset the clock I guess
-                    default:
+                    case .pointing, .clicking:
                         self.state = .pointing
                     }
 

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -602,14 +602,10 @@ final class WindowManager: NSObject {
         markAllScreensForReflowWithChange(.unknown)
     }
 
-    func markAllScreensForReflowWithChange(_ windowChange: WindowChange, windowFilter isWindowIncluded: @escaping (SIWindow) -> Bool) {
-        for screenManager in screenManagers {
-            screenManager.setNeedsReflowWithWindowChange(windowChange, windowFilter: isWindowIncluded)
-        }
-    }
-
     func markAllScreensForReflowWithChange(_ windowChange: WindowChange) {
-        markAllScreensForReflowWithChange(windowChange) { _ in true }
+        for screenManager in screenManagers {
+            screenManager.setNeedsReflowWithWindowChange(windowChange)
+        }
     }
 
     func displayCurrentLayout() {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -165,6 +165,15 @@ private struct ObserveApplicationNotifications {
                     return
                 }
 
+                // Do a more in-depth check; make sure the window being dragged is being managed
+                guard let screenManager = windowManager.focusedScreenManager(),
+                    let layout = screenManager.currentLayout,
+                    let screen = movedWindow.screen(),
+                    layout.windowHasAssignedFrame(movedWindow, of: windowManager.activeWindowsForScreenManager(screenManager), on: screen) else {
+                    mouseState = .pointing
+                    return
+                }
+
                 guard !windowManager.windowIsFloating(movedWindow) else {
                     return
                 }

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -78,7 +78,7 @@ private struct ObserveApplicationNotifications {
             }
 
             application.observeNotification(kAXWindowMovedNotification as CFString!, with: application) { accessibilityElement in
-                guard let window = accessibilityElement as? SIWindow else {
+                guard accessibilityElement is SIWindow else {
                     return
                 }
 

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -183,13 +183,12 @@ private class ObserveApplicationNotifications {
                     return
                 }
 
-                // Do a more in-depth check; make sure the window being dragged is being managed
-                guard let screenManager = windowManager.focusedScreenManager(),
-                    let layout = screenManager.currentLayout,
-                    let screen = movedWindow.screen(),
-                    layout.windowHasAssignedFrame(movedWindow, of: windowManager.activeWindowsForScreenManager(screenManager), on: screen) else {
-                        self.mouse.state = .pointing
-                        return
+                guard let screen = movedWindow.screen() else {
+                    return
+                }
+
+                guard windowManager.activeWindows(on: screen).contains(movedWindow) else {
+                    return
                 }
 
                 guard !windowManager.windowIsFloating(movedWindow) else {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -90,9 +90,9 @@ private struct ObserveApplicationNotifications {
 
                 // need to flip mouse coordinate system to fit Amethyst https://stackoverflow.com/a/42901022/2063546
                 let flippedPointerLocation = NSPointToCGPoint(NSEvent.mouseLocation)
-                let screenFrame = (NSScreen.main?.frame)!
-                let unflippedY = screenFrame.size.height - flippedPointerLocation.y
-                let pointerLocation = NSPoint(x: flippedPointerLocation.x, y: unflippedY)
+                let heightMax = NSScreen.screens.map {$0.frame.origin.y + $0.frame.height}.max()!
+                let unflippedY = heightMax - flippedPointerLocation.y
+                let pointerLocation = NSPointToCGPoint(NSPoint(x: flippedPointerLocation.x, y: unflippedY))
 
                 // Ignore if there is no window at that point
                 guard let secondWindow = SIWindow.secondWindowForScreenAtPoint(pointerLocation, withWindows: windows) else {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -48,10 +48,10 @@ private class ObserveApplicationNotifications {
     fileprivate let windowManager: WindowManager
     fileprivate let mouse: MouseStateKeeper
 
-    init(application app: SIApplication, windowManager wm: WindowManager) {
-        application = app
-        windowManager = wm
-        mouse = wm.mouseStateKeeper
+    init(application theApp: SIApplication, windowManager theWM: WindowManager) {
+        application = theApp
+        windowManager = theWM
+        mouse = theWM.mouseStateKeeper
     }
 
     fileprivate func addObservers() -> Observable<Bool> {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -166,24 +166,13 @@ private class ObserveApplicationNotifications {
                     return
                 }
 
-                guard let focusedWindow = SIWindow.focused() else {
-                    return
-                }
-
-                guard focusedWindow == movedWindow else {
-                    // Explicitly reset mouse state if what we are dragging isn't a real window.  e.g. Giphy Capture
-                    if case .moving(window: _) = mouseState {
-                        mouseState = .pointing
-                    }
-                    return
-                }
-
+                // Do a more in-depth check; make sure the window being dragged is being managed
                 guard let screenManager = windowManager.focusedScreenManager(),
                     let layout = screenManager.currentLayout,
                     let screen = movedWindow.screen(),
                     layout.windowHasAssignedFrame(movedWindow, of: windowManager.activeWindowsForScreenManager(screenManager), on: screen) else {
                         self.mouse.state = .pointing
-                    return
+                        return
                 }
 
                 guard !windowManager.windowIsFloating(movedWindow) else {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -90,8 +90,7 @@ private struct ObserveApplicationNotifications {
 
                 // need to flip mouse coordinate system to fit Amethyst https://stackoverflow.com/a/42901022/2063546
                 let flippedPointerLocation = NSPointToCGPoint(NSEvent.mouseLocation)
-                let heightMax = NSScreen.screens.map {$0.frame.origin.y + $0.frame.height}.max()!
-                let unflippedY = heightMax - flippedPointerLocation.y
+                let unflippedY = NSScreen.globalHeight() - flippedPointerLocation.y
                 let pointerLocation = NSPointToCGPoint(NSPoint(x: flippedPointerLocation.x, y: unflippedY))
 
                 // Ignore if there is no window at that point

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -48,7 +48,7 @@ private struct ObserveApplicationNotifications {
         let pointerLocation = NSPointToCGPoint(NSPoint(x: flippedPointerLocation.x, y: unflippedY))
 
         // Ignore if there is no window at that point
-        guard let secondWindow = SIWindow.secondWindowForScreenAtPoint(pointerLocation, withWindows: windows) else {
+        guard let secondWindow = SIWindow.alternateWindowForScreenAtPoint(pointerLocation, withWindows: windows, butNot: draggedWindow) else {
             return
         }
         windowManager.switchWindow(draggedWindow, with: secondWindow)

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -89,7 +89,7 @@ class MouseStateKeeper {
                         self.state = .pointing
                         self.delegate.focusedScreenManager()?.updateCurrentLayout { layout in
                             if let panedLayout = layout as? PanedLayout {
-                                panedLayout.setMainPaneRatio(ratio)
+                                panedLayout.recommendMainPaneRatio(ratio)
                             }
                         }
                     case .doneDragging:
@@ -253,7 +253,7 @@ private class ObserveApplicationNotifications {
                         self.mouse.state = .pointing // flip state first to prevent race condition
                         windowManager.focusedScreenManager()?.updateCurrentLayout { layout in
                             if let panedLayout = layout as? PanedLayout {
-                                panedLayout.setMainPaneRatio(ratio)
+                                panedLayout.recommendMainPaneRatio(ratio)
                             }
                         }
                     }

--- a/Amethyst/Managers/WindowModifier.swift
+++ b/Amethyst/Managers/WindowModifier.swift
@@ -443,7 +443,7 @@ extension WindowManager: WindowMover {
         return floatingMap[window.windowID()] ?? false
     }
 
-    func switchWindow(_ window: SIWindow, with otherWindow: SIWindow, whileDragging windowToNotReflow: SIWindow?) {
+    func switchWindow(_ window: SIWindow, with otherWindow: SIWindow) {
         guard let windowIndex = windows.index(of: window), let otherWindowIndex = windows.index(of: otherWindow) else {
             return
         }
@@ -452,15 +452,7 @@ extension WindowManager: WindowMover {
         windows[otherWindowIndex] = window
         let theChange = WindowChange.windowSwap(window: window, otherWindow: otherWindow)
 
-        guard let windowBeingDragged = windowToNotReflow else {
-            return markAllScreensForReflowWithChange(theChange)
-        }
-
-        markAllScreensForReflowWithChange(theChange) { $0.windowID() != windowBeingDragged.windowID() }
-    }
-
-    func switchWindow(_ window: SIWindow, with otherWindow: SIWindow) {
-        switchWindow(window, with: otherWindow, whileDragging: nil)
+        markAllScreensForReflowWithChange(theChange)
     }
 }
 

--- a/Amethyst/Managers/WindowModifier.swift
+++ b/Amethyst/Managers/WindowModifier.swift
@@ -443,15 +443,24 @@ extension WindowManager: WindowMover {
         return floatingMap[window.windowID()] ?? false
     }
 
-    func switchWindow(_ window: SIWindow, with otherWindow: SIWindow) {
+    func switchWindow(_ window: SIWindow, with otherWindow: SIWindow, whileDragging windowToNotReflow: SIWindow?) {
         guard let windowIndex = windows.index(of: window), let otherWindowIndex = windows.index(of: otherWindow) else {
             return
         }
 
         windows[windowIndex] = otherWindow
         windows[otherWindowIndex] = window
+        let theChange = WindowChange.windowSwap(window: window, otherWindow: otherWindow)
 
-        markAllScreensForReflowWithChange(.windowSwap(window: window, otherWindow: otherWindow))
+        guard let windowBeingDragged = windowToNotReflow else {
+            return markAllScreensForReflowWithChange(theChange)
+        }
+
+        markAllScreensForReflowWithChange(theChange) { $0.windowID() != windowBeingDragged.windowID() }
+    }
+
+    func switchWindow(_ window: SIWindow, with otherWindow: SIWindow) {
+        switchWindow(window, with: otherWindow, whileDragging: nil)
     }
 }
 

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -15,11 +15,11 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customView id="LsO-9M-hEw" userLabel="General Preferences">
-            <rect key="frame" x="0.0" y="0.0" width="468" height="593"/>
+            <rect key="frame" x="0.0" y="0.0" width="468" height="634"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9hq-U6-t9B">
-                    <rect key="frame" x="170" y="422" width="148" height="18"/>
+                    <rect key="frame" x="170" y="463" width="148" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Float small windows" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="phj-M8-HfQ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -30,7 +30,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jbq-77-1YW">
-                    <rect key="frame" x="170" y="314" width="142" height="18"/>
+                    <rect key="frame" x="170" y="355" width="142" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable Layout HUD" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="UVr-KG-wFB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -41,7 +41,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ej5-FV-H6Q">
-                    <rect key="frame" x="170" y="294" width="255" height="18"/>
+                    <rect key="frame" x="170" y="335" width="255" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable Layout HUD on Space Change" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="o6e-e0-t64">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -52,7 +52,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wg4-Ew-VOi">
-                    <rect key="frame" x="107" y="423" width="59" height="17"/>
+                    <rect key="frame" x="107" y="464" width="59" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Floating:" id="H0k-aA-syT">
                         <font key="font" metaFont="system"/>
@@ -61,7 +61,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MKd-ZG-j26">
-                    <rect key="frame" x="83" y="315" width="83" height="17"/>
+                    <rect key="frame" x="83" y="356" width="83" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Layout HUD:" id="dFS-Je-lML">
                         <font key="font" metaFont="system"/>
@@ -70,7 +70,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G9A-P1-Ks1">
-                    <rect key="frame" x="126" y="271" width="40" height="17"/>
+                    <rect key="frame" x="126" y="312" width="40" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Misc.:" id="SoK-X5-vwJ">
                         <font key="font" metaFont="system"/>
@@ -79,7 +79,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TMz-ps-mVD">
-                    <rect key="frame" x="79" y="209" width="87" height="17"/>
+                    <rect key="frame" x="79" y="250" width="87" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Experimental:" id="Kol-kh-2eQ">
                         <font key="font" metaFont="system"/>
@@ -88,7 +88,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pGc-zn-uC7">
-                    <rect key="frame" x="170" y="270" width="133" height="18"/>
+                    <rect key="frame" x="170" y="311" width="133" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Ignore menu bars" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="LKn-n5-1ay">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -99,7 +99,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Eb-EJ-evb">
-                    <rect key="frame" x="170" y="250" width="223" height="18"/>
+                    <rect key="frame" x="170" y="291" width="223" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Mouse follows focused windows" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="6fy-Pu-AhI">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -110,7 +110,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xay-gW-zGw">
-                    <rect key="frame" x="170" y="230" width="223" height="18"/>
+                    <rect key="frame" x="170" y="271" width="223" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Send new windows to main pane" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="stG-cM-1bg">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -121,7 +121,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mtD-Sc-koj">
-                    <rect key="frame" x="170" y="207" width="243" height="18"/>
+                    <rect key="frame" x="170" y="248" width="243" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Focus follows mouse" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="u5m-jH-xzU">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -132,7 +132,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="m3g-TM-DNo">
-                    <rect key="frame" x="170" y="187" width="243" height="18"/>
+                    <rect key="frame" x="170" y="228" width="243" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Swap windows using mouse" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Wzj-wd-uh8">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -143,7 +143,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vRo-Ax-vKh">
-                    <rect key="frame" x="170" y="155" width="280" height="18"/>
+                    <rect key="frame" x="170" y="175" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Get development builds" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="5v8-xo-EWM">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -154,7 +154,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MGP-cm-WTe">
-                    <rect key="frame" x="170" y="115" width="280" height="18"/>
+                    <rect key="frame" x="170" y="135" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable crash reporting" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="T33-wB-9cH">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -165,7 +165,7 @@
                     </connections>
                 </button>
                 <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U6O-Ka-pXq">
-                    <rect key="frame" x="172" y="360" width="251" height="56"/>
+                    <rect key="frame" x="172" y="401" width="251" height="56"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" ambiguous="YES" id="RT8-fN-JDO">
                         <rect key="frame" x="1" y="1" width="249" height="54"/>
@@ -200,16 +200,16 @@
                         </subviews>
                     </clipView>
                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="IwH-cx-YkX">
-                        <rect key="frame" x="-7" y="-14" width="0.0" height="15"/>
+                        <rect key="frame" x="1" y="-15" width="0.0" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="eCG-Tq-r9K">
-                        <rect key="frame" x="-14" y="-7" width="15" height="0.0"/>
+                        <rect key="frame" x="-15" y="1" width="16" height="0.0"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZH0-nz-Yiv">
-                    <rect key="frame" x="172" y="339" width="27" height="23"/>
+                    <rect key="frame" x="172" y="380" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ok9-1r-DwF">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -220,7 +220,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cfp-8K-Cdt">
-                    <rect key="frame" x="198" y="339" width="27" height="23"/>
+                    <rect key="frame" x="198" y="380" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Xif-lH-IK0">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -231,7 +231,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c03-Jd-KsK">
-                    <rect key="frame" x="223" y="339" width="200" height="23"/>
+                    <rect key="frame" x="223" y="380" width="200" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="w8y-WB-Ax2">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -239,7 +239,7 @@
                     </buttonCell>
                 </button>
                 <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kgh-Mo-aGF">
-                    <rect key="frame" x="172" y="488" width="251" height="85"/>
+                    <rect key="frame" x="172" y="529" width="251" height="85"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" ambiguous="YES" id="NPi-lT-8Xb">
                         <rect key="frame" x="1" y="1" width="249" height="83"/>
@@ -274,16 +274,16 @@
                         </subviews>
                     </clipView>
                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="ldJ-I2-SGG">
-                        <rect key="frame" x="-7" y="-14" width="0.0" height="15"/>
+                        <rect key="frame" x="1" y="-15" width="0.0" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="URc-2W-nZo">
-                        <rect key="frame" x="-14" y="-7" width="15" height="0.0"/>
+                        <rect key="frame" x="-15" y="1" width="16" height="0.0"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AUR-i7-d99">
-                    <rect key="frame" x="172" y="467" width="27" height="23"/>
+                    <rect key="frame" x="172" y="508" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="v7u-4j-Gv9">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -294,7 +294,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="khH-XV-GhW">
-                    <rect key="frame" x="198" y="467" width="27" height="23"/>
+                    <rect key="frame" x="198" y="508" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="pcN-ET-p91">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -305,7 +305,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="A8V-CN-miB">
-                    <rect key="frame" x="223" y="467" width="200" height="23"/>
+                    <rect key="frame" x="223" y="508" width="200" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="8al-n7-kkn">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -313,7 +313,7 @@
                     </buttonCell>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M7e-Dw-sVZ">
-                    <rect key="frame" x="110" y="556" width="56" height="17"/>
+                    <rect key="frame" x="110" y="597" width="56" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Layouts:" id="tof-Wx-pYR">
                         <font key="font" metaFont="system"/>
@@ -322,7 +322,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fBD-ab-yJQ">
-                    <rect key="frame" x="170" y="139" width="280" height="15"/>
+                    <rect key="frame" x="170" y="159" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must relaunch for changes to take effect" id="Cak-aF-OC2">
                         <font key="font" metaFont="smallSystem"/>
@@ -331,7 +331,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4eN-rj-3bX">
-                    <rect key="frame" x="170" y="448" width="280" height="15"/>
+                    <rect key="frame" x="170" y="489" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must relaunch for changes to take effect" id="jJZ-0G-DUC">
                         <font key="font" metaFont="smallSystem"/>
@@ -340,7 +340,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ryf-WE-u7b">
-                    <rect key="frame" x="170" y="86" width="280" height="28"/>
+                    <rect key="frame" x="170" y="106" width="280" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Enabling this also sends some anonymous analytics" id="DiA-Hm-lgJ">
                         <font key="font" metaFont="smallSystem"/>
@@ -349,7 +349,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="l9P-32-7UB">
-                    <rect key="frame" x="170" y="85" width="280" height="15"/>
+                    <rect key="frame" x="170" y="105" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must relaunch for changes to take effect" id="2us-TJ-7M2">
                         <font key="font" metaFont="smallSystem"/>
@@ -358,7 +358,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="luh-Gm-ZV0">
-                    <rect key="frame" x="57" y="60" width="109" height="17"/>
+                    <rect key="frame" x="57" y="80" width="109" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Margins:" id="LnD-6G-RSL">
                         <font key="font" metaFont="system"/>
@@ -367,7 +367,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tXC-cK-Yql">
-                    <rect key="frame" x="170" y="59" width="265" height="18"/>
+                    <rect key="frame" x="170" y="79" width="265" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enabled" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="59W-1k-G1j">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -378,7 +378,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ric-uO-1Cb">
-                    <rect key="frame" x="244" y="57" width="40" height="22"/>
+                    <rect key="frame" x="244" y="77" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" usesSingleLineMode="YES" id="Qi6-Bv-Yh1">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="gi8-52-60I">
@@ -397,7 +397,7 @@
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tGv-Wn-caL" userLabel="step size field">
-                    <rect key="frame" x="172" y="31" width="32" height="22"/>
+                    <rect key="frame" x="172" y="51" width="32" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="5" placeholderString="5" drawsBackground="YES" id="Ia5-T5-2gf">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="DNi-LX-9DG"/>
@@ -414,7 +414,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pwW-SE-wmY">
-                    <rect key="frame" x="299" y="60" width="19" height="17"/>
+                    <rect key="frame" x="299" y="80" width="19" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="Qfs-D0-k4Z">
                         <font key="font" metaFont="system"/>
@@ -423,7 +423,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oRH-MS-UAd">
-                    <rect key="frame" x="18" y="33" width="148" height="17"/>
+                    <rect key="frame" x="18" y="53" width="148" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Resize Interval:" id="nKR-ho-85Z">
                         <font key="font" metaFont="system"/>
@@ -432,7 +432,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g66-QF-Hrs">
-                    <rect key="frame" x="202" y="28" width="19" height="27"/>
+                    <rect key="frame" x="202" y="48" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="100" doubleValue="1" id="sPZ-B7-TQF"/>
                     <connections>
@@ -440,7 +440,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SGf-OP-a9f">
-                    <rect key="frame" x="218" y="33" width="15" height="17"/>
+                    <rect key="frame" x="218" y="53" width="15" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="%" id="Dpb-P9-t0R">
                         <font key="font" metaFont="system"/>
@@ -449,7 +449,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VsK-s4-pep">
-                    <rect key="frame" x="282" y="54" width="19" height="27"/>
+                    <rect key="frame" x="282" y="74" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="100" doubleValue="1" id="kSN-EK-HUy"/>
                     <connections>
@@ -458,7 +458,7 @@
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e6w-YL-rzU">
-                    <rect key="frame" x="47" y="182" width="119" height="28"/>
+                    <rect key="frame" x="47" y="223" width="119" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="May have unstable or unexpected behavior" id="em1-tY-3zU">
                         <font key="font" metaFont="smallSystem"/>
@@ -466,8 +466,19 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WI6-fc-YuY">
+                    <rect key="frame" x="170" y="208" width="248" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Resize windows (panes) using mouse" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="mwH-DQ-I0Y">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="value" keyPath="values.mouse-resizes-windows" id="09z-sc-YMk"/>
+                    </connections>
+                </button>
             </subviews>
-            <point key="canvasLocation" x="562" y="319.5"/>
+            <point key="canvasLocation" x="562" y="340"/>
         </customView>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <userDefaultsController id="XhK-Tn-zrU"/>

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13122.19" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13156.6" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13122.19"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13156.6"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -78,6 +78,15 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TMz-ps-mVD">
+                    <rect key="frame" x="79" y="209" width="87" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Experimental:" id="Kol-kh-2eQ">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pGc-zn-uC7">
                     <rect key="frame" x="170" y="270" width="133" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -112,7 +121,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mtD-Sc-koj">
-                    <rect key="frame" x="170" y="210" width="243" height="18"/>
+                    <rect key="frame" x="170" y="207" width="243" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Focus follows mouse" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="u5m-jH-xzU">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -120,6 +129,17 @@
                     </buttonCell>
                     <connections>
                         <binding destination="XhK-Tn-zrU" name="value" keyPath="values.focus-follows-mouse" id="oAA-AT-aLw"/>
+                    </connections>
+                </button>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="m3g-TM-DNo">
+                    <rect key="frame" x="170" y="187" width="243" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Swap windows using mouse" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Wzj-wd-uh8">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="value" keyPath="values.mouse-swaps-windows" id="g99-Of-jvT"/>
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vRo-Ax-vKh">
@@ -319,15 +339,6 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e6w-YL-rzU">
-                    <rect key="frame" x="170" y="181" width="280" height="28"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="This feature is still experimental and may be unstable or have unexpected behavior" id="em1-tY-3zU">
-                        <font key="font" metaFont="smallSystem"/>
-                        <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ryf-WE-u7b">
                     <rect key="frame" x="170" y="86" width="280" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -446,8 +457,17 @@
                         <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.window-margins" id="TKt-Pl-ye5"/>
                     </connections>
                 </stepper>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e6w-YL-rzU">
+                    <rect key="frame" x="47" y="182" width="119" height="28"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="May have unstable or unexpected behavior" id="em1-tY-3zU">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
-            <point key="canvasLocation" x="562" y="320"/>
+            <point key="canvasLocation" x="562" y="319.5"/>
         </customView>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <userDefaultsController id="XhK-Tn-zrU"/>

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -35,6 +35,7 @@ enum ConfigurationKey: String {
     case floatSmallWindows = "float-small-windows"
     case mouseFollowsFocus = "mouse-follows-focus"
     case focusFollowsMouse = "focus-follows-mouse"
+    case mouseSwapsWindows = "mouse-swaps-windows"
     case layoutHUD = "enables-layout-hud"
     case layoutHUDOnSpaceChange = "enables-layout-hud-on-space-change"
     case useCanaryBuild = "use-canary-build"
@@ -50,6 +51,7 @@ enum ConfigurationKey: String {
             .floatSmallWindows,
             .mouseFollowsFocus,
             .focusFollowsMouse,
+            .mouseSwapsWindows,
             .layoutHUD,
             .layoutHUDOnSpaceChange,
             .useCanaryBuild,
@@ -323,6 +325,10 @@ final class UserConfiguration: NSObject {
 
     func toggleFocusFollowsMouse() {
         storage.set(!focusFollowsMouse(), forKey: ConfigurationKey.focusFollowsMouse.rawValue)
+    }
+
+    func mouseSwapsWindows() -> Bool {
+        return storage.bool(forKey: ConfigurationKey.mouseSwapsWindows.rawValue)
     }
 
     func enablesLayoutHUD() -> Bool {

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -36,6 +36,7 @@ enum ConfigurationKey: String {
     case mouseFollowsFocus = "mouse-follows-focus"
     case focusFollowsMouse = "focus-follows-mouse"
     case mouseSwapsWindows = "mouse-swaps-windows"
+    case mouseResizesWindows = "mouse-resizes-windows"
     case layoutHUD = "enables-layout-hud"
     case layoutHUDOnSpaceChange = "enables-layout-hud-on-space-change"
     case useCanaryBuild = "use-canary-build"
@@ -52,6 +53,7 @@ enum ConfigurationKey: String {
             .mouseFollowsFocus,
             .focusFollowsMouse,
             .mouseSwapsWindows,
+            .mouseResizesWindows,
             .layoutHUD,
             .layoutHUDOnSpaceChange,
             .useCanaryBuild,
@@ -329,6 +331,10 @@ final class UserConfiguration: NSObject {
 
     func mouseSwapsWindows() -> Bool {
         return storage.bool(forKey: ConfigurationKey.mouseSwapsWindows.rawValue)
+    }
+
+    func mouseResizesWindows() -> Bool {
+        return storage.bool(forKey: ConfigurationKey.mouseResizesWindows.rawValue)
     }
 
     func enablesLayoutHUD() -> Bool {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,7 +48,7 @@ CHECKOUT OPTIONS:
     :commit: 0964e89cb52c99fb9e7a02f21127d01ca82b0c8f
     :git: https://github.com/ianyh/MASShortcut
   Silica:
-    :commit: 231e303da30450ba364f1ff3c0007b00931c6e71
+    :commit: 84037d446e6109875182fdb8f490e8a22a192237
     :git: https://github.com/ianyh/Silica
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
## Demo

![amethyst_mouse_demo_480](https://user-images.githubusercontent.com/583459/29676922-7d933440-88c7-11e7-9e4d-aca5b430cebc.gif)


* Fixes #618 
* Fixes #634 
* Fixes #646
* Fixes #617 
* Fixes #216  (More accurately, can't reproduce it after making possibly-relevant changes; assuming fixed)
* Fixes #341  (More accurately, can't reproduce it after making possibly-relevant changes; assuming fixed)

## Current issues

* I do not aggressively reposition windows that are dragged to a different location within their same frame.  I'm not sure that I should.

## Features That Look Like Bugs

* When you resize a window, you are resizing _that window_ -- not a pane --, even if the border of that window lies on a pane boundary.  This means that for column layout, or multiple main windows, your newly-resized window may be nudged into a different location from the one where you released the mouse button; this happens when layouts constrain many windows to be the same size.  The simplest example of this would be the middle layout when 3 windows are open; the window will recenter after you resize, giving the appearance that you're only effecting half of the drag operation.
* Windows that enforce their own minimum size may overlap with other windows that attempt to resize into that frame.  If you want to arrange your windows such that the window with a size constraint is at its minimum (or maximum) size, then that's the window you should be resizing.


## Testing

* Tested on all layouts.
* Resize logic tested on all layouts, with and without multiple main windows
* Tested with focus-follows-mouse enabled
* Tested with window margins on 
* Tested with multiple monitors: 
  * a combination of a vertical and a horizontal monitor
  * in a configuration where the global coordinate space is larger than either of the individual displays.  
* Tested alongside "swap focused window with main window" actions

## Methodology

### Handling the mouse
Subscribe to two event streams: the mouse (`.leftMouseUp` events), and accessibility (`kAXWindowMovedNotification` / `kAXWindowResizedNotification` events).  Get the window being moved from `kAXWindowMovedNotification`, and the moment that the drag ends from `.leftMouseUp`.   We use a small delay hack here to prevent race conditions, since these 2 streams are in no way synchronized.


### Swapping windows
When `kAXWindowMovedNotification` and the mouse button is down, capture a reference to that window. When the mouseUp event fires, read the mouse pointer position.  Find the window underneath the one we are dragging (using code refactored from the "swap with focused window" algorithm), and swap it with whatever we are dragging.  Reflow all windows except the one we are dragging.

This approach is somewhat sane because due to the tiling we are reasonably guaranteed to avoid the situation where an external window-move operation happens with 2 windows simultaneously under the mouse pointer.

The feature itself is behind a checkbox in the preferences window.


### Resizing windows
When `kAXWindowResizedNotification` if the mouse is down, capture the layout and find how big the window is supposed to be.  Then calculate how big the pane would have to be to reflow the window to its current size, and save that information for later.  When the event fires, apply the change.

This approach is somewhat sane because since we're following the mouse button we're unlikely to end up in some sort of reflow/resize loop.

The feature itself is behind a checkbox in the preferences window.

![screen shot 2017-08-24 at 1 48 21 pm](https://user-images.githubusercontent.com/583459/29680559-f1354d6a-88d2-11e7-900c-3c40c1fef6f0.png)


[Trello Card](https://trello.com/c/EvSDKLAD/280-amethyst-swap-windows-between-frames-using-the-mouse)