### PR TITLE
Simplify layout structures

### DIFF
--- a/Amethyst.xcodeproj/project.pbxproj
+++ b/Amethyst.xcodeproj/project.pbxproj
@@ -369,10 +369,10 @@
 				40637072224EF9B20081299D /* Change.swift */,
 				401C35B22244650F0019ED07 /* MouseState.swift */,
 				400540F12325CDF4004B8656 /* Reliability.swift */,
+				40578C18232D9CC0006553A0 /* Screen.swift */,
 				400A5E9C2327350C00F0A2C3 /* Space.swift */,
 				4046EFCE2236019400113067 /* Window.swift */,
 				401BC8A71CE8E94000F89B3F /* WindowsInformation.swift */,
-				40578C18232D9CC0006553A0 /* Screen.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";

--- a/Amethyst/Layout/Layouts/ColumnLayout.swift
+++ b/Amethyst/Layout/Layouts/ColumnLayout.swift
@@ -8,25 +8,38 @@
 
 import Silica
 
-class ColumnReflowOperation<Window: WindowType>: ReflowOperation<Window> {
-    let layout: ColumnLayout<Window>
+class ColumnLayout<Window: WindowType>: Layout<Window>, PanedLayout {
+    override static var layoutName: String { return "Column" }
+    override static var layoutKey: String { return "column" }
 
-    init(screen: Screen, windows: [Window], layout: ColumnLayout<Window>, frameAssigner: FrameAssigner) {
-        self.layout = layout
-        super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
+    private(set) var mainPaneCount: Int = 1
+    private(set) var mainPaneRatio: CGFloat = 0.5
+
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
-    override func frameAssignments() -> [FrameAssignment<Window>]? {
+    func increaseMainPaneCount() {
+        mainPaneCount += 1
+    }
+
+    func decreaseMainPaneCount() {
+        mainPaneCount = max(1, mainPaneCount - 1)
+    }
+
+    override func frameAssignments(_ windowSet: WindowSet<Window>, on screen: Screen) -> [FrameAssignment<Window>]? {
+        let windows = windowSet.windows
+
         guard !windows.isEmpty else {
             return []
         }
 
-        let mainPaneCount = min(windows.count, layout.mainPaneCount)
+        let mainPaneCount = min(windows.count, self.mainPaneCount)
         let secondaryPaneCount = windows.count - mainPaneCount
         let hasSecondaryPane = secondaryPaneCount > 0
 
         let screenFrame = screen.adjustedFrame()
-        let mainPaneWindowWidth = round(screenFrame.width * (hasSecondaryPane ? CGFloat(layout.mainPaneRatio) : 1.0))
+        let mainPaneWindowWidth = round(screenFrame.width * (hasSecondaryPane ? CGFloat(mainPaneRatio) : 1.0))
         let secondaryPaneWindowWidth = hasSecondaryPane ? round((screenFrame.width - mainPaneWindowWidth) / CGFloat(secondaryPaneCount)) : 0.0
 
         return windows.reduce([]) { frameAssignments, window -> [FrameAssignment<Window>] in
@@ -50,36 +63,17 @@ class ColumnReflowOperation<Window: WindowType>: ReflowOperation<Window> {
             }
 
             let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .horizontal, scaleFactor: scaleFactor)
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isFocused(), screenFrame: screenFrame, resizeRules: resizeRules)
+            let frameAssignment = FrameAssignment<Window>(
+                frame: windowFrame,
+                window: window,
+                focused: windowSet.isWindowFloating(window),
+                screenFrame: screenFrame,
+                resizeRules: resizeRules
+            )
 
             assignments.append(frameAssignment)
 
             return assignments
         }
-    }
-}
-
-class ColumnLayout<Window: WindowType>: Layout<Window>, PanedLayout {
-    override static var layoutName: String { return "Column" }
-    override static var layoutKey: String { return "column" }
-
-    private(set) var mainPaneCount: Int = 1
-    private(set) var mainPaneRatio: CGFloat = 0.5
-
-    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
-        mainPaneRatio = rawRatio
-    }
-
-    func increaseMainPaneCount() {
-        mainPaneCount += 1
-    }
-
-    func decreaseMainPaneCount() {
-        mainPaneCount = max(1, mainPaneCount - 1)
-    }
-
-    override func reflow(_ windows: [Window], on screen: Screen) -> ReflowOperation<Window>? {
-        let assigner = Assigner(windowActivityCache: windowActivityCache)
-        return ColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: assigner)
     }
 }

--- a/Amethyst/Layout/Layouts/FloatingLayout.swift
+++ b/Amethyst/Layout/Layouts/FloatingLayout.swift
@@ -14,7 +14,7 @@ class FloatingLayout<Window: WindowType>: Layout<Window> {
 
     override var layoutDescription: String { return "" }
 
-    override func reflow(_ windows: [Window], on screen: Screen) -> ReflowOperation<Window>? {
+    override func frameAssignments(_ windowSet: WindowSet<Window>, on screen: Screen) -> [FrameAssignment<Window>]? {
         return nil
     }
 }

--- a/Amethyst/Layout/Layouts/FullscreenLayout.swift
+++ b/Amethyst/Layout/Layouts/FullscreenLayout.swift
@@ -8,31 +8,17 @@
 
 import Silica
 
-class FullscreenReflowOperation<Window: WindowType>: ReflowOperation<Window> {
-    private let layout: FullscreenLayout<Window>
-
-    init(screen: Screen, windows: [Window], layout: FullscreenLayout<Window>, frameAssigner: FrameAssigner) {
-        self.layout = layout
-        super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
-    }
-
-    override func frameAssignments() -> [FrameAssignment<Window>]? {
-        let screenFrame = screen.adjustedFrame()
-        return windows.map { window in
-            let resizeRules = ResizeRules(isMain: true, unconstrainedDimension: .horizontal, scaleFactor: 1)
-            return FrameAssignment(frame: screenFrame, window: window, focused: false, screenFrame: screenFrame, resizeRules: resizeRules)
-        }
-    }
-}
-
 class FullscreenLayout<Window: WindowType>: Layout<Window> {
     override static var layoutName: String { return "Fullscreen" }
     override static var layoutKey: String { return "fullscreen" }
 
     override var layoutDescription: String { return "" }
 
-    override func reflow(_ windows: [Window], on screen: Screen) -> ReflowOperation<Window>? {
-        let assigner = Assigner(windowActivityCache: windowActivityCache)
-        return FullscreenReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: assigner)
+    override func frameAssignments(_ windowSet: WindowSet<Window>, on screen: Screen) -> [FrameAssignment<Window>]? {
+        let screenFrame = screen.adjustedFrame()
+        return windowSet.windows.map { window in
+            let resizeRules = ResizeRules(isMain: true, unconstrainedDimension: .horizontal, scaleFactor: 1)
+            return FrameAssignment<Window>(frame: screenFrame, window: window, focused: false, screenFrame: screenFrame, resizeRules: resizeRules)
+        }
     }
 }

--- a/Amethyst/Layout/Layouts/RowLayout.swift
+++ b/Amethyst/Layout/Layouts/RowLayout.swift
@@ -8,26 +8,39 @@
 
 import Silica
 
-class RowReflowOperation<Window: WindowType>: ReflowOperation<Window> {
-    let layout: RowLayout<Window>
+class RowLayout<Window: WindowType>: Layout<Window>, PanedLayout {
+    override static var layoutName: String { return "Row" }
+    override static var layoutKey: String { return "row" }
 
-    init(screen: Screen, windows: [Window], layout: RowLayout<Window>, frameAssigner: FrameAssigner) {
-        self.layout = layout
-        super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
+    private(set) var mainPaneCount: Int = 1
+    private(set) var mainPaneRatio: CGFloat = 0.5
+
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
-    override func frameAssignments() -> [FrameAssignment<Window>]? {
+    func increaseMainPaneCount() {
+        mainPaneCount += 1
+    }
+
+    func decreaseMainPaneCount() {
+        mainPaneCount = max(1, mainPaneCount - 1)
+    }
+
+    override func frameAssignments(_ windowSet: WindowSet<Window>, on screen: Screen) -> [FrameAssignment<Window>]? {
+        let windows = windowSet.windows
+
         guard !windows.isEmpty else {
             return []
         }
 
-        let mainPaneCount = min(windows.count, layout.mainPaneCount)
+        let mainPaneCount = min(windows.count, self.mainPaneCount)
         let secondaryPaneCount = windows.count - mainPaneCount
         let hasSecondaryPane = secondaryPaneCount > 0
 
         let screenFrame = screen.adjustedFrame()
 
-        let mainPaneWindowHeight = round(screenFrame.size.height * (hasSecondaryPane ? CGFloat(layout.mainPaneRatio) : 1.0))
+        let mainPaneWindowHeight = round(screenFrame.size.height * (hasSecondaryPane ? CGFloat(mainPaneRatio) : 1.0))
         let secondaryPaneWindowHeight = hasSecondaryPane ? round((screenFrame.size.height - mainPaneWindowHeight) / CGFloat(secondaryPaneCount)) : 0.0
 
         return windows.reduce([]) { frameAssignments, window -> [FrameAssignment<Window>] in
@@ -51,10 +64,10 @@ class RowReflowOperation<Window: WindowType>: ReflowOperation<Window> {
             }
 
             let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .vertical, scaleFactor: scaleFactor)
-            let frameAssignment = FrameAssignment(
+            let frameAssignment = FrameAssignment<Window>(
                 frame: windowFrame,
                 window: window,
-                focused: window.isFocused(),
+                focused: windowSet.isWindowFloating(window),
                 screenFrame: screenFrame,
                 resizeRules: resizeRules
             )
@@ -63,30 +76,5 @@ class RowReflowOperation<Window: WindowType>: ReflowOperation<Window> {
 
             return assignments
         }
-    }
-}
-
-class RowLayout<Window: WindowType>: Layout<Window>, PanedLayout {
-    override static var layoutName: String { return "Row" }
-    override static var layoutKey: String { return "row" }
-
-    private(set) var mainPaneCount: Int = 1
-    private(set) var mainPaneRatio: CGFloat = 0.5
-
-    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
-        mainPaneRatio = rawRatio
-    }
-
-    func increaseMainPaneCount() {
-        mainPaneCount += 1
-    }
-
-    func decreaseMainPaneCount() {
-        mainPaneCount = max(1, mainPaneCount - 1)
-    }
-
-    override func reflow(_ windows: [Window], on screen: Screen) -> ReflowOperation<Window>? {
-        let assigner = Assigner(windowActivityCache: windowActivityCache)
-        return RowReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: assigner)
     }
 }

--- a/Amethyst/Layout/Layouts/TallLayout.swift
+++ b/Amethyst/Layout/Layouts/TallLayout.swift
@@ -8,20 +8,35 @@
 
 import Silica
 
-class TallReflowOperation<Window: WindowType>: ReflowOperation<Window> {
-    let layout: TallLayout<Window>
+class TallLayout<Window: WindowType>: Layout<Window>, PanedLayout {
+    override static var layoutName: String { return "Tall" }
+    override static var layoutKey: String { return "tall" }
 
-    init(screen: Screen, windows: [Window], layout: TallLayout<Window>, frameAssigner: FrameAssigner) {
-        self.layout = layout
-        super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
+    override var layoutDescription: String { return "" }
+
+    private(set) var mainPaneCount: Int = 1
+    private(set) var mainPaneRatio: CGFloat = 0.5
+
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
-    override func frameAssignments() -> [FrameAssignment<Window>]? {
+    func increaseMainPaneCount() {
+        mainPaneCount += 1
+    }
+
+    func decreaseMainPaneCount() {
+        mainPaneCount = max(1, mainPaneCount - 1)
+    }
+
+    override func frameAssignments(_ windowSet: WindowSet<Window>, on screen: Screen) -> [FrameAssignment<Window>]? {
+        let windows = windowSet.windows
+
         guard !windows.isEmpty else {
             return []
         }
 
-        let mainPaneCount = min(windows.count, layout.mainPaneCount)
+        let mainPaneCount = min(windows.count, self.mainPaneCount)
         let secondaryPaneCount = windows.count - mainPaneCount
         let hasSecondaryPane = secondaryPaneCount > 0
 
@@ -30,7 +45,7 @@ class TallReflowOperation<Window: WindowType>: ReflowOperation<Window> {
         let mainPaneWindowHeight = round(screenFrame.size.height / CGFloat(mainPaneCount))
         let secondaryPaneWindowHeight = hasSecondaryPane ? round(screenFrame.size.height / CGFloat(secondaryPaneCount)) : 0.0
 
-        let mainPaneWindowWidth = round(screenFrame.size.width * (hasSecondaryPane ? CGFloat(layout.mainPaneRatio) : 1.0))
+        let mainPaneWindowWidth = round(screenFrame.size.width * (hasSecondaryPane ? CGFloat(mainPaneRatio) : 1.0))
         let secondaryPaneWindowWidth = screenFrame.size.width - mainPaneWindowWidth
 
         return windows.reduce([]) { acc, window -> [FrameAssignment<Window>] in
@@ -54,38 +69,17 @@ class TallReflowOperation<Window: WindowType>: ReflowOperation<Window> {
             }
 
             let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .horizontal, scaleFactor: scaleFactor)
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isFocused(), screenFrame: screenFrame, resizeRules: resizeRules)
+            let frameAssignment = FrameAssignment<Window>(
+                frame: windowFrame,
+                window: window,
+                focused: windowSet.isWindowFloating(window),
+                screenFrame: screenFrame,
+                resizeRules: resizeRules
+            )
 
             assignments.append(frameAssignment)
 
             return assignments
         }
-    }
-}
-
-class TallLayout<Window: WindowType>: Layout<Window>, PanedLayout {
-    override static var layoutName: String { return "Tall" }
-    override static var layoutKey: String { return "tall" }
-
-    override var layoutDescription: String { return "" }
-
-    private(set) var mainPaneCount: Int = 1
-    private(set) var mainPaneRatio: CGFloat = 0.5
-
-    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
-        mainPaneRatio = rawRatio
-    }
-
-    func increaseMainPaneCount() {
-        mainPaneCount += 1
-    }
-
-    func decreaseMainPaneCount() {
-        mainPaneCount = max(1, mainPaneCount - 1)
-    }
-
-    override func reflow(_ windows: [Window], on screen: Screen) -> ReflowOperation<Window>? {
-        let assigner = Assigner(windowActivityCache: windowActivityCache)
-        return TallReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: assigner)
     }
 }

--- a/Amethyst/Layout/Layouts/TallRightLayout.swift
+++ b/Amethyst/Layout/Layouts/TallRightLayout.swift
@@ -8,20 +8,33 @@
 
 import Silica
 
-class TallRightReflowOperation<Window: WindowType>: ReflowOperation<Window> {
-    let layout: TallRightLayout<Window>
+class TallRightLayout<Window: WindowType>: Layout<Window>, PanedLayout {
+    override static var layoutName: String { return "Tall Right" }
+    override static var layoutKey: String { return "tall-right" }
 
-    init(screen: Screen, windows: [Window], layout: TallRightLayout<Window>, frameAssigner: FrameAssigner) {
-        self.layout = layout
-        super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
+    private(set) var mainPaneCount: Int = 1
+    private(set) var mainPaneRatio: CGFloat = 0.5
+
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
-    override func frameAssignments() -> [FrameAssignment<Window>]? {
+    func increaseMainPaneCount() {
+        mainPaneCount += 1
+    }
+
+    func decreaseMainPaneCount() {
+        mainPaneCount = max(1, mainPaneCount - 1)
+    }
+
+    override func frameAssignments(_ windowSet: WindowSet<Window>, on screen: Screen) -> [FrameAssignment<Window>]? {
+        let windows = windowSet.windows
+
         guard !windows.isEmpty else {
             return []
         }
 
-        let mainPaneCount = min(windows.count, layout.mainPaneCount)
+        let mainPaneCount = min(windows.count, self.mainPaneCount)
         let secondaryPaneCount = windows.count - mainPaneCount
         let hasSecondaryPane = secondaryPaneCount > 0
 
@@ -30,7 +43,7 @@ class TallRightReflowOperation<Window: WindowType>: ReflowOperation<Window> {
         let mainPaneWindowHeight = round(screenFrame.size.height / CGFloat(mainPaneCount))
         let secondaryPaneWindowHeight = hasSecondaryPane ? round(screenFrame.size.height / CGFloat(secondaryPaneCount)) : 0.0
 
-        let mainPaneWindowWidth = round(screenFrame.size.width * (hasSecondaryPane ? CGFloat(layout.mainPaneRatio) : 1.0))
+        let mainPaneWindowWidth = round(screenFrame.size.width * (hasSecondaryPane ? CGFloat(mainPaneRatio) : 1.0))
         let secondaryPaneWindowWidth = screenFrame.size.width - mainPaneWindowWidth
 
         return windows.reduce([]) { frameAssignments, window -> [FrameAssignment<Window>] in
@@ -54,36 +67,17 @@ class TallRightReflowOperation<Window: WindowType>: ReflowOperation<Window> {
             }
 
             let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .horizontal, scaleFactor: scaleFactor)
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isFocused(), screenFrame: screenFrame, resizeRules: resizeRules)
+            let frameAssignment = FrameAssignment<Window>(
+                frame: windowFrame,
+                window: window,
+                focused: windowSet.isWindowFloating(window),
+                screenFrame: screenFrame,
+                resizeRules: resizeRules
+            )
 
             assignments.append(frameAssignment)
 
             return assignments
         }
-    }
-}
-
-class TallRightLayout<Window: WindowType>: Layout<Window>, PanedLayout {
-    override static var layoutName: String { return "Tall Right" }
-    override static var layoutKey: String { return "tall-right" }
-
-    private(set) var mainPaneCount: Int = 1
-    private(set) var mainPaneRatio: CGFloat = 0.5
-
-    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
-        mainPaneRatio = rawRatio
-    }
-
-    func increaseMainPaneCount() {
-        mainPaneCount += 1
-    }
-
-    func decreaseMainPaneCount() {
-        mainPaneCount = max(1, mainPaneCount - 1)
-    }
-
-    override func reflow(_ windows: [Window], on screen: Screen) -> ReflowOperation<Window>? {
-        let assigner = Assigner(windowActivityCache: windowActivityCache)
-        return TallRightReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: assigner)
     }
 }

--- a/Amethyst/Layout/Layouts/ThreeColumnLayout.swift
+++ b/Amethyst/Layout/Layouts/ThreeColumnLayout.swift
@@ -132,25 +132,28 @@ struct TriplePaneArrangement {
     }
 }
 
-class ThreeColumnReflowOperation<Window: WindowType>: ReflowOperation<Window> {
-    private let layout: ThreeColumnLayout<Window>
+// not an actual Layout, just a base class for the three actual Layouts below
+class ThreeColumnLayout<Window: WindowType>: Layout<Window> {
+    class var mainColumn: Column { fatalError("Must be implemented by subclass") }
 
-    fileprivate init(screen: Screen, windows: [Window], layout: ThreeColumnLayout<Window>, frameAssigner: FrameAssigner) {
-        self.layout = layout
-        super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
-    }
+    private(set) var mainPaneCount: Int = 1
+    private(set) var mainPaneRatio: CGFloat = 0.5
 
-    override func frameAssignments() -> [FrameAssignment<Window>]? {
+    override func frameAssignments(_ windowSet: WindowSet<Window>, on screen: Screen) -> [FrameAssignment<Window>]? {
+        let windows = windowSet.windows
+
         guard !windows.isEmpty else {
             return []
         }
 
         let screenFrame = screen.adjustedFrame()
-        let paneArrangement = TriplePaneArrangement(mainPane: type(of: layout).mainColumn,
-                                              numWindows: UInt(windows.count),
-                                              numMainPane: UInt(layout.mainPaneCount),
-                                              screenSize: screenFrame.size,
-                                              mainPaneRatio: layout.mainPaneRatio)
+        let paneArrangement = TriplePaneArrangement(
+            mainPane: type(of: self).mainColumn,
+            numWindows: UInt(windows.count),
+            numMainPane: UInt(mainPaneCount),
+            screenSize: screenFrame.size,
+            mainPaneRatio: mainPaneRatio
+        )
 
         return windows.reduce([]) { frameAssignments, window -> [FrameAssignment<Window>] in
             var assignments = frameAssignments
@@ -187,25 +190,18 @@ class ThreeColumnReflowOperation<Window: WindowType>: ReflowOperation<Window> {
             let isMain = windowIndex < paneArrangement.firstIndex(.secondary)
 
             let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .horizontal, scaleFactor: scaleFactor)
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isFocused(), screenFrame: screenFrame, resizeRules: resizeRules)
+            let frameAssignment = FrameAssignment<Window>(
+                frame: windowFrame,
+                window: window,
+                focused: windowSet.isWindowFloating(window),
+                screenFrame: screenFrame,
+                resizeRules: resizeRules
+            )
 
             assignments.append(frameAssignment)
 
             return assignments
         }
-    }
-}
-
-// not an actual Layout, just a base class for the three actual Layouts below
-class ThreeColumnLayout<Window: WindowType>: Layout<Window> {
-    class var mainColumn: Column { fatalError("Must be implemented by subclass") }
-
-    private(set) var mainPaneCount: Int = 1
-    private(set) var mainPaneRatio: CGFloat = 0.5
-
-    override func reflow(_ windows: [Window], on screen: Screen) -> ReflowOperation<Window>? {
-        let assigner = Assigner(windowActivityCache: windowActivityCache)
-        return ThreeColumnReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: assigner)
     }
 }
 

--- a/Amethyst/Layout/Layouts/WideLayout.swift
+++ b/Amethyst/Layout/Layouts/WideLayout.swift
@@ -8,26 +8,38 @@
 
 import Silica
 
-private class WideReflowOperation<Window: WindowType>: ReflowOperation<Window> {
-    private let layout: WideLayout<Window>
+class WideLayout<Window: WindowType>: Layout<Window>, PanedLayout {
+    override static var layoutName: String { return "Wide" }
+    override static var layoutKey: String { return "wide" }
 
-    init(screen: Screen, windows: [Window], layout: WideLayout<Window>, frameAssigner: FrameAssigner) {
-        self.layout = layout
-        super.init(screen: screen, windows: windows, frameAssigner: frameAssigner)
+    private(set) var mainPaneCount: Int = 1
+    private(set) var mainPaneRatio: CGFloat = 0.5
+
+    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
+        mainPaneRatio = rawRatio
     }
 
-    override func frameAssignments() -> [FrameAssignment<Window>]? {
+    func increaseMainPaneCount() {
+        mainPaneCount += 1
+    }
+
+    func decreaseMainPaneCount() {
+        mainPaneCount = max(1, mainPaneCount - 1)
+    }
+
+    override func frameAssignments(_ windowSet: WindowSet<Window>, on screen: Screen) -> [FrameAssignment<Window>]? {
+        let windows = windowSet.windows
+
         guard !windows.isEmpty else {
             return []
         }
 
-        let mainPaneCount = min(windows.count, layout.mainPaneCount)
         let secondaryPaneCount = windows.count - mainPaneCount
         let hasSecondaryPane = secondaryPaneCount > 0
 
         let screenFrame = screen.adjustedFrame()
 
-        let mainPaneWindowHeight = round(screenFrame.height * CGFloat(hasSecondaryPane ? layout.mainPaneRatio : 1))
+        let mainPaneWindowHeight = round(screenFrame.height * CGFloat(hasSecondaryPane ? mainPaneRatio : 1))
         let secondaryPaneWindowHeight = screenFrame.height - mainPaneWindowHeight
 
         let mainPaneWindowWidth = round(screenFrame.width / CGFloat(mainPaneCount))
@@ -54,36 +66,17 @@ private class WideReflowOperation<Window: WindowType>: ReflowOperation<Window> {
             }
 
             let resizeRules = ResizeRules(isMain: isMain, unconstrainedDimension: .vertical, scaleFactor: scaleFactor)
-            let frameAssignment = FrameAssignment(frame: windowFrame, window: window, focused: window.isFocused(), screenFrame: screenFrame, resizeRules: resizeRules)
+            let frameAssignment = FrameAssignment<Window>(
+                frame: windowFrame,
+                window: window,
+                focused: windowSet.isWindowFloating(window),
+                screenFrame: screenFrame,
+                resizeRules: resizeRules
+            )
 
             assignments.append(frameAssignment)
 
             return assignments
         }
-    }
-}
-
-class WideLayout<Window: WindowType>: Layout<Window>, PanedLayout {
-    override static var layoutName: String { return "Wide" }
-    override static var layoutKey: String { return "wide" }
-
-    private(set) var mainPaneCount: Int = 1
-    private(set) var mainPaneRatio: CGFloat = 0.5
-
-    func recommendMainPaneRawRatio(rawRatio: CGFloat) {
-        mainPaneRatio = rawRatio
-    }
-
-    func increaseMainPaneCount() {
-        mainPaneCount += 1
-    }
-
-    func decreaseMainPaneCount() {
-        mainPaneCount = max(1, mainPaneCount - 1)
-    }
-
-    override func reflow(_ windows: [Window], on screen: Screen) -> ReflowOperation<Window>? {
-        let assigner = Assigner(windowActivityCache: windowActivityCache)
-        return WideReflowOperation(screen: screen, windows: windows, layout: self, frameAssigner: assigner)
     }
 }

--- a/Amethyst/Managers/FocusFollowsMouseManager.swift
+++ b/Amethyst/Managers/FocusFollowsMouseManager.swift
@@ -12,12 +12,13 @@ import Silica
 import RxSwift
 
 protocol FocusFollowsMouseManagerDelegate: class {
-    associatedtype Application: ApplicationType
-    var windows: WindowManager<Application>.Windows { get }
+    associatedtype Window: WindowType
+    typealias Screen = Window.Screen
+    func windows(onScreen screen: Screen) -> [Window]
 }
 
 class FocusFollowsMouseManager<Delegate: FocusFollowsMouseManagerDelegate> {
-    typealias Window = Delegate.Application.Window
+    typealias Window = Delegate.Window
     typealias Screen = Window.Screen
 
     weak var delegate: Delegate!
@@ -59,7 +60,7 @@ class FocusFollowsMouseManager<Delegate: FocusFollowsMouseManagerDelegate> {
             return
         }
 
-        guard let windows = delegate?.windows.windows(onScreen: screen) else {
+        guard let windows = delegate?.windows(onScreen: screen) else {
             return
         }
 

--- a/Amethyst/Managers/FocusTransitionCoordinator.swift
+++ b/Amethyst/Managers/FocusTransitionCoordinator.swift
@@ -21,12 +21,11 @@ protocol FocusTransitionTarget: class {
     typealias Window = Application.Window
     typealias Screen = Window.Screen
 
-    var windows: WindowManager<Application>.Windows { get }
-
     func executeTransition(_ transition: FocusTransition<Window>)
 
     func lastFocusedWindow(on screen: Screen) -> Window?
     func screen(at index: Int) -> Screen?
+    func windows(onScreen screen: Screen) -> [Window]
     func nextWindowIDClockwise(on screen: Screen) -> CGWindowID?
     func nextWindowIDCounterClockwise(on screen: Screen) -> CGWindowID?
     func nextScreenIndexClockwise(from screen: Screen) -> Int
@@ -60,7 +59,7 @@ class FocusTransitionCoordinator<Target: FocusTransitionTarget> {
             return
         }
 
-        let windows = target.windows.windows(onScreen: screen)
+        let windows = target.windows(onScreen: screen)
 
         guard !windows.isEmpty else {
             return
@@ -90,7 +89,7 @@ class FocusTransitionCoordinator<Target: FocusTransitionTarget> {
             return
         }
 
-        let windows = target.windows.windows(onScreen: screen)
+        let windows = target.windows(onScreen: screen)
 
         guard !windows.isEmpty else {
             return
@@ -120,7 +119,7 @@ class FocusTransitionCoordinator<Target: FocusTransitionTarget> {
             return
         }
 
-        let windows = target.windows.windows(onScreen: screen)
+        let windows = target.windows(onScreen: screen)
 
         guard !windows.isEmpty else {
             return
@@ -145,7 +144,7 @@ class FocusTransitionCoordinator<Target: FocusTransitionTarget> {
             return
         }
 
-        let windows = target.windows.windows(onScreen: screen)
+        let windows = target.windows(onScreen: screen)
 
         // If there are no windows on the screen focus the screen directly
         guard !windows.isEmpty else {
@@ -187,9 +186,7 @@ class FocusTransitionCoordinator<Target: FocusTransitionTarget> {
 }
 
 extension FocusTransitionCoordinator: FocusFollowsMouseManagerDelegate {
-    typealias Application = Target.Application
-
-    var windows: WindowManager<Application>.Windows {
-        return target.windows
+    func windows(onScreen screen: Screen) -> [Window] {
+        return target.windows(onScreen: screen)
     }
 }

--- a/Amethyst/Managers/LayoutManager.swift
+++ b/Amethyst/Managers/LayoutManager.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 enum LayoutManager<Window: WindowType> {
-    static func layoutForKey(_ layoutKey: String, with windowActivityCache: WindowActivityCache) -> Layout<Window>? {
-        return layoutByKey()[layoutKey]?.init(windowActivityCache: windowActivityCache)
+    static func layoutForKey(_ layoutKey: String) -> Layout<Window>? {
+        return layoutByKey()[layoutKey]?.init()
     }
 
     static func layoutNameForKey(_ layoutKey: String) -> String? {
@@ -44,10 +44,10 @@ enum LayoutManager<Window: WindowType> {
         return layoutClasses().map { ($0.layoutKey, $0.layoutName) }
     }
 
-    static func layoutsWithConfiguration(_ userConfiguration: UserConfiguration, windowActivityCache: WindowActivityCache) -> [Layout<Window>] {
+    static func layoutsWithConfiguration(_ userConfiguration: UserConfiguration) -> [Layout<Window>] {
         let layoutKeys: [String] = userConfiguration.layoutKeys()
         let layouts = layoutKeys.map { layoutKey -> Layout<Window>? in
-            guard let layout = LayoutManager.layoutForKey(layoutKey, with: windowActivityCache) else {
+            guard let layout = LayoutManager.layoutForKey(layoutKey) else {
                 log.warning("Unrecognized layout key \(layoutKey)")
                 return nil
             }

--- a/Amethyst/Managers/WindowTransitionCoordinator.swift
+++ b/Amethyst/Managers/WindowTransitionCoordinator.swift
@@ -23,21 +23,13 @@ protocol WindowTransitionTarget: class {
     typealias Window = Application.Window
     typealias Screen = Window.Screen
 
-    var windows: WindowManager<Application>.Windows { get }
-
     func executeTransition(_ transition: WindowTransition<Window>)
 
+    func isWindowFloating(_ window: Window) -> Bool
     func screen(at index: Int) -> Screen?
+    func activeWindows(on screen: Screen) -> [Window]
     func nextScreenIndexClockwise(from screen: Screen) -> Int
     func nextScreenIndexCounterClockwise(from screen: Screen) -> Int
-}
-
-extension WindowTransitionTarget {
-    func activeWindows(on screen: Screen) -> [Window] {
-        return windows.activeWindows(onScreen: screen).filter { window in
-            return window.shouldBeManaged() && !self.windows.isWindowFloating(window)
-        }
-    }
 }
 
 class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
@@ -51,7 +43,7 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
     }
 
     func swapFocusedWindowToMain() {
-        guard let focusedWindow = Window.currentlyFocused(), !target.windows.isWindowFloating(focusedWindow), let screen = focusedWindow.screen() else {
+        guard let focusedWindow = Window.currentlyFocused(), !target.isWindowFloating(focusedWindow), let screen = focusedWindow.screen() else {
             return
         }
 
@@ -73,7 +65,7 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
     }
 
     func swapFocusedWindowCounterClockwise() {
-        guard let focusedWindow = Window.currentlyFocused(), !target.windows.isWindowFloating(focusedWindow) else {
+        guard let focusedWindow = Window.currentlyFocused(), !target.isWindowFloating(focusedWindow) else {
             target.executeTransition(.resetFocus)
             return
         }
@@ -94,7 +86,7 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
     }
 
     func swapFocusedWindowClockwise() {
-        guard let focusedWindow = Window.currentlyFocused(), !target.windows.isWindowFloating(focusedWindow) else {
+        guard let focusedWindow = Window.currentlyFocused(), !target.isWindowFloating(focusedWindow) else {
             target.executeTransition(.resetFocus)
             return
         }
@@ -129,7 +121,7 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
     }
 
     func swapFocusedWindowScreenClockwise() {
-        guard let focusedWindow = Window.currentlyFocused(), !target.windows.isWindowFloating(focusedWindow) else {
+        guard let focusedWindow = Window.currentlyFocused(), !target.isWindowFloating(focusedWindow) else {
             target.executeTransition(.resetFocus)
             return
         }
@@ -146,7 +138,7 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
     }
 
     func swapFocusedWindowScreenCounterClockwise() {
-        guard let focusedWindow = Window.currentlyFocused(), !target.windows.isWindowFloating(focusedWindow) else {
+        guard let focusedWindow = Window.currentlyFocused(), !target.isWindowFloating(focusedWindow) else {
             target.executeTransition(.resetFocus)
             return
         }

--- a/AmethystTests/Tests/Layout/FullscreenLayoutTests.swift
+++ b/AmethystTests/Tests/Layout/FullscreenLayoutTests.swift
@@ -28,38 +28,22 @@ class FullscreenLayoutTests: QuickSpec {
                 let screen = TestScreen()
                 TestScreen.availableScreens = [screen]
 
-                let window1 = TestWindow(element: nil)!
-                let window2 = TestWindow(element: nil)!
-                let window3 = TestWindow(element: nil)!
-                let layout = FullscreenLayout<TestWindow>(windowActivityCache: self)
-                let fullscreenOperation = FullscreenReflowOperation(
-                    screen: screen,
-                    windows: [window1, window2, window3],
-                    layout: layout,
-                    frameAssigner: Assigner(windowActivityCache: self)
+                let windows = [TestWindow(element: nil)!, TestWindow(element: nil)!, TestWindow(element: nil)!]
+                let layoutWindows = windows.map { LayoutWindow(id: $0.windowID(), frame: $0.frame()) }
+                let windowSet = WindowSet<TestWindow>(
+                    windows: layoutWindows,
+                    isWindowWithIDActive: { _ in return true },
+                    isWindowWithIDFloating: { _ in return false },
+                    windowForID: { id in return windows.first { $0.windowID() == id } }
                 )
+                let layout = FullscreenLayout<TestWindow>()
+                let frameAssignments = layout.frameAssignments(windowSet, on: screen)!
 
-                waitUntil { done in
-                    self.operationQueue.addOperation(fullscreenOperation)
-                    self.operationQueue.addOperation {
-                        done()
-                    }
+                frameAssignments.forEach { assignment in
+                    expect(assignment.frame).to(equal(screen.adjustedFrame()))
+                    expect(assignment.finalFrame).to(equal(screen.adjustedFrame()))
                 }
-
-                expect(window1.frame()).to(equal(screen.adjustedFrame()))
-                expect(window2.frame()).to(equal(screen.adjustedFrame()))
-                expect(window3.frame()).to(equal(screen.adjustedFrame()))
             }
         }
-    }
-}
-
-extension FullscreenLayoutTests: WindowActivityCache {
-    func windowIsFloating<Window>(_ window: Window) -> Bool where Window: WindowType {
-        return false
-    }
-
-    func windowIsActive<Window>(_ window: Window) -> Bool where Window: WindowType {
-        return window.isActive()
     }
 }


### PR DESCRIPTION
The interactions were kind of a mess. The screen manager had to pass the window activity cache through, like, four layers of indirection and a handful of protocols. I decided to simplify this to just be the screen manager creates a reflow operation and passes in a layout, the layout generates frame assignments, and then the reflow operation applies the frames. This maintains the testability of isolating layout logic from actual application logic, but doesn't require so much passing around.