### PR TITLE
Show layout names rather than keys in Preferences UI

### DIFF
--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -187,9 +187,9 @@ final class HotKeyManager: NSObject {
             self.userConfiguration.toggleFocusFollowsMouse()
         }
 
-        LayoutManager.availableLayoutStrings().forEach { layoutString in
-            self.constructCommandWithCommandKey(UserConfiguration.constructLayoutKeyString(layoutString)) {
-                windowManager.focusedScreenManager()?.selectLayout(layoutString)
+        LayoutManager.availableLayoutStrings().forEach { (layoutKey, _) in
+            self.constructCommandWithCommandKey(UserConfiguration.constructLayoutKeyString(layoutKey)) {
+                windowManager.focusedScreenManager()?.selectLayout(layoutKey)
             }
         }
     }
@@ -336,9 +336,9 @@ final class HotKeyManager: NSObject {
         hotKeyNameToDefaultsKey.append(["Display current layout", CommandKey.displayCurrentLayout.rawValue])
         hotKeyNameToDefaultsKey.append(["Toggle global tiling", CommandKey.toggleTiling.rawValue])
 
-        for layoutString in LayoutManager.availableLayoutStrings() {
-            let commandName = "Select \(layoutString) layout"
-            let commandKey = "select-\(layoutString)-layout"
+        for (layoutKey, layoutName) in LayoutManager.availableLayoutStrings() {
+            let commandName = "Select \(layoutName) layout"
+            let commandKey = "select-\(layoutKey)-layout"
             hotKeyNameToDefaultsKey.append([commandName, commandKey])
         }
 

--- a/Amethyst/Layout/Layout.swift
+++ b/Amethyst/Layout/Layout.swift
@@ -239,6 +239,8 @@ protocol Layout {
 
     var windowActivityCache: WindowActivityCache { get }
 
+    init(windowActivityCache: WindowActivityCache)
+
     func reflow(_ windows: [SIWindow], on screen: NSScreen) -> ReflowOperation?
 }
 

--- a/Amethyst/Managers/LayoutManager.swift
+++ b/Amethyst/Managers/LayoutManager.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 enum LayoutManager {
-    static func layoutForKey(_ layoutString: String, with windowActivityCache: WindowActivityCache) -> Layout? {
-        switch layoutString {
+    static func layoutForKey(_ layoutKey: String, with windowActivityCache: WindowActivityCache) -> Layout? {
+        switch layoutKey {
         case "tall":
             return TallLayout(windowActivityCache: windowActivityCache)
         case "tall-right":
@@ -40,7 +40,39 @@ enum LayoutManager {
         }
     }
 
-    static func availableLayoutStrings() -> [String] {
+    static func layoutNameForKey(_ layoutKey: String) -> String? {
+        switch layoutKey {
+        case "tall":
+            return TallLayout.layoutName
+        case "tall-right":
+            return TallRightLayout.layoutName
+        case "wide":
+            return WideLayout.layoutName
+        case "3column-left":
+            return ThreeColumnLeftLayout.layoutName
+        case "middle-wide":
+            return ThreeColumnMiddleLayout.layoutName
+        case "3column-right":
+            return ThreeColumnRightLayout.layoutName
+        case "fullscreen":
+            return FullscreenLayout.layoutName
+        case "column":
+            return ColumnLayout.layoutName
+        case "row":
+            return RowLayout.layoutName
+        case "floating":
+            return FloatingLayout.layoutName
+        case "widescreen-tall":
+            return WidescreenTallLayout.layoutName
+        case "bsp":
+            return BinarySpacePartitioningLayout.layoutName
+        default:
+            return nil
+        }
+    }
+
+    // Returns a list of (key, name) pairs
+    static func availableLayoutStrings() -> [(key: String, name: String)] {
         let layoutClasses: [Layout.Type] = [
             TallLayout.self,
             TallRightLayout.self,
@@ -56,14 +88,14 @@ enum LayoutManager {
             BinarySpacePartitioningLayout.self
         ]
 
-        return layoutClasses.map { $0.layoutKey }
+        return layoutClasses.map { ($0.layoutKey, $0.layoutName) }
     }
 
     static func layoutsWithConfiguration(_ userConfiguration: UserConfiguration, windowActivityCache: WindowActivityCache) -> [Layout] {
-        let layoutStrings: [String] = userConfiguration.layoutStrings()
-        let layouts = layoutStrings.map { layoutString -> Layout? in
-            guard let layout = LayoutManager.layoutForKey(layoutString, with: windowActivityCache) else {
-                log.warning("Unrecognized layout string \(layoutString)")
+        let layoutKeys: [String] = userConfiguration.layoutKeys()
+        let layouts = layoutKeys.map { layoutKey -> Layout? in
+            guard let layout = LayoutManager.layoutForKey(layoutKey, with: windowActivityCache) else {
+                log.warning("Unrecognized layout key \(layoutKey)")
                 return nil
             }
 

--- a/Amethyst/Managers/LayoutManager.swift
+++ b/Amethyst/Managers/LayoutManager.swift
@@ -10,84 +10,32 @@ import Foundation
 
 enum LayoutManager {
     static func layoutForKey(_ layoutKey: String, with windowActivityCache: WindowActivityCache) -> Layout? {
-        switch layoutKey {
-        case "tall":
-            return TallLayout(windowActivityCache: windowActivityCache)
-        case "tall-right":
-            return TallRightLayout(windowActivityCache: windowActivityCache)
-        case "wide":
-            return WideLayout(windowActivityCache: windowActivityCache)
-        case "3column-left":
-            return ThreeColumnLeftLayout(windowActivityCache: windowActivityCache)
-        case "middle-wide":
-            return ThreeColumnMiddleLayout(windowActivityCache: windowActivityCache)
-        case "3column-right":
-            return ThreeColumnRightLayout(windowActivityCache: windowActivityCache)
-        case "fullscreen":
-            return FullscreenLayout(windowActivityCache: windowActivityCache)
-        case "column":
-            return ColumnLayout(windowActivityCache: windowActivityCache)
-        case "row":
-            return RowLayout(windowActivityCache: windowActivityCache)
-        case "floating":
-            return FloatingLayout(windowActivityCache: windowActivityCache)
-        case "widescreen-tall":
-            return WidescreenTallLayout(windowActivityCache: windowActivityCache)
-        case "bsp":
-            return BinarySpacePartitioningLayout(windowActivityCache: windowActivityCache)
-        default:
-            return nil
-        }
+        return layoutByKey[layoutKey]?.init(windowActivityCache: windowActivityCache)
     }
 
     static func layoutNameForKey(_ layoutKey: String) -> String? {
-        switch layoutKey {
-        case "tall":
-            return TallLayout.layoutName
-        case "tall-right":
-            return TallRightLayout.layoutName
-        case "wide":
-            return WideLayout.layoutName
-        case "3column-left":
-            return ThreeColumnLeftLayout.layoutName
-        case "middle-wide":
-            return ThreeColumnMiddleLayout.layoutName
-        case "3column-right":
-            return ThreeColumnRightLayout.layoutName
-        case "fullscreen":
-            return FullscreenLayout.layoutName
-        case "column":
-            return ColumnLayout.layoutName
-        case "row":
-            return RowLayout.layoutName
-        case "floating":
-            return FloatingLayout.layoutName
-        case "widescreen-tall":
-            return WidescreenTallLayout.layoutName
-        case "bsp":
-            return BinarySpacePartitioningLayout.layoutName
-        default:
-            return nil
-        }
+        return layoutByKey[layoutKey]?.layoutName
     }
+
+    static var layoutClasses: [Layout.Type] = [
+        TallLayout.self,
+        TallRightLayout.self,
+        WideLayout.self,
+        ThreeColumnLeftLayout.self,
+        ThreeColumnMiddleLayout.self,
+        ThreeColumnRightLayout.self,
+        FullscreenLayout.self,
+        ColumnLayout.self,
+        RowLayout.self,
+        FloatingLayout.self,
+        WidescreenTallLayout.self,
+        BinarySpacePartitioningLayout.self
+    ]
+
+    static var layoutByKey: [String: Layout.Type] = Dictionary(uniqueKeysWithValues: zip( layoutClasses.map { ($0.layoutKey) }, layoutClasses ))
 
     // Returns a list of (key, name) pairs
     static func availableLayoutStrings() -> [(key: String, name: String)] {
-        let layoutClasses: [Layout.Type] = [
-            TallLayout.self,
-            TallRightLayout.self,
-            WideLayout.self,
-            ThreeColumnLeftLayout.self,
-            ThreeColumnMiddleLayout.self,
-            ThreeColumnRightLayout.self,
-            FullscreenLayout.self,
-            ColumnLayout.self,
-            RowLayout.self,
-            FloatingLayout.self,
-            WidescreenTallLayout.self,
-            BinarySpacePartitioningLayout.self
-        ]
-
         return layoutClasses.map { ($0.layoutKey, $0.layoutName) }
     }
 

--- a/Amethyst/Preferences/GeneralPreferencesViewController.swift
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.swift
@@ -10,7 +10,7 @@ import Cocoa
 import Foundation
 
 final class GeneralPreferencesViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate {
-    private var layouts: [String] = []
+    private var layoutKeys: [String] = []
 
     @IBOutlet var layoutsTableView: NSTableView?
 
@@ -24,7 +24,7 @@ final class GeneralPreferencesViewController: NSViewController, NSTableViewDataS
     override func viewWillAppear() {
         super.viewWillAppear()
 
-        layouts = UserConfiguration.shared.layoutStrings()
+        layoutKeys = UserConfiguration.shared.layoutKeys()
 
         layoutsTableView?.reloadData()
     }
@@ -32,8 +32,10 @@ final class GeneralPreferencesViewController: NSViewController, NSTableViewDataS
     @IBAction func addLayout(_ sender: NSButton) {
         let layoutMenu = NSMenu(title: "")
 
-        for layoutString in LayoutManager.availableLayoutStrings() {
-            let menuItem = NSMenuItem(title: layoutString, action: #selector(addLayoutString(_:)), keyEquivalent: "")
+        for (layoutKey, layoutName) in LayoutManager.availableLayoutStrings() {
+            let menuItem = NSMenuItem(title: layoutKey, action: #selector(addLayoutString(_:)), keyEquivalent: "")
+            menuItem.attributedTitle = NSAttributedString(string: layoutName)
+            menuItem.title = layoutKey
             menuItem.target = self
             menuItem.action = #selector(addLayoutString(_:))
 
@@ -59,27 +61,27 @@ final class GeneralPreferencesViewController: NSViewController, NSTableViewDataS
     }
 
     @IBAction func addLayoutString(_ sender: NSMenuItem) {
-        var layouts = self.layouts
-        layouts.append(sender.title)
-        self.layouts = layouts
+        var layoutKeys = self.layoutKeys
+        layoutKeys.append(sender.title)
+        self.layoutKeys = layoutKeys
 
-        UserConfiguration.shared.setLayoutStrings(self.layouts)
+        UserConfiguration.shared.setLayoutKeys(self.layoutKeys)
 
         layoutsTableView?.reloadData()
     }
 
     @IBAction func removeLayout(_ sender: AnyObject) {
-        guard let selectedRow = layoutsTableView?.selectedRow, selectedRow < self.layouts.count, selectedRow != NSTableView.noRowSelectedIndex else { return }
+        guard let selectedRow = layoutsTableView?.selectedRow, selectedRow < self.layoutKeys.count, selectedRow != NSTableView.noRowSelectedIndex else { return }
 
-        layouts.remove(at: selectedRow)
+        layoutKeys.remove(at: selectedRow)
 
-        UserConfiguration.shared.setLayoutStrings(layouts)
+        UserConfiguration.shared.setLayoutKeys(layoutKeys)
 
         layoutsTableView?.reloadData()
     }
 
     func numberOfRows(in tableView: NSTableView) -> Int {
-        return layouts.count
+        return layoutKeys.count
     }
 
     func tableView(_ tableView: NSTableView, objectValueFor tableColumn: NSTableColumn?, row: Int) -> Any? {
@@ -87,6 +89,6 @@ final class GeneralPreferencesViewController: NSViewController, NSTableViewDataS
             return nil
         }
 
-        return layouts[row]
+        return LayoutManager.layoutNameForKey(layoutKeys[row])
     }
 }

--- a/Amethyst/Preferences/GeneralPreferencesViewController.swift
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.swift
@@ -33,9 +33,8 @@ final class GeneralPreferencesViewController: NSViewController, NSTableViewDataS
         let layoutMenu = NSMenu(title: "")
 
         for (layoutKey, layoutName) in LayoutManager.availableLayoutStrings() {
-            let menuItem = NSMenuItem(title: layoutKey, action: #selector(addLayoutString(_:)), keyEquivalent: "")
-            menuItem.attributedTitle = NSAttributedString(string: layoutName)
-            menuItem.title = layoutKey
+            let menuItem = NSMenuItem(title: layoutName, action: #selector(addLayoutString(_:)), keyEquivalent: "")
+            menuItem.representedObject = layoutKey
             menuItem.target = self
             menuItem.action = #selector(addLayoutString(_:))
 
@@ -61,8 +60,10 @@ final class GeneralPreferencesViewController: NSViewController, NSTableViewDataS
     }
 
     @IBAction func addLayoutString(_ sender: NSMenuItem) {
+        guard let layoutKey: String = sender.representedObject as? String else { return }
+
         var layoutKeys = self.layoutKeys
-        layoutKeys.append(sender.title)
+        layoutKeys.append(layoutKey)
         self.layoutKeys = layoutKeys
 
         UserConfiguration.shared.setLayoutKeys(self.layoutKeys)

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -312,8 +312,8 @@ final class UserConfiguration: NSObject {
         modifier2 = modifierFlagsForStrings(mod2Strings)
     }
 
-    static func constructLayoutKeyString(_ layoutString: String) -> String {
-        return "select-\(layoutString)-layout"
+    static func constructLayoutKeyString(_ layoutKey: String) -> String {
+        return "select-\(layoutKey)-layout"
     }
 
     func constructCommand(for hotKeyRegistrar: HotKeyRegistrar, commandKey: String, handler: @escaping HotKeyHandler) {
@@ -388,13 +388,13 @@ final class UserConfiguration: NSObject {
         }
     }
 
-    func layoutStrings() -> [String] {
-        let layoutStrings = storage.array(forKey: .layouts) as? [String]
-        return layoutStrings ?? []
+    func layoutKeys() -> [String] {
+        let layoutKeys = storage.array(forKey: .layouts) as? [String]
+        return layoutKeys ?? []
     }
 
-    func setLayoutStrings(_ layoutStrings: [String]) {
-        storage.set(layoutStrings as Any?, forKey: .layouts)
+    func setLayoutKeys(_ layoutKeys: [String]) {
+        storage.set(layoutKeys as Any?, forKey: .layouts)
     }
 
     func runningApplication(_ runningApplication: BundleIdentifiable, shouldFloatWindowWithTitle title: String) -> Bool {

--- a/AmethystTests/Configuration/UserConfigurationTests.swift
+++ b/AmethystTests/Configuration/UserConfigurationTests.swift
@@ -414,10 +414,10 @@ final class UserConfigurationTests: QuickSpec {
 
                 storage.set(existingLayouts, forKey: .layouts)
 
-                expect(configuration.layoutStrings()).to(equal(existingLayouts))
+                expect(configuration.layoutKeys()).to(equal(existingLayouts))
                 configuration.defaultConfiguration = JSON(defaultConfiguration)
                 configuration.loadConfiguration()
-                expect(configuration.layoutStrings()).to(equal(existingLayouts))
+                expect(configuration.layoutKeys()).to(equal(existingLayouts))
             }
 
             it("local configuration does override existing configuration") {
@@ -437,11 +437,11 @@ final class UserConfigurationTests: QuickSpec {
 
                 storage.set(existingLayouts, forKey: .layouts)
 
-                expect(configuration.layoutStrings()).to(equal(existingLayouts))
+                expect(configuration.layoutKeys()).to(equal(existingLayouts))
                 configuration.configuration = JSON(localConfiguration)
                 configuration.defaultConfiguration = JSON(defaultConfiguration)
                 configuration.loadConfiguration()
-                expect(configuration.layoutStrings()).to(equal(localConfiguration["layouts"]))
+                expect(configuration.layoutKeys()).to(equal(localConfiguration["layouts"]))
             }
         }
 


### PR DESCRIPTION
Also rename some variables/functions to explicitly distinguish between layout keys and
names (avoid ambiguous term `layoutString`).  If you want, I can split this into two separate PRs, but I figured they are quite related.

This should be a UI change only; functionality should not be affected.  For instance, preferences storage is still by layout key, not layout name; it's just displayed as layout names.

With this PR, the layout _keys_ should be entirely invisible to the average user, unless I'm missing something.  This is advantageous for layouts where the key bears little resemblance to the name, e.g. key `middle-wide` with name `3Column Middle`.