### PR TITLE
Use Floating Bundle Identifiers as Blacklist

### DIFF
--- a/Amethyst/Preferences/GeneralPreferencesViewController.swift
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.swift
@@ -16,6 +16,7 @@ final class GeneralPreferencesViewController: NSViewController, CCNPreferencesWi
 
     @IBOutlet var layoutsTableView: NSTableView?
     @IBOutlet var floatingTableView: NSTableView?
+    @IBOutlet weak var floatingLabel: NSTextField!
 
     private var editingFloatingBundleIdentifier = false
 
@@ -37,6 +38,8 @@ final class GeneralPreferencesViewController: NSViewController, CCNPreferencesWi
 
         layoutsTableView?.reloadData()
         floatingTableView?.reloadData()
+
+        updateFloatingLabel()
     }
 
     @IBAction func addLayout(_ sender: NSButton) {
@@ -174,6 +177,14 @@ final class GeneralPreferencesViewController: NSViewController, CCNPreferencesWi
         UserConfiguration.shared.setFloatingBundleIdentifiers(self.floatingBundleIdentifiers)
 
         floatingTableView.reloadData()
+    }
+
+    @IBAction func toggleFloatingLabel(_ sender: NSButton) {
+        updateFloatingLabel()
+    }
+
+    private func updateFloatingLabel() {
+        floatingLabel.stringValue = UserConfiguration.shared.floatingBundleIdentifiersIsBlacklist() ? "Tile Windows:" : "Float Windows:"
     }
 
     func preferenceIdentifier() -> String! {

--- a/Amethyst/Preferences/GeneralPreferencesViewController.swift
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.swift
@@ -16,7 +16,6 @@ final class GeneralPreferencesViewController: NSViewController, CCNPreferencesWi
 
     @IBOutlet var layoutsTableView: NSTableView?
     @IBOutlet var floatingTableView: NSTableView?
-    @IBOutlet weak var floatingLabel: NSTextField!
 
     private var editingFloatingBundleIdentifier = false
 
@@ -38,8 +37,6 @@ final class GeneralPreferencesViewController: NSViewController, CCNPreferencesWi
 
         layoutsTableView?.reloadData()
         floatingTableView?.reloadData()
-
-        updateFloatingLabel()
     }
 
     @IBAction func addLayout(_ sender: NSButton) {
@@ -179,14 +176,6 @@ final class GeneralPreferencesViewController: NSViewController, CCNPreferencesWi
         floatingTableView.reloadData()
     }
 
-    @IBAction func toggleFloatingLabel(_ sender: NSButton) {
-        updateFloatingLabel()
-    }
-
-    private func updateFloatingLabel() {
-        floatingLabel.stringValue = UserConfiguration.shared.floatingBundleIdentifiersIsBlacklist() ? "Tile Windows:" : "Float Windows:"
-    }
-
     func preferenceIdentifier() -> String! {
         return NSStringFromClass(type(of: self))
     }
@@ -247,5 +236,20 @@ final class GeneralPreferencesViewController: NSViewController, CCNPreferencesWi
         }
 
         floatingTableView?.reloadData()
+    }
+}
+
+@objc(TileOrFloatTransformer) class TileOrFloatTransformer: ValueTransformer {
+    override class func transformedValueClass() -> AnyClass {
+        return NSString.self
+    }
+
+    override class func allowsReverseTransformation() -> Bool {
+        return false
+    }
+
+    override func transformedValue(_ value: Any?) -> Any? {
+        guard let type = value as? Int else { return nil }
+        return (type == 1 ? "Tile Windows:" : "Float Windows:") as AnyObject?
     }
 }

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13156.6" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13156.6"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="GeneralPreferencesViewController" customModule="Amethyst" customModuleProvider="target">
             <connections>
-                <outlet property="floatingLabel" destination="NDo-t3-gcp" id="s12-sy-lno"/>
                 <outlet property="floatingTableView" destination="0sm-tb-Rkn" id="4dS-u4-ZLp"/>
                 <outlet property="layoutsTableView" destination="fHR-0d-W1l" id="TR4-Ub-lKc"/>
                 <outlet property="view" destination="LsO-9M-hEw" id="7dy-Su-MSH"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customView id="LsO-9M-hEw" userLabel="General Preferences">
-            <rect key="frame" x="0.0" y="0.0" width="468" height="634"/>
+        <customView wantsLayer="YES" id="LsO-9M-hEw" userLabel="General Preferences">
+            <rect key="frame" x="0.0" y="0.0" width="468" height="658"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9hq-U6-t9B">
-                    <rect key="frame" x="170" y="463" width="148" height="18"/>
+                    <rect key="frame" x="170" y="487" width="148" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Float small windows" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="phj-M8-HfQ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -31,19 +30,18 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="feH-10-64P">
-                    <rect key="frame" x="170" y="431" width="244" height="18"/>
+                    <rect key="frame" x="169" y="467" width="244" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Float all windows except those listed" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oCx-5O-Ocb">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <action selector="toggleFloatingLabel:" target="-2" id="OmC-bt-dOp"/>
                         <binding destination="N2H-cZ-f1m" name="value" keyPath="values.floating-is-blacklist" id="ZII-r2-BtU"/>
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jbq-77-1YW">
-                    <rect key="frame" x="170" y="355" width="142" height="18"/>
+                    <rect key="frame" x="170" y="359" width="142" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable Layout HUD" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="UVr-KG-wFB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -54,7 +52,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ej5-FV-H6Q">
-                    <rect key="frame" x="170" y="335" width="255" height="18"/>
+                    <rect key="frame" x="170" y="339" width="255" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable Layout HUD on Space Change" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="o6e-e0-t64">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -65,7 +63,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wg4-Ew-VOi">
-                    <rect key="frame" x="107" y="464" width="59" height="17"/>
+                    <rect key="frame" x="107" y="488" width="59" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Floating:" id="H0k-aA-syT">
                         <font key="font" metaFont="system"/>
@@ -74,7 +72,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MKd-ZG-j26">
-                    <rect key="frame" x="83" y="356" width="83" height="17"/>
+                    <rect key="frame" x="83" y="360" width="83" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Layout HUD:" id="dFS-Je-lML">
                         <font key="font" metaFont="system"/>
@@ -83,7 +81,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G9A-P1-Ks1">
-                    <rect key="frame" x="126" y="312" width="40" height="17"/>
+                    <rect key="frame" x="126" y="316" width="40" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Misc.:" id="SoK-X5-vwJ">
                         <font key="font" metaFont="system"/>
@@ -92,7 +90,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TMz-ps-mVD">
-                    <rect key="frame" x="79" y="250" width="87" height="17"/>
+                    <rect key="frame" x="79" y="254" width="87" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Experimental:" id="Kol-kh-2eQ">
                         <font key="font" metaFont="system"/>
@@ -101,7 +99,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pGc-zn-uC7">
-                    <rect key="frame" x="170" y="311" width="133" height="18"/>
+                    <rect key="frame" x="170" y="315" width="133" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Ignore menu bars" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="LKn-n5-1ay">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -112,7 +110,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Eb-EJ-evb">
-                    <rect key="frame" x="170" y="291" width="223" height="18"/>
+                    <rect key="frame" x="170" y="295" width="223" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Mouse follows focused windows" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="6fy-Pu-AhI">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -123,7 +121,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xay-gW-zGw">
-                    <rect key="frame" x="170" y="271" width="223" height="18"/>
+                    <rect key="frame" x="170" y="275" width="223" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Send new windows to main pane" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="stG-cM-1bg">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -134,7 +132,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mtD-Sc-koj">
-                    <rect key="frame" x="170" y="248" width="243" height="18"/>
+                    <rect key="frame" x="170" y="252" width="243" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Focus follows mouse" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="u5m-jH-xzU">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -145,7 +143,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="m3g-TM-DNo">
-                    <rect key="frame" x="170" y="228" width="243" height="18"/>
+                    <rect key="frame" x="170" y="232" width="243" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Swap windows using mouse" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Wzj-wd-uh8">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -156,7 +154,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vRo-Ax-vKh">
-                    <rect key="frame" x="170" y="175" width="280" height="18"/>
+                    <rect key="frame" x="170" y="179" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Get development builds" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="5v8-xo-EWM">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -167,7 +165,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MGP-cm-WTe">
-                    <rect key="frame" x="170" y="135" width="280" height="18"/>
+                    <rect key="frame" x="170" y="139" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enable crash reporting" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="T33-wB-9cH">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -178,7 +176,7 @@
                     </connections>
                 </button>
                 <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U6O-Ka-pXq">
-                    <rect key="frame" x="172" y="401" width="251" height="56"/>
+                    <rect key="frame" x="172" y="405" width="251" height="56"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" ambiguous="YES" id="RT8-fN-JDO">
                         <rect key="frame" x="1" y="1" width="249" height="54"/>
@@ -222,7 +220,7 @@
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZH0-nz-Yiv">
-                    <rect key="frame" x="172" y="380" width="27" height="23"/>
+                    <rect key="frame" x="172" y="384" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ok9-1r-DwF">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -233,7 +231,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cfp-8K-Cdt">
-                    <rect key="frame" x="198" y="380" width="27" height="23"/>
+                    <rect key="frame" x="198" y="384" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Xif-lH-IK0">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -244,7 +242,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c03-Jd-KsK">
-                    <rect key="frame" x="223" y="380" width="200" height="23"/>
+                    <rect key="frame" x="223" y="384" width="200" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="w8y-WB-Ax2">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -252,7 +250,7 @@
                     </buttonCell>
                 </button>
                 <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kgh-Mo-aGF">
-                    <rect key="frame" x="172" y="529" width="251" height="85"/>
+                    <rect key="frame" x="172" y="553" width="251" height="85"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" ambiguous="YES" id="NPi-lT-8Xb">
                         <rect key="frame" x="1" y="1" width="249" height="83"/>
@@ -296,7 +294,7 @@
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AUR-i7-d99">
-                    <rect key="frame" x="172" y="508" width="27" height="23"/>
+                    <rect key="frame" x="172" y="532" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="v7u-4j-Gv9">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -307,7 +305,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="khH-XV-GhW">
-                    <rect key="frame" x="198" y="508" width="27" height="23"/>
+                    <rect key="frame" x="198" y="532" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="pcN-ET-p91">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -318,7 +316,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="A8V-CN-miB">
-                    <rect key="frame" x="223" y="508" width="200" height="23"/>
+                    <rect key="frame" x="223" y="532" width="200" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="8al-n7-kkn">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -326,7 +324,7 @@
                     </buttonCell>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M7e-Dw-sVZ">
-                    <rect key="frame" x="110" y="597" width="56" height="17"/>
+                    <rect key="frame" x="110" y="621" width="56" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Layouts:" id="tof-Wx-pYR">
                         <font key="font" metaFont="system"/>
@@ -335,7 +333,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fBD-ab-yJQ">
-                    <rect key="frame" x="170" y="159" width="280" height="15"/>
+                    <rect key="frame" x="170" y="163" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must relaunch for changes to take effect" id="Cak-aF-OC2">
                         <font key="font" metaFont="smallSystem"/>
@@ -344,7 +342,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4eN-rj-3bX">
-                    <rect key="frame" x="170" y="489" width="280" height="15"/>
+                    <rect key="frame" x="170" y="513" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must relaunch for changes to take effect" id="jJZ-0G-DUC">
                         <font key="font" metaFont="smallSystem"/>
@@ -353,7 +351,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ryf-WE-u7b">
-                    <rect key="frame" x="170" y="106" width="280" height="28"/>
+                    <rect key="frame" x="170" y="110" width="280" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Enabling this also sends some anonymous analytics" id="DiA-Hm-lgJ">
                         <font key="font" metaFont="smallSystem"/>
@@ -362,7 +360,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="l9P-32-7UB">
-                    <rect key="frame" x="170" y="105" width="280" height="15"/>
+                    <rect key="frame" x="170" y="109" width="280" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You must relaunch for changes to take effect" id="2us-TJ-7M2">
                         <font key="font" metaFont="smallSystem"/>
@@ -371,7 +369,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="luh-Gm-ZV0">
-                    <rect key="frame" x="57" y="80" width="109" height="17"/>
+                    <rect key="frame" x="57" y="84" width="109" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Margins:" id="LnD-6G-RSL">
                         <font key="font" metaFont="system"/>
@@ -380,7 +378,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tXC-cK-Yql">
-                    <rect key="frame" x="170" y="79" width="265" height="18"/>
+                    <rect key="frame" x="170" y="83" width="265" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enabled" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="59W-1k-G1j">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -391,7 +389,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ric-uO-1Cb">
-                    <rect key="frame" x="244" y="77" width="40" height="22"/>
+                    <rect key="frame" x="244" y="81" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" usesSingleLineMode="YES" id="Qi6-Bv-Yh1">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="gi8-52-60I">
@@ -410,7 +408,7 @@
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tGv-Wn-caL" userLabel="step size field">
-                    <rect key="frame" x="172" y="51" width="32" height="22"/>
+                    <rect key="frame" x="172" y="55" width="32" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="5" placeholderString="5" drawsBackground="YES" id="Ia5-T5-2gf">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="DNi-LX-9DG"/>
@@ -427,7 +425,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pwW-SE-wmY">
-                    <rect key="frame" x="299" y="80" width="19" height="17"/>
+                    <rect key="frame" x="299" y="84" width="19" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="Qfs-D0-k4Z">
                         <font key="font" metaFont="system"/>
@@ -436,7 +434,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oRH-MS-UAd">
-                    <rect key="frame" x="18" y="53" width="148" height="17"/>
+                    <rect key="frame" x="18" y="57" width="148" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Resize Interval:" id="nKR-ho-85Z">
                         <font key="font" metaFont="system"/>
@@ -445,7 +443,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g66-QF-Hrs">
-                    <rect key="frame" x="202" y="48" width="19" height="27"/>
+                    <rect key="frame" x="202" y="52" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="100" doubleValue="1" id="sPZ-B7-TQF"/>
                     <connections>
@@ -453,7 +451,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SGf-OP-a9f">
-                    <rect key="frame" x="218" y="53" width="15" height="17"/>
+                    <rect key="frame" x="218" y="57" width="15" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="%" id="Dpb-P9-t0R">
                         <font key="font" metaFont="system"/>
@@ -462,7 +460,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VsK-s4-pep">
-                    <rect key="frame" x="282" y="74" width="19" height="27"/>
+                    <rect key="frame" x="282" y="78" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="100" doubleValue="1" id="kSN-EK-HUy"/>
                     <connections>
@@ -471,7 +469,7 @@
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e6w-YL-rzU">
-                    <rect key="frame" x="47" y="223" width="119" height="28"/>
+                    <rect key="frame" x="47" y="227" width="119" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="May have unstable or unexpected behavior" id="em1-tY-3zU">
                         <font key="font" metaFont="smallSystem"/>
@@ -480,7 +478,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WI6-fc-YuY">
-                    <rect key="frame" x="170" y="208" width="248" height="18"/>
+                    <rect key="frame" x="170" y="212" width="248" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Resize windows (panes) using mouse" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="mwH-DQ-I0Y">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -490,8 +488,25 @@
                         <binding destination="XhK-Tn-zrU" name="value" keyPath="values.mouse-resizes-windows" id="09z-sc-YMk"/>
                     </connections>
                 </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TJ8-Zl-csG">
+                    <rect key="frame" x="45" y="444" width="121" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Float Windows:" id="fwr-ye-Gve">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="displayPatternValue1" keyPath="values.floating-is-blacklist" id="Lfc-ra-kZj">
+                            <dictionary key="options">
+                                <string key="NSDisplayPattern">%{value1}@</string>
+                                <string key="NSValueTransformerName">TileOrFloatTransformer</string>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </textField>
             </subviews>
-            <point key="canvasLocation" x="562" y="340"/>
+            <point key="canvasLocation" x="562" y="352"/>
         </customView>
         <userDefaultsController id="XhK-Tn-zrU"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -8,6 +8,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="GeneralPreferencesViewController" customModule="Amethyst" customModuleProvider="target">
             <connections>
+                <outlet property="floatingLabel" destination="NDo-t3-gcp" id="s12-sy-lno"/>
                 <outlet property="floatingTableView" destination="0sm-tb-Rkn" id="4dS-u4-ZLp"/>
                 <outlet property="layoutsTableView" destination="fHR-0d-W1l" id="TR4-Ub-lKc"/>
                 <outlet property="view" destination="LsO-9M-hEw" id="7dy-Su-MSH"/>
@@ -30,13 +31,14 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="feH-10-64P">
-                    <rect key="frame" x="170" y="431" width="117" height="18"/>
+                    <rect key="frame" x="170" y="431" width="244" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Use as blacklist" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oCx-5O-Ocb">
+                    <buttonCell key="cell" type="check" title="Float all windows except those listed" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oCx-5O-Ocb">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
+                        <action selector="toggleFloatingLabel:" target="-2" id="OmC-bt-dOp"/>
                         <binding destination="N2H-cZ-f1m" name="value" keyPath="values.floating-is-blacklist" id="ZII-r2-BtU"/>
                     </connections>
                 </button>

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -29,6 +29,17 @@
                         <binding destination="XhK-Tn-zrU" name="value" keyPath="values.float-small-windows" id="ahP-PY-5hW"/>
                     </connections>
                 </button>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="feH-10-64P">
+                    <rect key="frame" x="170" y="431" width="117" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Use as blacklist" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oCx-5O-Ocb">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="N2H-cZ-f1m" name="value" keyPath="values.floating-is-blacklist" id="ZII-r2-BtU"/>
+                    </connections>
+                </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jbq-77-1YW">
                     <rect key="frame" x="170" y="355" width="142" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -480,8 +491,8 @@
             </subviews>
             <point key="canvasLocation" x="562" y="340"/>
         </customView>
-        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <userDefaultsController id="XhK-Tn-zrU"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <userDefaultsController representsSharedInstance="YES" id="N2H-cZ-f1m"/>
     </objects>
     <resources>

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -31,6 +31,7 @@ enum ConfigurationKey: String {
     case windowMargins = "window-margins"
     case windowMarginSize = "window-margin-size"
     case floatingBundleIdentifiers = "floating"
+    case floatingBundleIdentifiersIsBlacklist = "floating-is-blacklist"
     case ignoreMenuBar = "ignore-menu-bar"
     case floatSmallWindows = "float-small-windows"
     case mouseFollowsFocus = "mouse-follows-focus"
@@ -48,6 +49,7 @@ enum ConfigurationKey: String {
         return [
             .layouts,
             .floatingBundleIdentifiers,
+            .floatingBundleIdentifiersIsBlacklist,
             .ignoreMenuBar,
             .floatSmallWindows,
             .mouseFollowsFocus,
@@ -293,20 +295,22 @@ final class UserConfiguration: NSObject {
             return false
         }
 
+        let useIdentifiersAsBlacklist = floatingBundleIdentifiersIsBlacklist()
+
         for floatingBundleIdentifier in floatingBundleIdentifiers {
             if floatingBundleIdentifier.contains("*") {
                 let sanitizedIdentifier = floatingBundleIdentifier.replacingOccurrences(of: "*", with: "")
                 if runningApplication.bundleIdentifier?.hasPrefix(sanitizedIdentifier) == true {
-                    return true
+                    return useIdentifiersAsBlacklist ? false : true
                 }
             } else {
                 if floatingBundleIdentifier == runningApplication.bundleIdentifier {
-                    return true
+                    return useIdentifiersAsBlacklist ? false : true
                 }
             }
         }
 
-        return false
+        return useIdentifiersAsBlacklist ? true : false
     }
 
     func ignoreMenuBar() -> Bool {
@@ -359,6 +363,10 @@ final class UserConfiguration: NSObject {
 
     func windowResizeStep() -> CGFloat {
         return CGFloat(storage.float(forKey: ConfigurationKey.windowResizeStep.rawValue) / 100.0)
+    }
+
+    func floatingBundleIdentifiersIsBlacklist() -> Bool {
+        return storage.bool(forKey: ConfigurationKey.floatingBundleIdentifiersIsBlacklist.rawValue)
     }
 
     func floatingBundleIdentifiers() -> [String] {

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -301,16 +301,16 @@ final class UserConfiguration: NSObject {
             if floatingBundleIdentifier.contains("*") {
                 let sanitizedIdentifier = floatingBundleIdentifier.replacingOccurrences(of: "*", with: "")
                 if runningApplication.bundleIdentifier?.hasPrefix(sanitizedIdentifier) == true {
-                    return useIdentifiersAsBlacklist ? false : true
+                    return !useIdentifiersAsBlacklist
                 }
             } else {
                 if floatingBundleIdentifier == runningApplication.bundleIdentifier {
-                    return useIdentifiersAsBlacklist ? false : true
+                    return !useIdentifiersAsBlacklist
                 }
             }
         }
 
-        return useIdentifiersAsBlacklist ? true : false
+        return useIdentifiersAsBlacklist
     }
 
     func ignoreMenuBar() -> Bool {

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -190,7 +190,7 @@
         "key": "x"
     },
     "floating": [],
-    "floating-is-blacklist": false,
+    "floating-is-blacklist": true,
     "float-small-windows": true,
     "mouse-follows-focus": false,
     "focus-follows-mouse": false,

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -190,6 +190,7 @@
         "key": "x"
     },
     "floating": [],
+    "floating-is-blacklist": false,
     "float-small-windows": true,
     "mouse-follows-focus": false,
     "focus-follows-mouse": false,


### PR DESCRIPTION
## Related issues

* Main issue: #171
* Duplicate issue: #250 
* An issue where whitelisting was wanted as a workaround: #200 

## Motivation

Some users have mentioned that they either prefer to use Amethyst only for certain windows, such as primary windows for their development environments. Other users have ran into too many windows that are incompatible with Amethyst, and they would prefer to be choosy with what gets controlled by Amethyst.

## Modifications

* New configuration setting in General > Floating: "Use as Blacklist"
* When "Use as Blacklist" is checked, windows entered into the Floating identifiers will not be automatically set to float (though the "Float small windows" option may still be respected).
* Also, when "Use as Blacklist" is checked, all other windows are floated.

## Video

This video starts with standard behavior. Google Chrome is the only window in the float list. I demonstrate that other windows are not floating, but Google Chrome is floating and unaffected by layout changes.

Then I enable the new option "Use as blacklist", and I demonstrate that not only is Chrome not floating, but all other windows besides Chrome are floating and unaffected by layout changes.

https://cl.ly/0P0p273E1W3X

## Screenshots

![image](https://user-images.githubusercontent.com/607938/31857310-e2d2358a-b6a9-11e7-9f17-164ca82c01b9.png)





[Trello Card](https://trello.com/c/BpPMrUwu/292-amethyst-use-floating-bundle-identifiers-as-blacklist)