### PR TITLE
Add throwing windows to left/right command to preferences, resolves #660

### DIFF
--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -321,6 +321,8 @@ final class HotKeyManager: NSObject {
         hotKeyNameToDefaultsKey.append(["Swap focused window clockwise", CommandKey.swapCW.rawValue])
         hotKeyNameToDefaultsKey.append(["Swap focused window with main window", CommandKey.swapMain.rawValue])
         hotKeyNameToDefaultsKey.append(["Force windows to be reevaluated", CommandKey.reevaluateWindows.rawValue])
+        hotKeyNameToDefaultsKey.append(["Throw focused window to space left", CommandKey.throwSpaceLeft.rawValue])
+        hotKeyNameToDefaultsKey.append(["Throw focused window to space right", CommandKey.throwSpaceRight.rawValue])
 
         (1...10).forEach { spaceNumber in
             let name = "Throw focused window to space \(spaceNumber)"


### PR DESCRIPTION
Add commands implemented in #458 to preferences. Just two lines of code fixed #660.
# Test
Simply test the load/store of related preferences, the key bindings and the effect of these two commands.