### PR TITLE
Focus the previously focused window when switching screens.

### DIFF
--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -17,6 +17,9 @@ protocol ScreenManagerDelegate: class {
 final class ScreenManager: NSObject {
     var screen: NSScreen
     let screenIdentifier: String
+    /// The last window that has been focused on the screen. This value is updated by the notification observations in
+    /// `ObserveApplicationNotifications`.
+    public internal(set) var lastFocusedWindow: SIWindow?
     fileprivate weak var delegate: ScreenManagerDelegate?
     private let userConfiguration: UserConfiguration
     public var onReflowInitiation: (() -> Void)?

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -223,6 +223,7 @@ private class ObserveApplicationNotifications {
                 } else {
                     windowManager.markScreenForReflow(screen, withChange: .focusChanged(window: focusedWindow))
                 }
+                windowManager.screenManager(for: screen)?.lastFocusedWindow = focusedWindow
             }
 
             application.observeNotification(kAXApplicationActivatedNotification as CFString!, with: application) { _ in

--- a/Amethyst/Managers/WindowModifier.swift
+++ b/Amethyst/Managers/WindowModifier.swift
@@ -295,7 +295,7 @@ extension ScreenFocuser {
         }
 
         // If the previous focus has been tracked, then focus the window that had the focus before.
-        if let previouslyFocused = screenManager.lastFocusedWindow {
+        if let previouslyFocused = screenManager.lastFocusedWindow, previouslyFocused.isOnScreen() {
             previouslyFocused.am_focusWindow()
             return
         }

--- a/Amethyst/Managers/WindowModifier.swift
+++ b/Amethyst/Managers/WindowModifier.swift
@@ -294,6 +294,12 @@ extension ScreenFocuser {
             return
         }
 
+        // If the previous focus has been tracked, then focus the window that had the focus before.
+        if let previouslyFocused = screenManager.lastFocusedWindow {
+            previouslyFocused.am_focusWindow()
+            return
+        }
+
         let windows = self.windows(on: screenManager.screen)
 
         // If there are no windows on the screen focus the screen directly


### PR DESCRIPTION
Adds tracking of the last focused window per screen. When switching windows, it then tries to focus the previously tracked screen.

Resolves #703 