### PR TITLE
Simplify some of the dependency handling

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,6 +13,7 @@ target 'Amethyst' do
   pod 'Silica', git: 'https://github.com/ianyh/Silica'
   pod 'Sparkle'
   pod 'SwiftyJSON', '~> 3.1'
+  pod 'SwiftLint'
 
   target 'AmethystTests' do
     inherit! :search_paths

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -34,7 +34,7 @@ fi
 printf "Checking for bundler: "
 bundle version >/dev/null 2>&1 || { printf >&2 "nope!\nbundler must be installed. Try running:\n\tgem install bundler\n"; exit 1; }
 printf "\nChecking for CocoaPods:\n"
-pod --version > /dev/nul 2>&1 || { printf >&2 "nope!\nCocoaPods must be installed. Try running:\n\tgem install cocoapods\n"; exit 1; }
+pod --version > /dev/null 2>&1 || { printf >&2 "nope!\nCocoaPods must be installed. Try running:\n\tgem install cocoapods\n"; exit 1; }
 # Install pods
 printf "Installing Pods:\n"
 pod install

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -10,11 +10,6 @@ else
     printf "WARNING: Xcode $OUR_XCODE is used to develop this project.\n"
 fi
 
-# Check for swiftlint
-printf "Checking for swiftlint: "
-swiftlint version >/dev/null 2>&1 || { printf >&2 "nope!\nswiftlint must be installed. Try running:\n\tbrew install swiftlint\n"; exit 1; }
-printf "found!\n"
-
 # Check for installed ruby version
 printf "Checking for rbenv: "
 if rbenv version >/dev/null 2>&1 ; then
@@ -38,12 +33,10 @@ fi
 # Install CocoaPods via bundler
 printf "Checking for bundler: "
 bundle version >/dev/null 2>&1 || { printf >&2 "nope!\nbundler must be installed. Try running:\n\tgem install bundler\n"; exit 1; }
-printf "\nInstalling CocoaPods via bundler:\n"
-bundle install
-bundle exec pod --version >/dev/null 2>&1 || { echo >&2 "CocoaPods failed to install! You might want to open an issue for this: https://github.com/ianyh/Amethyst/issues/new"; exit 1; }
-
+printf "\nChecking for CocoaPods:\n"
+pod --version > /dev/nul 2>&1 || { printf >&2 "nope!\nCocoaPods must be installed. Try running:\n\tgem install cocoapods\n"; exit 1; }
 # Install pods
 printf "Installing Pods:\n"
-bundle exec pod install
+pod install
 
 printf "\n\nDone! Now you can open Amethyst.xcworkspace and build\n"


### PR DESCRIPTION
Since the project is already using CocoaPods, SwiftLint should probably be installed that way since a pod is available from it. I added it to the Podfile and took that section out of the setup script.  I also think that, instead of just automatically installing CocoaPods via bundler in the script, we should check for CocoaPods and allow the user/developer to install it how they wish, suggesting to use `gem install cocoapods` as is in the CocoaPods documentation.  I then changed the appropriate line to `pod install` since it would no longer be under bundler.  I left the bundler check in there for now because I am not sure if it is used for anything else in the project.