### PR TITLE
Treat empty and nil window titles as unreliable for floating

### DIFF
--- a/Amethyst/Categories/SIApplication+Amethyst.swift
+++ b/Amethyst/Categories/SIApplication+Amethyst.swift
@@ -10,12 +10,12 @@ import Foundation
 import Silica
 
 extension SIApplication {
-    func windowWithTitleShouldFloat(_ windowTitle: String) -> Bool {
+    func defaultFloatForWindowWithTitle(_ windowTitle: String?) -> DefaultFloat {
         guard let runningApplication = NSRunningApplication(processIdentifier: processIdentifier()) else {
-            return true
+            return .notFloating
         }
 
-        return UserConfiguration.shared.runningApplication(runningApplication, shouldFloatWindowWithTitle: windowTitle)
+        return UserConfiguration.shared.runningApplication(runningApplication, byDefaultFloatsForTitle: windowTitle)
     }
 
     func observe(notification: String, with accessibilityElement: SIAccessibilityElement, handler: @escaping SIAXNotificationHandler) -> Bool {

--- a/Amethyst/Categories/SIApplication+Amethyst.swift
+++ b/Amethyst/Categories/SIApplication+Amethyst.swift
@@ -12,7 +12,7 @@ import Silica
 extension SIApplication {
     func defaultFloatForWindowWithTitle(_ windowTitle: String?) -> DefaultFloat {
         guard let runningApplication = NSRunningApplication(processIdentifier: processIdentifier()) else {
-            return .notFloating
+            return .floating
         }
 
         return UserConfiguration.shared.runningApplication(runningApplication, byDefaultFloatsForTitle: windowTitle)

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -317,9 +317,30 @@ extension WindowManager {
         markAllScreensForReflowWithChange(.unknown)
     }
 
-    func add(window: Window) {
+    private func add(window: Window, retries: Int = 5) {
         guard !windows.contains(window) && window.shouldBeManaged() else {
             return
+        }
+
+        guard let application = applicationWithProcessIdentifier(window.pid()) else {
+            log.error("Tried to add a window without an application")
+            return
+        }
+
+        let defaultFloat = application.defaultFloatForWindowWithTitle(window.title())
+        switch defaultFloat {
+        case .unreliable where retries > 0:
+            return DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                self.add(window: window, retries: retries - 1)
+            }
+        case .floating, .unreliable(.floating):
+            floatingMap[window.windowID()] = true
+        case .notFloating, .unreliable(.notFloating):
+            floatingMap[window.windowID()] = false
+        case .unreliable(.unreliable):
+            // Uh, what?
+            log.error("Reached nested unreliability")
+            floatingMap[window.windowID()] = false
         }
 
         regenerateActiveIDCache()
@@ -328,17 +349,6 @@ extension WindowManager {
             windows.insert(window, at: 0)
         } else {
             windows.append(window)
-        }
-
-        guard let application = applicationWithProcessIdentifier(window.pid()) else {
-            log.error("Tried to add a window without an application")
-            return
-        }
-
-        if let windowTitle = window.title(), application.windowWithTitleShouldFloat(windowTitle) {
-            floatingMap[window.windowID()] = true
-        } else {
-            floatingMap[window.windowID()] = window.shouldFloat()
         }
 
         application.observe(notification: kAXUIElementDestroyedNotification, window: window) { element in

--- a/Amethyst/Model/Application.swift
+++ b/Amethyst/Model/Application.swift
@@ -41,8 +41,11 @@ protocol ApplicationType: Equatable {
      
      - Parameters:
          - windowTitle: The window title to test.
+     
+     - Note:
+     We can receive an unreliable result. It is up to the caller to determine whether or not that result is good enough.
      */
-    func windowWithTitleShouldFloat(_ windowTitle: String) -> Bool
+    func defaultFloatForWindowWithTitle(_ windowTitle: String?) -> DefaultFloat
 
     /// Clears the internal cache of application windows.
     func dropWindowsCache()
@@ -138,8 +141,8 @@ class AnyApplication<Application: ApplicationType>: ApplicationType {
         return internalApplication.pid()
     }
 
-    func windowWithTitleShouldFloat(_ windowTitle: String) -> Bool {
-        return internalApplication.windowWithTitleShouldFloat(windowTitle)
+    func defaultFloatForWindowWithTitle(_ windowTitle: String?) -> DefaultFloat {
+        return internalApplication.defaultFloatForWindowWithTitle(windowTitle)
     }
 
     func dropWindowsCache() {

--- a/Amethyst/Model/ApplicationObservation.swift
+++ b/Amethyst/Model/ApplicationObservation.swift
@@ -193,7 +193,7 @@ struct ApplicationObservation<Delegate: ApplicationObservationDelegate> {
                 do {
                     try self.addObserver(for: notification)
                 } catch {
-                    log.error("Failed to add observer \(notification) on application \(self.application.title() ?? "<unknown>")")
+                    log.error("Failed to add observer \(notification) on application \(self.application.title() ?? "<unknown>") (\(self.application.pid()))")
                     self.removeObservers(notifications: observed)
                     throw error
                 }

--- a/AmethystTests/Configuration/UserConfigurationTests.swift
+++ b/AmethystTests/Configuration/UserConfigurationTests.swift
@@ -220,7 +220,7 @@ final class UserConfigurationTests: QuickSpec {
                 let title = UUID().uuidString
                 bundleIdentifiable.bundleIdentifier = "test.test.Test"
 
-                expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: title)).to(beFalse())
+                expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: title)).to(equal(.notFloating))
             }
 
             it("floats for exact matches") {
@@ -234,7 +234,7 @@ final class UserConfigurationTests: QuickSpec {
                 let title = UUID().uuidString
                 bundleIdentifiable.bundleIdentifier = "test.test.Test"
 
-                expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: title)).to(beTrue())
+                expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: title)).to(equal(.floating))
             }
 
             it("floats for wildcard matches") {
@@ -248,7 +248,7 @@ final class UserConfigurationTests: QuickSpec {
                 let title = UUID().uuidString
                 bundleIdentifiable.bundleIdentifier = "test.test.Test"
 
-                expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: title)).to(beTrue())
+                expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: title)).to(equal(.floating))
             }
 
             it("floats for prefixed wildcard matches") {
@@ -262,7 +262,7 @@ final class UserConfigurationTests: QuickSpec {
                 let title = UUID().uuidString
                 bundleIdentifiable.bundleIdentifier = "test.test.Test"
 
-                expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: title)).to(beTrue())
+                expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: title)).to(equal(.floating))
             }
 
             it("floats for inline wildcard matches") {
@@ -276,7 +276,7 @@ final class UserConfigurationTests: QuickSpec {
                 let title = UUID().uuidString
                 bundleIdentifiable.bundleIdentifier = "test.foo.Test"
 
-                expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: title)).to(beTrue())
+                expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: title)).to(equal(.floating))
             }
 
             it("does not float for exact mismatches") {
@@ -290,7 +290,7 @@ final class UserConfigurationTests: QuickSpec {
                 let title = UUID().uuidString
                 bundleIdentifiable.bundleIdentifier = "test.test.Test"
 
-                expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: title)).to(beFalse())
+                expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: title)).to(equal(.notFloating))
             }
 
             it("does not float for wildcard mismatches") {
@@ -304,7 +304,7 @@ final class UserConfigurationTests: QuickSpec {
                 let title = UUID().uuidString
                 bundleIdentifiable.bundleIdentifier = "test.test.Test"
 
-                expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: title)).to(beFalse())
+                expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: title)).to(equal(.notFloating))
             }
 
             context("as whitelist") {
@@ -320,7 +320,7 @@ final class UserConfigurationTests: QuickSpec {
                     let title = "test"
                     bundleIdentifiable.bundleIdentifier = "test.test.Test"
 
-                    expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: title)).to(beFalse())
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: title)).to(equal(.notFloating))
                 }
 
                 it("does not float for a matching application with no specified window titles") {
@@ -334,7 +334,7 @@ final class UserConfigurationTests: QuickSpec {
                     let title = UUID().uuidString
                     bundleIdentifiable.bundleIdentifier = "test.test.Test"
 
-                    expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: title)).to(beFalse())
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: title)).to(equal(.notFloating))
                 }
 
                 it("floats for no specified applications") {
@@ -348,8 +348,8 @@ final class UserConfigurationTests: QuickSpec {
                     let title = UUID().uuidString
                     bundleIdentifiable.bundleIdentifier = "test.test.Test"
 
-                    let float = configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: title)
-                    expect(float).to(beTrue())
+                    let float = configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: title)
+                    expect(float).to(equal(.floating))
                 }
             }
 
@@ -365,8 +365,8 @@ final class UserConfigurationTests: QuickSpec {
                     let bundleIdentifiable = TestBundleIdentifiable()
                     bundleIdentifiable.bundleIdentifier = "test.test.Test"
 
-                    expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: "test1")).to(beTrue())
-                    expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: "test2")).to(beFalse())
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: "test1")).to(equal(.floating))
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: "test2")).to(equal(.notFloating))
                 }
 
                 it("only allow windows with titles") {
@@ -380,8 +380,47 @@ final class UserConfigurationTests: QuickSpec {
                     let bundleIdentifiable = TestBundleIdentifiable()
                     bundleIdentifiable.bundleIdentifier = "test.test.Test"
 
-                    expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: "test1")).to(beFalse())
-                    expect(configuration.runningApplication(bundleIdentifiable, shouldFloatWindowWithTitle: "test2")).to(beTrue())
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: "test1")).to(equal(.notFloating))
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: "test2")).to(equal(.floating))
+                }
+
+                it("treats empty and nil titles as unreliable") {
+                    let storage = TestConfigurationStorage()
+                    let configuration = UserConfiguration(storage: storage)
+                    let floatingBundle = FloatingBundle(id: "test.test.Test", windowTitles: ["test1"])
+
+                    storage.set(true, forKey: .floatingBundleIdentifiersIsBlacklist)
+                    configuration.setFloatingBundles([floatingBundle])
+
+                    let bundleIdentifiable = TestBundleIdentifiable()
+                    bundleIdentifiable.bundleIdentifier = "test.test.Test"
+
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: "")).to(equal(.unreliable(.notFloating)))
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: nil)).to(equal(.unreliable(.notFloating)))
+
+                    storage.set(false, forKey: .floatingBundleIdentifiersIsBlacklist)
+
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: "")).to(equal(.unreliable(.floating)))
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: nil)).to(equal(.unreliable(.floating)))
+                }
+
+                it("treats empty and nil titles as reliable if no title would match anyway") {
+                    let storage = TestConfigurationStorage()
+                    let configuration = UserConfiguration(storage: storage)
+
+                    storage.set(true, forKey: .floatingBundleIdentifiersIsBlacklist)
+                    configuration.setFloatingBundles([])
+
+                    let bundleIdentifiable = TestBundleIdentifiable()
+                    bundleIdentifiable.bundleIdentifier = "test.test.Test"
+
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: "")).to(equal(.notFloating))
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: nil)).to(equal(.notFloating))
+
+                    storage.set(false, forKey: .floatingBundleIdentifiersIsBlacklist)
+
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: "")).to(equal(.floating))
+                    expect(configuration.runningApplication(bundleIdentifiable, byDefaultFloatsForTitle: nil)).to(equal(.floating))
                 }
             }
         }


### PR DESCRIPTION
Fixes #748 