### PR TITLE
Prefer the use of frame (vs window) boundaries when reacting to mouse drags

### DIFF
--- a/Amethyst/Layout/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/BinarySpacePartitioningLayout.swift
@@ -140,7 +140,7 @@ func == (lhs: TreeNode, rhs: TreeNode) -> Bool {
     return lhs.windowID == rhs.windowID
 }
 
-final class BinarySpacePartitioningReflowOperation: ReflowOperation {
+final class BinarySpacePartitioningReflowOperation: ReflowOperation, FrameReflower {
     private typealias TraversalNode = (node: TreeNode, frame: CGRect)
     private let rootNode: TreeNode
 
@@ -233,7 +233,7 @@ final class BinarySpacePartitioningReflowOperation: ReflowOperation {
     }
 }
 
-final class BinarySpacePartitioningLayout: Layout {
+final class BinarySpacePartitioningLayout: Layout, FramedLayout {
     static var layoutName: String { return "Binary Space Partitioning" }
     static var layoutKey: String { return "bsp" }
 
@@ -246,11 +246,10 @@ final class BinarySpacePartitioningLayout: Layout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
+    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
         if !windows.isEmpty && !rootNode.valid {
             constructInitialTreeWithWindows(windows)
         }
-
         return BinarySpacePartitioningReflowOperation(screen: screen, windows: windows, rootNode: rootNode, frameAssigner: self)
     }
 

--- a/Amethyst/Layout/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/BinarySpacePartitioningLayout.swift
@@ -140,7 +140,7 @@ func == (lhs: TreeNode, rhs: TreeNode) -> Bool {
     return lhs.windowID == rhs.windowID
 }
 
-final class BinarySpacePartitioningReflowOperation: ReflowOperation, FrameReflower {
+final class BinarySpacePartitioningReflowOperation: ReflowOperation {
     private typealias TraversalNode = (node: TreeNode, frame: CGRect)
     private let rootNode: TreeNode
 
@@ -149,7 +149,7 @@ final class BinarySpacePartitioningReflowOperation: ReflowOperation, FrameReflow
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    func frameAssignments() -> [FrameAssignment] {
+    override func frameAssignments() -> [FrameAssignment]? {
         guard !windows.isEmpty else {
             return []
         }
@@ -223,17 +223,9 @@ final class BinarySpacePartitioningReflowOperation: ReflowOperation, FrameReflow
 
         return ret
     }
-
-    override func main() {
-        guard !isCancelled else {
-            return
-        }
-
-        frameAssigner.performFrameAssignments(frameAssignments())
-    }
 }
 
-final class BinarySpacePartitioningLayout: Layout, FramedLayout {
+final class BinarySpacePartitioningLayout: Layout {
     static var layoutName: String { return "Binary Space Partitioning" }
     static var layoutKey: String { return "bsp" }
 
@@ -246,15 +238,11 @@ final class BinarySpacePartitioningLayout: Layout, FramedLayout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
+    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation? {
         if !windows.isEmpty && !rootNode.valid {
             constructInitialTreeWithWindows(windows)
         }
         return BinarySpacePartitioningReflowOperation(screen: screen, windows: windows, rootNode: rootNode, frameAssigner: self)
-    }
-
-    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return BinarySpacePartitioningReflowOperation(screen: screen, windows: windows, rootNode: rootNode, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 
     private func constructInitialTreeWithWindows(_ windows: [SIWindow]) {

--- a/Amethyst/Layout/ColumnLayout.swift
+++ b/Amethyst/Layout/ColumnLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class ColumnReflowOperation: ReflowOperation {
+final class ColumnReflowOperation: ReflowOperation, FrameReflower {
     let layout: ColumnLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: ColumnLayout, frameAssigner: FrameAssigner) {
@@ -69,7 +69,7 @@ final class ColumnReflowOperation: ReflowOperation {
     }
 }
 
-final class ColumnLayout: Layout {
+final class ColumnLayout: Layout, FramedLayout {
     static var layoutName: String { return "Column" }
     static var layoutKey: String { return "column" }
 
@@ -81,7 +81,7 @@ final class ColumnLayout: Layout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
+    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
         return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 

--- a/Amethyst/Layout/ColumnLayout.swift
+++ b/Amethyst/Layout/ColumnLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class ColumnReflowOperation: ReflowOperation, FrameReflower {
+final class ColumnReflowOperation: ReflowOperation {
     let layout: ColumnLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: ColumnLayout, frameAssigner: FrameAssigner) {
@@ -16,7 +16,7 @@ final class ColumnReflowOperation: ReflowOperation, FrameReflower {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    func frameAssignments() -> [FrameAssignment] {
+    override func frameAssignments() -> [FrameAssignment]? {
         guard !windows.isEmpty else {
             return []
         }
@@ -59,17 +59,9 @@ final class ColumnReflowOperation: ReflowOperation, FrameReflower {
             return assignments
         }
     }
-
-    override func main() {
-        guard !isCancelled else {
-            return
-        }
-
-        frameAssigner.performFrameAssignments(frameAssignments())
-    }
 }
 
-final class ColumnLayout: Layout, FramedLayout {
+final class ColumnLayout: Layout {
     static var layoutName: String { return "Column" }
     static var layoutKey: String { return "column" }
 
@@ -81,12 +73,8 @@ final class ColumnLayout: Layout, FramedLayout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
+    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation? {
         return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
-    }
-
-    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/FloatingLayout.swift
+++ b/Amethyst/Layout/FloatingLayout.swift
@@ -8,8 +8,6 @@
 
 import Silica
 
-final class FloatingReflowOperation: ReflowOperation {}
-
 final class FloatingLayout: Layout {
     static var layoutName: String { return "Floating" }
     static var layoutKey: String { return "floating" }
@@ -20,11 +18,7 @@ final class FloatingLayout: Layout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
-        return FloatingReflowOperation(screen: screen, windows: windows, frameAssigner: self)
-    }
-
-    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation? {
         return nil
     }
 

--- a/Amethyst/Layout/FullscreenLayout.swift
+++ b/Amethyst/Layout/FullscreenLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class FullscreenReflowOperation: ReflowOperation, FrameReflower {
+final class FullscreenReflowOperation: ReflowOperation {
     private let layout: FullscreenLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: FullscreenLayout, frameAssigner: FrameAssigner) {
@@ -16,24 +16,16 @@ final class FullscreenReflowOperation: ReflowOperation, FrameReflower {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    func frameAssignments() -> [FrameAssignment] {
+    override func frameAssignments() -> [FrameAssignment]? {
         let screenFrame = screen.adjustedFrame()
         return windows.map { window in
             let resizeRules = ResizeRules(isMain: true, unconstrainedDimension: .horizontal, scaleFactor: 1)
             return FrameAssignment(frame: screenFrame, window: window, focused: false, screenFrame: screenFrame, resizeRules: resizeRules)
         }
     }
-
-    override func main() {
-        guard !isCancelled else {
-            return
-        }
-
-        frameAssigner.performFrameAssignments(frameAssignments())
-    }
 }
 
-final class FullscreenLayout: Layout, FramedLayout {
+final class FullscreenLayout: Layout {
     static var layoutName: String { return "Fullscreen" }
     static var layoutKey: String { return "fullscreen" }
 
@@ -43,12 +35,8 @@ final class FullscreenLayout: Layout, FramedLayout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
+    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation? {
         return FullscreenReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
-    }
-
-    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return FullscreenReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/FullscreenLayout.swift
+++ b/Amethyst/Layout/FullscreenLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class FullscreenReflowOperation: ReflowOperation {
+final class FullscreenReflowOperation: ReflowOperation, FrameReflower {
     private let layout: FullscreenLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: FullscreenLayout, frameAssigner: FrameAssigner) {
@@ -33,7 +33,7 @@ final class FullscreenReflowOperation: ReflowOperation {
     }
 }
 
-final class FullscreenLayout: Layout {
+final class FullscreenLayout: Layout, FramedLayout {
     static var layoutName: String { return "Fullscreen" }
     static var layoutKey: String { return "fullscreen" }
 
@@ -43,7 +43,7 @@ final class FullscreenLayout: Layout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
+    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
         return FullscreenReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -135,8 +135,18 @@ class ReflowOperation: Operation {
         }
     }
 
+    public func frameAssignments() -> [FrameAssignment]? {
+        return nil
+    }
+
     public func enqueue(_ aQueue: OperationQueue) {
         aQueue.addOperation(self)
+    }
+
+    override func main() {
+        guard !isCancelled else { return }
+        guard let assignments = frameAssignments() else { return }
+        frameAssigner.performFrameAssignments(assignments)
     }
 
     // Carve out a separate completion block for reflow stuff.
@@ -154,11 +164,6 @@ class ReflowOperation: Operation {
     deinit {
         self.onReflowCompletion = nil
     }
-}
-
-// a reflow operation that organizes frames
-protocol FrameReflower {
-    func frameAssignments() -> [FrameAssignment]
 }
 
 protocol FrameAssigner: WindowActivityCache {
@@ -234,8 +239,21 @@ protocol Layout {
 
     var windowActivityCache: WindowActivityCache { get }
 
-    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation
-    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment?
+    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation?
+}
+
+extension Layout {
+    func frameAssignments(_ windows: [SIWindow], on screen: NSScreen) -> [FrameAssignment]? {
+        return reflow(windows, on: screen)?.frameAssignments()
+    }
+
+    func windowAtPoint(_ point: CGPoint, of windows: [SIWindow], on screen: NSScreen) -> SIWindow? {
+        return frameAssignments(windows, on: screen)?.first(where: { $0.frame.contains(point) })?.window
+    }
+
+    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
+        return frameAssignments(windows, on: screen)?.first { $0.window == window }
+    }
 }
 
 protocol PanedLayout {
@@ -269,24 +287,4 @@ protocol StatefulLayout {
     func updateWithChange(_ windowChange: WindowChange)
     func nextWindowIDCounterClockwise() -> CGWindowID?
     func nextWindowIDClockwise() -> CGWindowID?
-}
-
-// a layout whose reflow operation is a FrameReflower
-protocol FramedLayout {
-    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> (ReflowOperation & FrameReflower)
-}
-
-extension FramedLayout {
-    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
-        return reflowFrames(windows, on: screen)
-    }
-}
-
-// use existing groundwork in layouts / reflowOperations in order to get the window from an assigned frame
-extension FramedLayout {
-    func windowAtPoint(_ point: CGPoint, of windows: [SIWindow], on screen: NSScreen) -> SIWindow? {
-        let assignments = reflowFrames(windows, on: screen).frameAssignments()
-        guard let assignment = assignments.first(where: { $0.frame.contains(point) }) else { return nil }
-        return assignment.window
-    }
 }

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class RowReflowOperation: ReflowOperation, FrameReflower {
+final class RowReflowOperation: ReflowOperation {
     let layout: RowLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: RowLayout, frameAssigner: FrameAssigner) {
@@ -16,7 +16,7 @@ final class RowReflowOperation: ReflowOperation, FrameReflower {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    func frameAssignments() -> [FrameAssignment] {
+    override func frameAssignments() -> [FrameAssignment]? {
         guard !windows.isEmpty else {
             return []
         }
@@ -66,17 +66,9 @@ final class RowReflowOperation: ReflowOperation, FrameReflower {
             return assignments
         }
     }
-
-    override func main() {
-        guard !isCancelled else {
-            return
-        }
-
-        layout.performFrameAssignments(frameAssignments())
-    }
 }
 
-final class RowLayout: Layout, FramedLayout {
+final class RowLayout: Layout {
     static var layoutName: String { return "Row" }
     static var layoutKey: String { return "row" }
 
@@ -89,12 +81,8 @@ final class RowLayout: Layout, FramedLayout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
+    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation? {
         return RowReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
-    }
-
-    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return RowReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/RowLayout.swift
+++ b/Amethyst/Layout/RowLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class RowReflowOperation: ReflowOperation {
+final class RowReflowOperation: ReflowOperation, FrameReflower {
     let layout: RowLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: RowLayout, frameAssigner: FrameAssigner) {
@@ -76,7 +76,7 @@ final class RowReflowOperation: ReflowOperation {
     }
 }
 
-final class RowLayout: Layout {
+final class RowLayout: Layout, FramedLayout {
     static var layoutName: String { return "Row" }
     static var layoutKey: String { return "row" }
 
@@ -89,7 +89,7 @@ final class RowLayout: Layout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
+    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
         return RowReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 

--- a/Amethyst/Layout/TallLayout.swift
+++ b/Amethyst/Layout/TallLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class TallReflowOperation: ReflowOperation, FrameReflower {
+final class TallReflowOperation: ReflowOperation {
     let layout: TallLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: TallLayout, frameAssigner: FrameAssigner) {
@@ -16,7 +16,7 @@ final class TallReflowOperation: ReflowOperation, FrameReflower {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    func frameAssignments() -> [FrameAssignment] {
+    override func frameAssignments() -> [FrameAssignment]? {
         guard !windows.isEmpty else {
             return []
         }
@@ -63,18 +63,9 @@ final class TallReflowOperation: ReflowOperation, FrameReflower {
             return assignments
         }
     }
-
-    override func main() {
-        guard !isCancelled else {
-            return
-        }
-
-        frameAssigner.performFrameAssignments(frameAssignments())
-    }
 }
 
-final class TallLayout: Layout, FramedLayout {
-
+final class TallLayout: Layout {
     static var layoutName: String { return "Tall" }
     static var layoutKey: String { return "tall" }
 
@@ -87,12 +78,8 @@ final class TallLayout: Layout, FramedLayout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
+    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation? {
         return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
-    }
-
-    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/TallLayout.swift
+++ b/Amethyst/Layout/TallLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class TallReflowOperation: ReflowOperation {
+final class TallReflowOperation: ReflowOperation, FrameReflower {
     let layout: TallLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: TallLayout, frameAssigner: FrameAssigner) {
@@ -73,7 +73,8 @@ final class TallReflowOperation: ReflowOperation {
     }
 }
 
-final class TallLayout: Layout {
+final class TallLayout: Layout, FramedLayout {
+
     static var layoutName: String { return "Tall" }
     static var layoutKey: String { return "tall" }
 
@@ -86,7 +87,7 @@ final class TallLayout: Layout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
+    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
         return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 

--- a/Amethyst/Layout/TallRightLayout.swift
+++ b/Amethyst/Layout/TallRightLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class TallRightReflowOperation: ReflowOperation {
+final class TallRightReflowOperation: ReflowOperation, FrameReflower {
     let layout: TallRightLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: TallRightLayout, frameAssigner: FrameAssigner) {
@@ -73,7 +73,7 @@ final class TallRightReflowOperation: ReflowOperation {
     }
 }
 
-final class TallRightLayout: Layout {
+final class TallRightLayout: Layout, FramedLayout {
     static var layoutName: String { return "Tall Right" }
     static var layoutKey: String { return "tall-right" }
 
@@ -86,7 +86,7 @@ final class TallRightLayout: Layout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
+    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
         return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 

--- a/Amethyst/Layout/TallRightLayout.swift
+++ b/Amethyst/Layout/TallRightLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class TallRightReflowOperation: ReflowOperation, FrameReflower {
+final class TallRightReflowOperation: ReflowOperation {
     let layout: TallRightLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: TallRightLayout, frameAssigner: FrameAssigner) {
@@ -16,7 +16,7 @@ final class TallRightReflowOperation: ReflowOperation, FrameReflower {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    func frameAssignments() -> [FrameAssignment] {
+    override func frameAssignments() -> [FrameAssignment]? {
         guard !windows.isEmpty else {
             return []
         }
@@ -63,17 +63,9 @@ final class TallRightReflowOperation: ReflowOperation, FrameReflower {
             return assignments
         }
     }
-
-    override func main() {
-         guard !isCancelled else {
-            return
-        }
-
-        frameAssigner.performFrameAssignments(frameAssignments())
-    }
 }
 
-final class TallRightLayout: Layout, FramedLayout {
+final class TallRightLayout: Layout {
     static var layoutName: String { return "Tall Right" }
     static var layoutKey: String { return "tall-right" }
 
@@ -86,12 +78,8 @@ final class TallRightLayout: Layout, FramedLayout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
+    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation? {
         return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
-    }
-
-    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/ThreeColumnLayout.swift
+++ b/Amethyst/Layout/ThreeColumnLayout.swift
@@ -133,7 +133,7 @@ internal struct TriplePaneArrangement {
     }
 }
 
-final class ThreeColumnReflowOperation: ReflowOperation {
+final class ThreeColumnReflowOperation: ReflowOperation, FrameReflower {
     private let layout: ThreeColumnLayout & MainColumnSpecifier
 
     fileprivate init(screen: NSScreen, windows: [SIWindow],
@@ -230,29 +230,29 @@ extension MainColumnSpecifier where Self: ThreeColumnLayout & Layout {
         return ThreeColumnReflowOperation(screen: screen, windows: windows, layout: self)
     }
 
-    internal func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
+    internal func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
         return reflow3columns(windows, on: screen)
     }
 
     internal func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return reflow3columns(windows, on: screen).frameAssignments().first { $0.window == window }
+        return reflowFrames(windows, on: screen).frameAssignments().first { $0.window == window }
     }
 }
 
 // implement the three variants
-final class ThreeColumnLeftLayout: ThreeColumnLayout, MainColumnSpecifier, Layout {
+final class ThreeColumnLeftLayout: ThreeColumnLayout, MainColumnSpecifier, Layout, FramedLayout {
     static var layoutName: String { return "3Column Left" }
     static var layoutKey: String { return "3column-left" }
     internal let mainColumn = Column.left
 }
 
-final class ThreeColumnMiddleLayout: ThreeColumnLayout, MainColumnSpecifier, Layout {
+final class ThreeColumnMiddleLayout: ThreeColumnLayout, MainColumnSpecifier, Layout, FramedLayout {
     static var layoutName: String { return "3Column Middle" }
     static var layoutKey: String { return "middle-wide" }  // for backwards compatibility with users who still have 'middle-wide' in their active layouts
     internal let mainColumn = Column.middle
 }
 
-final class ThreeColumnRightLayout: ThreeColumnLayout, MainColumnSpecifier, Layout {
+final class ThreeColumnRightLayout: ThreeColumnLayout, MainColumnSpecifier, Layout, FramedLayout {
     static var layoutName: String { return "3Column Right" }
     static var layoutKey: String { return "3column-right" }
     internal let mainColumn = Column.right

--- a/Amethyst/Layout/ThreeColumnLayout.swift
+++ b/Amethyst/Layout/ThreeColumnLayout.swift
@@ -133,7 +133,7 @@ internal struct TriplePaneArrangement {
     }
 }
 
-final class ThreeColumnReflowOperation: ReflowOperation, FrameReflower {
+final class ThreeColumnReflowOperation: ReflowOperation {
     private let layout: ThreeColumnLayout & MainColumnSpecifier
 
     fileprivate init(screen: NSScreen, windows: [SIWindow],
@@ -142,7 +142,7 @@ final class ThreeColumnReflowOperation: ReflowOperation, FrameReflower {
         super.init(screen: screen, windows: windows, frameAssigner: layout)
     }
 
-    func frameAssignments() -> [FrameAssignment] {
+    override func frameAssignments() -> [FrameAssignment]? {
         guard !windows.isEmpty else {
             return []
         }
@@ -198,14 +198,6 @@ final class ThreeColumnReflowOperation: ReflowOperation, FrameReflower {
             return assignments
         }
     }
-
-    override func main() {
-        guard !isCancelled else {
-            return
-        }
-
-        layout.performFrameAssignments(frameAssignments())
-    }
 }
 
 // not an actual Layout, just a base class for the three actual Layouts below
@@ -230,29 +222,25 @@ extension MainColumnSpecifier where Self: ThreeColumnLayout & Layout {
         return ThreeColumnReflowOperation(screen: screen, windows: windows, layout: self)
     }
 
-    internal func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
+    internal func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation? {
         return reflow3columns(windows, on: screen)
-    }
-
-    internal func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return reflowFrames(windows, on: screen).frameAssignments().first { $0.window == window }
     }
 }
 
 // implement the three variants
-final class ThreeColumnLeftLayout: ThreeColumnLayout, MainColumnSpecifier, Layout, FramedLayout {
+final class ThreeColumnLeftLayout: ThreeColumnLayout, MainColumnSpecifier, Layout {
     static var layoutName: String { return "3Column Left" }
     static var layoutKey: String { return "3column-left" }
     internal let mainColumn = Column.left
 }
 
-final class ThreeColumnMiddleLayout: ThreeColumnLayout, MainColumnSpecifier, Layout, FramedLayout {
+final class ThreeColumnMiddleLayout: ThreeColumnLayout, MainColumnSpecifier, Layout {
     static var layoutName: String { return "3Column Middle" }
     static var layoutKey: String { return "middle-wide" }  // for backwards compatibility with users who still have 'middle-wide' in their active layouts
     internal let mainColumn = Column.middle
 }
 
-final class ThreeColumnRightLayout: ThreeColumnLayout, MainColumnSpecifier, Layout, FramedLayout {
+final class ThreeColumnRightLayout: ThreeColumnLayout, MainColumnSpecifier, Layout {
     static var layoutName: String { return "3Column Right" }
     static var layoutKey: String { return "3column-right" }
     internal let mainColumn = Column.right

--- a/Amethyst/Layout/WideLayout.swift
+++ b/Amethyst/Layout/WideLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-private final class WideReflowOperation: ReflowOperation, FrameReflower {
+private final class WideReflowOperation: ReflowOperation {
     private let layout: WideLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: WideLayout, frameAssigner: FrameAssigner) {
@@ -16,7 +16,7 @@ private final class WideReflowOperation: ReflowOperation, FrameReflower {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    func frameAssignments() -> [FrameAssignment] {
+    override func frameAssignments() -> [FrameAssignment]? {
         guard !windows.isEmpty else {
             return []
         }
@@ -63,18 +63,9 @@ private final class WideReflowOperation: ReflowOperation, FrameReflower {
             return assignments
         }
     }
-
-    override func main() {
-
-        guard !isCancelled else {
-            return
-        }
-
-        frameAssigner.performFrameAssignments(frameAssignments())
-    }
 }
 
-final class WideLayout: Layout, FramedLayout {
+final class WideLayout: Layout {
     static var layoutName: String { return "Wide" }
     static var layoutKey: String { return "wide" }
 
@@ -87,12 +78,8 @@ final class WideLayout: Layout, FramedLayout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
+    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation? {
         return WideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
-    }
-
-    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return WideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/WideLayout.swift
+++ b/Amethyst/Layout/WideLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-private final class WideReflowOperation: ReflowOperation {
+private final class WideReflowOperation: ReflowOperation, FrameReflower {
     private let layout: WideLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: WideLayout, frameAssigner: FrameAssigner) {
@@ -74,7 +74,7 @@ private final class WideReflowOperation: ReflowOperation {
     }
 }
 
-final class WideLayout: Layout {
+final class WideLayout: Layout, FramedLayout {
     static var layoutName: String { return "Wide" }
     static var layoutKey: String { return "wide" }
 
@@ -87,7 +87,7 @@ final class WideLayout: Layout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
+    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
         return WideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 

--- a/Amethyst/Layout/WidescreenTallLayout.swift
+++ b/Amethyst/Layout/WidescreenTallLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class WidescreenTallReflowOperation: ReflowOperation, FrameReflower {
+final class WidescreenTallReflowOperation: ReflowOperation {
     let layout: WidescreenTallLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: WidescreenTallLayout, frameAssigner: FrameAssigner) {
@@ -16,7 +16,7 @@ final class WidescreenTallReflowOperation: ReflowOperation, FrameReflower {
         super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
     }
 
-    func frameAssignments() -> [FrameAssignment] {
+    override func frameAssignments() -> [FrameAssignment]? {
         if windows.count == 0 {
             return []
         }
@@ -65,18 +65,9 @@ final class WidescreenTallReflowOperation: ReflowOperation, FrameReflower {
             return assignments
         }
     }
-
-    override func main() {
-
-        if isCancelled {
-            return
-        }
-
-        frameAssigner.performFrameAssignments(frameAssignments())
-    }
 }
 
-final class WidescreenTallLayout: Layout, FramedLayout {
+final class WidescreenTallLayout: Layout {
     static var layoutName: String { return "Widescreen Tall" }
     static var layoutKey: String { return "widescreen-tall" }
 
@@ -89,12 +80,8 @@ final class WidescreenTallLayout: Layout, FramedLayout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
+    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation? {
         return WidescreenTallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
-    }
-
-    func assignedFrame(_ window: SIWindow, of windows: [SIWindow], on screen: NSScreen) -> FrameAssignment? {
-        return WidescreenTallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self).frameAssignments().first { $0.window == window }
     }
 }
 

--- a/Amethyst/Layout/WidescreenTallLayout.swift
+++ b/Amethyst/Layout/WidescreenTallLayout.swift
@@ -8,7 +8,7 @@
 
 import Silica
 
-final class WidescreenTallReflowOperation: ReflowOperation {
+final class WidescreenTallReflowOperation: ReflowOperation, FrameReflower {
     let layout: WidescreenTallLayout
 
     init(screen: NSScreen, windows: [SIWindow], layout: WidescreenTallLayout, frameAssigner: FrameAssigner) {
@@ -76,7 +76,7 @@ final class WidescreenTallReflowOperation: ReflowOperation {
     }
 }
 
-final class WidescreenTallLayout: Layout {
+final class WidescreenTallLayout: Layout, FramedLayout {
     static var layoutName: String { return "Widescreen Tall" }
     static var layoutKey: String { return "widescreen-tall" }
 
@@ -89,7 +89,7 @@ final class WidescreenTallLayout: Layout {
         self.windowActivityCache = windowActivityCache
     }
 
-    func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation {
+    func reflowFrames(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation & FrameReflower {
         return WidescreenTallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: self)
     }
 

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -141,8 +141,8 @@ class MouseStateKeeper {
         let unflippedY = NSScreen.globalHeight() - flippedPointerLocation.y + screen.frameIncludingDockAndMenu().origin.y
         let pointerLocation = NSPointToCGPoint(NSPoint(x: flippedPointerLocation.x, y: unflippedY))
 
-        if let framedLayout = delegate.focusedScreenManager()?.currentLayout as? FramedLayout {
-            if let framedWindow = framedLayout.windowAtPoint(pointerLocation, of: windows, on: screen) {
+        if let layout = delegate.focusedScreenManager()?.currentLayout {
+            if let framedWindow = layout.windowAtPoint(pointerLocation, of: windows, on: screen) {
                 return delegate.switchWindow(draggedWindow, with: framedWindow)
             }
         }

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -132,9 +132,7 @@ class MouseStateKeeper {
     // Execute an action that was initiated by the observer and completed by the state keeper
     func swapDraggedWindowWithDropzone(_ draggedWindow: SIWindow) {
         guard let delegate = self.delegate else { return }
-        guard let screen = draggedWindow.screen() else {
-            return
-        }
+        guard let screen = draggedWindow.screen() else { return }
 
         let windows = delegate.windows(on: screen)
 
@@ -142,6 +140,12 @@ class MouseStateKeeper {
         let flippedPointerLocation = NSPointToCGPoint(NSEvent.mouseLocation)
         let unflippedY = NSScreen.globalHeight() - flippedPointerLocation.y + screen.frameIncludingDockAndMenu().origin.y
         let pointerLocation = NSPointToCGPoint(NSPoint(x: flippedPointerLocation.x, y: unflippedY))
+
+        if let framedLayout = delegate.focusedScreenManager()?.currentLayout as? FramedLayout {
+            if let framedWindow = framedLayout.windowAtPoint(pointerLocation, of: windows, on: screen) {
+                return delegate.switchWindow(draggedWindow, with: framedWindow)
+            }
+        }
 
         // Ignore if there is no window at that point
         guard let secondWindow = SIWindow.alternateWindowForScreenAtPoint(pointerLocation, withWindows: windows, butNot: draggedWindow) else {

--- a/Amethyst/Managers/WindowModifier.swift
+++ b/Amethyst/Managers/WindowModifier.swift
@@ -454,6 +454,8 @@ extension WindowManager: WindowMover {
             return
         }
 
+        guard windowIndex != otherWindowIndex else { return }
+
         windows[windowIndex] = otherWindow
         windows[otherWindowIndex] = window
         let theChange = WindowChange.windowSwap(window: window, otherWindow: otherWindow)


### PR DESCRIPTION
## Problem
This fixes a problem commonly found with the new google chrome where mouse-based swap actions don't actually work. This comes from some strange reporting of window boundaries by google chrome.

### Demo

![dec-04-2018 13-26-42 amethyst broken mouse](https://user-images.githubusercontent.com/583459/49464306-90d1f980-f7c8-11e8-9003-42dc6829c61c.gif)


## Solution

I've slightly tweaked the reflow code to refer to what the layout says the frame boundaries are, not what the windows say their boundaries are.

This has the added effect of being able to swap a window with a fixed-size window like the settings window without dragging your cursor over the settings window itself -- you need only drag the window over the frame occupied by settings.

### Demo

![dec-04-2018 13-34-38 amethyst fixed mouse](https://user-images.githubusercontent.com/583459/49464625-6a608e00-f7c9-11e8-83da-0e43c3394fe4.gif)
