### PR TITLE
Fix race condition caused by drag events and window peeking

### DIFF
--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -124,7 +124,19 @@ class ReflowOperation: Operation {
         self.frameAssigner = frameAssigner
         self.onReflowCompletion = nil
         super.init()
-        self.completionBlock = nil
+        makeCompletionBlock(nil)
+    }
+
+    private func makeCompletionBlock(_ aBlock: (() -> Void)?) {
+        super.completionBlock = { [unowned self] in
+            aBlock?()
+            guard !self.isCancelled else { return }
+            self.onReflowCompletion?()
+        }
+    }
+
+    public func enqueue(_ aQueue: OperationQueue) {
+        aQueue.addOperation(self)
     }
 
     // Carve out a separate completion block for reflow stuff.
@@ -135,11 +147,7 @@ class ReflowOperation: Operation {
             return super.completionBlock
         }
         set {
-            self.completionBlock = { [unowned self] in
-                newValue?()
-                guard !self.isCancelled else { return }
-                self.onReflowCompletion?()
-            }
+            makeCompletionBlock(newValue)
         }
     }
 

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -124,10 +124,22 @@ class ReflowOperation: Operation {
         self.frameAssigner = frameAssigner
         self.onReflowCompletion = nil
         super.init()
-        self.completionBlock = { [unowned self] in
-            guard !self.isCancelled else { return }
-            guard let onReflowCompletion = self.onReflowCompletion else { return }
-            onReflowCompletion()
+        self.completionBlock = nil
+    }
+
+    // Carve out a separate completion block for reflow stuff.
+    // It will always fire after any existing completion block
+    // UNLESS the operation completed by being cancelled.
+    override public var completionBlock: (() -> Void)? {
+        get {
+            return super.completionBlock
+        }
+        set {
+            self.completionBlock = { [unowned self] in
+                newValue?()
+                guard !self.isCancelled else { return }
+                self.onReflowCompletion?()
+            }
         }
     }
 

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -124,7 +124,7 @@ class ReflowOperation: Operation {
         self.frameAssigner = frameAssigner
         self.onReflowCompletion = nil
         super.init()
-        self.completionBlock = {
+        self.completionBlock = { [unowned self] in
             guard !self.isCancelled else { return }
             guard let onReflowCompletion = self.onReflowCompletion else { return }
             onReflowCompletion()

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -133,16 +133,14 @@ final class ScreenManager: NSObject {
 
         let windows = (delegate?.activeWindowsForScreenManager(self) ?? [])
         changingSpace = false
-        reflowOperation = currentLayout?.reflow(windows, on: screen)
-        reflowOperation!.onReflowCompletion = {
+
+        guard let reflowOperation = currentLayout?.reflow(windows, on: screen) else { return }
+        reflowOperation.onReflowCompletion = { [unowned self] in
             // propagate the completion handler if we have one
-            guard let onReflow = self.onReflowCompletion else { return }
-            onReflow()
+            self.onReflowCompletion?()
         }
-        if let onReflowInitiation = self.onReflowInitiation {
-            onReflowInitiation()
-        }
-        OperationQueue.main.addOperation(reflowOperation!)
+        self.onReflowInitiation?()
+        OperationQueue.main.addOperation(reflowOperation)
     }
 
     func updateCurrentLayout(_ updater: (Layout) -> Void) {

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -134,13 +134,13 @@ final class ScreenManager: NSObject {
         let windows = (delegate?.activeWindowsForScreenManager(self) ?? [])
         changingSpace = false
 
-        guard let reflowOperation = currentLayout?.reflow(windows, on: screen) else { return }
-        reflowOperation.onReflowCompletion = { [unowned self] in
+        let reflowOperation = currentLayout?.reflow(windows, on: screen)
+        reflowOperation?.onReflowCompletion = { [unowned self] in
             // propagate the completion handler if we have one
             self.onReflowCompletion?()
         }
         self.onReflowInitiation?()
-        OperationQueue.main.addOperation(reflowOperation)
+        reflowOperation?.enqueue(OperationQueue.main)
     }
 
     func updateCurrentLayout(_ updater: (Layout) -> Void) {

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -139,8 +139,10 @@ final class ScreenManager: NSObject {
             // propagate the completion handler if we have one
             self.onReflowCompletion?()
         }
-        self.onReflowInitiation?()
-        reflowOperation?.enqueue(OperationQueue.main)
+        onReflowInitiation?()
+        if let reflowOperation = reflowOperation {
+            reflowOperation.enqueue(OperationQueue.main)
+        }
     }
 
     func updateCurrentLayout(_ updater: (Layout) -> Void) {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -656,16 +656,16 @@ final class WindowManager: NSObject, MouseStateKeeperDelegate {
 
             if screenManager == nil {
                 screenManager = ScreenManager(screen: screen, screenIdentifier: screenIdentifier, delegate: self, userConfiguration: userConfiguration)
-                screenManager!.onReflowInitiation = { [unowned self] in
-                    self.mouseStateKeeper.handleReflowEvent()
+                screenManager!.onReflowInitiation = { [weak self] in
+                    self?.mouseStateKeeper.handleReflowEvent()
                 }
-                screenManager!.onReflowCompletion = { [unowned self] in
+                screenManager!.onReflowCompletion = { [weak self] in
                     // This handler will be executed by the Operation, in a queue.  Although async
                     // (and although the docs say that it executes in a separate thread), I consider
                     // this to be thread safe, at least safe enough, because we always want the
                     // latest time that a reflow took place.
-                    self.mouseStateKeeper.handleReflowEvent()
-                    self.lastReflowTime = Date()
+                    self?.mouseStateKeeper.handleReflowEvent()
+                    self?.lastReflowTime = Date()
                 }
                 screenManagersCache[screenIdentifier] = screenManager
             }


### PR DESCRIPTION
Fixes #690 

This patch adds some event propagation (via closures) so that the mouse state -- used to correlate the mouse event stream with the window event stream -- can be marginally aware of events that were _not_ triggered by the user.

In other words, if window focus is changed by a drag event (triggering a reflow), the movements caused by the reflow would ordinarily cause the `MouseStateKeeper` to think that the drag operation and window move were correlated.  Most commonly, this would cause unexpected window swaps.  

By signaling the beginning (scheduling) and ending (completion) of reflows, we can _de_-correlate mouse and window movements as necessary.  

Please double check my work in regards to reference cycles, I'm inexpert at that.