### PR TITLE
Fix handling of focusChanged and remove events in setNeedsReflowWithWindowChange (Fixes #703 and #838)

### DIFF
--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -93,7 +93,7 @@ final class ScreenManager<Window: WindowType>: NSObject {
     }
 
     func setNeedsReflowWithWindowChange(_ windowChange: Change<Window>) {
-        if case let .add(window) = windowChange {
+        if case let .focusChanged(window) = windowChange {
             lastFocusedWindow = window
         }
 

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -93,8 +93,12 @@ final class ScreenManager<Window: WindowType>: NSObject {
     }
 
     func setNeedsReflowWithWindowChange(_ windowChange: Change<Window>) {
-        if case let .focusChanged(window) = windowChange {
+        switch windowChange {
+        case let .focusChanged(window):
             lastFocusedWindow = window
+        case .remove:
+            lastFocusedWindow = nil
+        default: ()
         }
 
         reflowOperation?.cancel()

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -94,11 +94,18 @@ final class ScreenManager<Window: WindowType>: NSObject {
 
     func setNeedsReflowWithWindowChange(_ windowChange: Change<Window>) {
         switch windowChange {
+        case let .add(window: window):
+            lastFocusedWindow = window
         case let .focusChanged(window):
             lastFocusedWindow = window
-        case .remove:
-            lastFocusedWindow = nil
-        default: ()
+        case let .remove(window):
+            if lastFocusedWindow == window {
+                lastFocusedWindow = nil
+            }
+        case .windowSwap:
+            break
+        case .unknown:
+            break
         }
 
         reflowOperation?.cancel()


### PR DESCRIPTION
I tracked issue #703 down to lastFocusedWindow only being updated when a new window was added, rather than when focus was changed.