### PR TITLE
Fix broken latest download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A quick screencast of basic functionality can be found [here](https://youtu.be/b
 Getting Amethyst
 ================
 
-Amethyst is available for direct download [here](http://ianyh.com/amethyst/versions/Amethyst-latest.zip) or using [homebrew cask](https://github.com/caskroom/homebrew-cask).
+Amethyst is available for direct download on the [releases page](https://github.com/ianyh/Amethyst/releases) or using [homebrew cask](https://github.com/caskroom/homebrew-cask).
 
 ```
 brew cask install amethyst


### PR DESCRIPTION
Relying on the ianyh.com hosted releases is deprecated so the `-latest.zip` doesn't exist anymore. A lot of projects seem to direct people to the Releases page so we'll do that for now. Open to suggestions otherwise.

Fixes #711