### PR TITLE
Respond to application hide/show events, fixes #575

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -187,6 +187,20 @@ private class ObserveApplicationNotifications {
                 windowManager.addWindow(window)
             }
 
+            application.observeNotification(kAXApplicationHiddenNotification as CFString!, with: application) { accessibilityElement in
+                guard let window = accessibilityElement as? SIWindow else {
+                    return
+                }
+                windowManager.removeWindow(window)
+            }
+
+            application.observeNotification(kAXApplicationShownNotification as CFString!, with: application) { accessibilityElement in
+                guard let window = accessibilityElement as? SIWindow else {
+                    return
+                }
+                windowManager.addWindow(window)
+            }
+
             application.observeNotification(kAXFocusedWindowChangedNotification as CFString!, with: application) { _ in
                 guard let focusedWindow = SIWindow.focused(), let screen = focusedWindow.screen() else {
                     return
@@ -568,7 +582,7 @@ final class WindowManager: NSObject, MouseStateKeeperDelegate {
         markScreenForReflow(screen, withChange: windowChange)
     }
 
-    private func removeWindow(_ window: SIWindow) {
+    fileprivate func removeWindow(_ window: SIWindow) {
         markAllScreensForReflowWithChange(.remove(window: window))
 
         let application = applicationWithProcessIdentifier(window.processIdentifier())


### PR DESCRIPTION
This patch adds what appears to be an oversight -- an Amethyst response to application hide/show events.  While testing this patch, I observed that the events seem to fire at the appropriate times, but the handling of `kAXApplicationShownNotification` is sometimes mistakenly aborted.  I've opened #662 to track that, as the proper fix is not immediately obvious to me.

Fixes #575 


[Trello Card](https://trello.com/c/woBCxWMr/300-amethyst-respond-to-application-hide-show-events-fixes-575)