### PR TITLE
toggle global tiling menu item, resolves #635

### DIFF
--- a/Amethyst/AppDelegate.swift
+++ b/Amethyst/AppDelegate.swift
@@ -27,6 +27,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet var statusItemMenu: NSMenu?
     @IBOutlet var versionMenuItem: NSMenuItem?
     @IBOutlet var startAtLoginMenuItem: NSMenuItem?
+    @IBOutlet var toggleGlobalTilingMenuItem: NSMenuItem?
 
     private var isFirstLaunch = true
 
@@ -94,6 +95,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem?.highlightMode = true
 
         versionMenuItem?.title = "Version \(shortVersion) (\(version))"
+        toggleGlobalTilingMenuItem?.title = "Disable"
 
         loginItem = CCNLaunchAtLoginItem(for: Bundle.main)
         startAtLoginMenuItem?.state = (loginItem!.isActive() ? .on : .off)
@@ -115,6 +117,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             loginItem?.deActivate()
         }
         startAtLoginMenuItem?.state = (loginItem!.isActive() ? .on : .off)
+    }
+
+    @IBAction func toggleGlobalTiling(_ sender: AnyObject) {
+        UserConfiguration.shared.tilingEnabled = !UserConfiguration.shared.tilingEnabled
+        windowManager?.markAllScreensForReflowWithChange(.unknown)
     }
 
     @IBAction func relaunch(_ sender: AnyObject) {
@@ -159,8 +166,10 @@ extension AppDelegate: UserConfigurationDelegate {
         var statusItemImage: NSImage?
         if UserConfiguration.shared.tilingEnabled == true {
             statusItemImage = NSImage(named: NSImage.Name(rawValue: "icon-statusitem"))
+            toggleGlobalTilingMenuItem?.title = "Disable"
         } else {
             statusItemImage = NSImage(named: NSImage.Name(rawValue: "icon-statusitem-disabled"))
+            toggleGlobalTilingMenuItem?.title = "Enable"
         }
         statusItemImage?.isTemplate = true
         statusItem?.image = statusItemImage

--- a/Amethyst/en.lproj/MainMenu.xib
+++ b/Amethyst/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13122.19" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13122.19"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,6 +19,12 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="uP9-ch-b7n"/>
+                <menuItem title="Disable" id="rjJ-w4-5Ht">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="toggleGlobalTiling:" target="494" id="3aM-9U-hWx"/>
+                    </connections>
+                </menuItem>
                 <menuItem title="Start Amethyst on Login" id="549">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
@@ -51,12 +57,14 @@
                     </connections>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="-179" y="92"/>
         </menu>
         <customObject id="494" customClass="AppDelegate" customModule="Amethyst" customModuleProvider="target">
             <connections>
                 <outlet property="preferencesWindowController" destination="0fi-bi-huz" id="dfn-JC-QBQ"/>
                 <outlet property="startAtLoginMenuItem" destination="549" id="551"/>
                 <outlet property="statusItemMenu" destination="536" id="547"/>
+                <outlet property="toggleGlobalTilingMenuItem" destination="rjJ-w4-5Ht" id="4Dq-e8-R1M"/>
                 <outlet property="versionMenuItem" destination="bNZ-Ry-Q4Q" id="jXC-pY-N2a"/>
             </connections>
         </customObject>
@@ -65,7 +73,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" topStrut="YES"/>
             <rect key="contentRect" x="446" y="472" width="480" height="270"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="IHj-fa-gIc">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
resolves #635

Hello! Big fan of Amethyst and wanted to get my feet wet with something small. I'm not super familiar with interface builder so let me know if I mucked up the xml.

Was hoping to get some feedback on what the title of the menu item should be or how it should behave. `Disable` / `Enable` doesn't feel quite right to me.

Right now I am leaning towards something like `Turn Global Tiling Off` and `Turn Global Tiling On`. This follows the pattern of other macOS menu bar items like WiFi and Bluetooth. Maybe just `Turn Tiling Off`?

Also, should the keyboard shortcut be in the menu similar to `Quit Amethyst`?


Thanks!



[Trello Card](https://trello.com/c/kUigu1Q1/302-amethyst-toggle-global-tiling-menu-item-resolves-635)