### PR TITLE
Update the Homebrew Cask GitHub link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A quick screencast of basic functionality can be found [here](https://youtu.be/b
 Getting Amethyst
 ================
 
-Amethyst is available for direct download on the [releases page](https://github.com/ianyh/Amethyst/releases) or using [homebrew cask](https://github.com/caskroom/homebrew-cask).
+Amethyst is available for direct download on the [releases page](https://github.com/ianyh/Amethyst/releases) or using [homebrew cask](https://github.com/Homebrew/homebrew-cask).
 
 ```
 brew cask install amethyst


### PR DESCRIPTION
- It moved from the caskroom org some time ago.