### PR TITLE
[Feature] Add the relaunch shortcut key

### DIFF
--- a/Amethyst/AppDelegate.swift
+++ b/Amethyst/AppDelegate.swift
@@ -55,7 +55,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         preferencesWindowController?.window?.level = .floating
 
         windowManager = WindowManager(userConfiguration: UserConfiguration.shared)
-        hotKeyManager = HotKeyManager(userConfiguration: UserConfiguration.shared)
+        hotKeyManager = HotKeyManager(appDelegate: self, userConfiguration: UserConfiguration.shared)
 
         hotKeyManager?.setUpWithWindowManager(windowManager!, configuration: UserConfiguration.shared)
     }

--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -24,13 +24,15 @@ typealias HotKeyHandler = () -> Void
 
 class HotKeyManager<Application: ApplicationType>: NSObject {
     private let userConfiguration: UserConfiguration
+    private weak var appDelegate: AppDelegate?
 
     private(set) lazy var stringToKeyCodes: [String: [AMKeyCode]] = {
         return self.constructKeyCodeMap()
     }()
 
-    init(userConfiguration: UserConfiguration) {
+    init(appDelegate: AppDelegate, userConfiguration: UserConfiguration) {
         self.userConfiguration = userConfiguration
+        self.appDelegate = appDelegate
         super.init()
         _ = constructKeyCodeMap()
         MASShortcutValidator.shared().allowAnyShortcutWithOptionModifier = true
@@ -206,6 +208,10 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
             self.userConfiguration.toggleFocusFollowsMouse()
         }
 
+        constructCommandWithCommandKey(CommandKey.relaunchAmethyst.rawValue) {
+            self.appDelegate?.relaunch(self)
+        }
+
         LayoutManager<Application.Window>.availableLayoutStrings().forEach { (layoutKey, _) in
             self.constructCommandWithCommandKey(UserConfiguration.constructLayoutKeyString(layoutKey)) {
                 let screenManager: ScreenManager<WindowManager<Application>>? = windowManager.focusedScreenManager()
@@ -364,6 +370,8 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
             let commandKey = "select-\(layoutKey)-layout"
             hotKeyNameToDefaultsKey.append([commandName, commandKey])
         }
+
+        hotKeyNameToDefaultsKey.append(["Relaunch Amethyst", CommandKey.relaunchAmethyst.rawValue])
 
         return hotKeyNameToDefaultsKey
     }

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -119,6 +119,7 @@ enum CommandKey: String {
     case toggleTiling = "toggle-tiling"
     case reevaluateWindows = "reevaluate-windows"
     case toggleFocusFollowsMouse = "toggle-focus-follows-mouse"
+    case relaunchAmethyst = "relaunch-amethyst"
 }
 
 protocol UserConfigurationDelegate: AnyObject {


### PR DESCRIPTION
Hi, I'm writing this PR as I find myself manually relaunching Amethyst pretty often, so I guess a shortcut is reasonable. I've been using it for the past 2 years and it's been amazing, so I thought I'd contribute. 
I'm really new to swift / macOS development, so let me know if anything is missing. Thanks.

For this PR, I'm essentially holding a reference to the main app delegate, where the original relaunch method lives, and call it in the hot key manager. I think it's fairly straightforward.

I've also manually verified the feature. It works for me. 
I did, however, need to remove the existing Amethyst entry in the system accessibility permission list and re-request the permission to make it work when I first started to make this.