### PR TITLE
Revert mouse-follows-focus changes

### DIFF
--- a/Amethyst/Managers/FocusFollowsMouseManager.swift
+++ b/Amethyst/Managers/FocusFollowsMouseManager.swift
@@ -23,8 +23,6 @@ class FocusFollowsMouseManager<Delegate: FocusFollowsMouseManagerDelegate> {
 
     weak var delegate: Delegate?
 
-    private var lastMouseFocusTime = Date.distantPast
-
     private let userConfiguration: UserConfiguration
     private let disposeBag = DisposeBag()
 
@@ -37,8 +35,8 @@ class FocusFollowsMouseManager<Delegate: FocusFollowsMouseManagerDelegate> {
             .scan(nil) { [unowned self] existingHandler, followingIsDesired -> Any? in
                 if let handler = existingHandler {
                     NSEvent.removeMonitor(handler)
-                }
-                if followingIsDesired! {
+                    return nil
+                } else if followingIsDesired! {
                     return NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [unowned self] event in
                         self.focusWindowWithMouseMovedEvent(event)
                     }
@@ -78,12 +76,6 @@ class FocusFollowsMouseManager<Delegate: FocusFollowsMouseManagerDelegate> {
             return
         }
 
-        self.lastMouseFocusTime = Date()
-
         topWindow.focus()
-    }
-
-    func recentlyTriggeredFocusFollowsMouse() -> Bool {
-        return Date().timeIntervalSince(lastMouseFocusTime) < 0.5
     }
 }

--- a/Amethyst/Managers/FocusTransitionCoordinator.swift
+++ b/Amethyst/Managers/FocusTransitionCoordinator.swift
@@ -181,10 +181,6 @@ class FocusTransitionCoordinator<Target: FocusTransitionTarget> {
 
         focusScreen(at: screenIndex)
     }
-
-    func recentlyTriggeredFocusFollowsMouse() -> Bool {
-        return focusFollowsMouseManager.recentlyTriggeredFocusFollowsMouse()
-    }
 }
 
 extension FocusTransitionCoordinator: FocusFollowsMouseManagerDelegate {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -189,7 +189,6 @@ final class WindowManager<Application: ApplicationType>: NSObject, Codable {
             return
         }
         markScreen(screen, forReflowWithChange: .unknown)
-        doMouseFollowsFocus(focusedWindow: focusedWindow)
     }
 
     @objc func applicationDidLaunch(_ notification: Notification) {
@@ -393,40 +392,12 @@ final class WindowManager<Application: ApplicationType>: NSObject, Codable {
     }
 
     func onReflowCompletion() {
-        if let focusedWindow = Window.currentlyFocused() {
-            doMouseFollowsFocus(focusedWindow: focusedWindow)
-        }
-
         // This handler will be executed by the Operation, in a queue.  Although async
         // (and although the docs say that it executes in a separate thread), I consider
         // this to be thread safe, at least safe enough, because we always want the
         // latest time that a reflow took place.
         mouseStateKeeper.handleReflowEvent()
         lastReflowTime = Date()
-    }
-
-    func doMouseFollowsFocus(focusedWindow: Window) {
-        guard UserConfiguration.shared.mouseFollowsFocus() else {
-            return
-        }
-
-        guard NSEvent.pressedMouseButtons == 0 else {
-            // If a mouse button is pressed, then the user is probably dragging something between windows. Do not move the mouse.
-            return
-        }
-
-        if focusTransitionCoordinator.recentlyTriggeredFocusFollowsMouse() {
-            // If we have recently triggered focus-follows-mouse, then disable mouse-follows-focus. Otherwise, the moment
-            // focus-follows-mouse is triggered, the mouse will jump to the center of the focused window.
-            return
-        }
-
-        let windowFrame = focusedWindow.frame()
-        let mouseCursorPoint = NSPoint(x: windowFrame.midX, y: windowFrame.midY)
-        if let mouseMoveEvent = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: mouseCursorPoint, mouseButton: .left) {
-            mouseMoveEvent.flags = CGEventFlags(rawValue: 0)
-            mouseMoveEvent.post(tap: CGEventTapLocation.cghidEventTap)
-        }
     }
 }
 
@@ -489,8 +460,6 @@ extension WindowManager: ApplicationObservationDelegate {
         } else {
             markScreen(screen, forReflowWithChange: .focusChanged(window: window))
         }
-
-        doMouseFollowsFocus(focusedWindow: window)
     }
 
     func application(_ application: AnyApplication<Application>, didFindPotentiallyNewWindow window: Window) {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -13,17 +13,6 @@ import RxSwiftExt
 import Silica
 import SwiftyJSON
 
-/**
- The tolerant interval between the click and the application of a mouse move from focus.
- 
- - Note:
- 
- At the time of the check we confirm that the mouse is not _currently_ clicked. However, it is possible that the click happened faster than the focus notification could be processed so that when we process the focus the mouse is no longer clicked. In this case we could incorrectly move the mouse to the center of the focused window.
- 
- This value is an approximation of the time between a fast click and the focus event being processed. For values larger than this we would expect the mouse to still be clicked.
- */
-private let mouseMoveClickSpeedTolerance: TimeInterval = 0.3
-
 final class WindowManager<Application: ApplicationType>: NSObject, Codable {
     typealias Window = Application.Window
     typealias Screen = Window.Screen
@@ -423,11 +412,6 @@ final class WindowManager<Application: ApplicationType>: NSObject, Codable {
 
         guard NSEvent.pressedMouseButtons == 0 else {
             // If a mouse button is pressed, then the user is probably dragging something between windows. Do not move the mouse.
-            return
-        }
-
-        // See the description of mouseMoveClickSpeedTolerance for details.
-        if let interval = mouseStateKeeper.lastClick?.timeIntervalSinceNow, abs(interval) < mouseMoveClickSpeedTolerance {
             return
         }
 

--- a/Amethyst/Model/MouseState.swift
+++ b/Amethyst/Model/MouseState.swift
@@ -44,7 +44,6 @@ class MouseStateKeeper<Delegate: MouseStateKeeperDelegate> {
     let dragRaceThresholdSeconds = 0.15 // prevent race conditions during drag ops
     var state: MouseState<Delegate.Window>
     private(set) weak var delegate: Delegate?
-    private(set) var lastClick: Date?
     private var monitor: Any?
 
     init(delegate: Delegate) {
@@ -90,10 +89,7 @@ class MouseStateKeeper<Delegate: MouseStateKeeperDelegate> {
                 self.resizeFrameToDraggedWindowBorder(ratio)
             case .doneDragging:
                 self.state = .doneDragging(atTime: Date()) // reset the clock I guess
-            case .clicking:
-                lastClick = Date()
-                self.state = .pointing
-            case .pointing:
+            case .pointing, .clicking:
                 self.state = .pointing
             }
 

--- a/Amethyst/Model/Window.swift
+++ b/Amethyst/Model/Window.swift
@@ -261,6 +261,34 @@ extension AXWindow: WindowType {
         return isEqual(to: focused)
     }
 
+    /**
+     Focuses the window.
+     
+     This handles focusing and also moves the cursor to the window's frame if mouse-follows-focus is enabled.
+     
+     - Returns:
+     `true` if the window was successfully focused, `false` otherwise.
+     */
+    @discardableResult override func focus() -> Bool {
+        guard super.focus() else {
+            return false
+        }
+
+        guard UserConfiguration.shared.mouseFollowsFocus() else {
+            return true
+        }
+
+        let windowFrame = frame()
+        let mouseCursorPoint = NSPoint(x: windowFrame.midX, y: windowFrame.midY)
+        guard let mouseMoveEvent = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: mouseCursorPoint, mouseButton: .left) else {
+            return true
+        }
+        mouseMoveEvent.flags = CGEventFlags(rawValue: 0)
+        mouseMoveEvent.post(tap: CGEventTapLocation.cghidEventTap)
+
+        return true
+    }
+
     func moveScaled(to screen: Screen) {
         let screenFrame = screen.frameWithoutDockOrMenu()
         let currentFrame = frame()


### PR DESCRIPTION
Reverts #1013. I ran into a lot of issues with various events triggering spurious mouse moves; e.g., closing a dialog in a window would move the mouse out from under me. Probably need to take a positive set of events to trigger it rather than trying to cover a sufficient negative set of events.