### PR TITLE
Disable mouse-follows-focus except for Amethyst window focuses

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -200,7 +200,7 @@ final class WindowManager<Application: ApplicationType>: NSObject, Codable {
             return
         }
         markScreen(screen, forReflowWithChange: .unknown)
-        doMouseFollowsFocus(focusedWindow: focusedWindow)
+//        doMouseFollowsFocus(focusedWindow: focusedWindow)
     }
 
     @objc func applicationDidLaunch(_ notification: Notification) {
@@ -405,7 +405,7 @@ final class WindowManager<Application: ApplicationType>: NSObject, Codable {
 
     func onReflowCompletion() {
         if let focusedWindow = Window.currentlyFocused() {
-            doMouseFollowsFocus(focusedWindow: focusedWindow)
+//            doMouseFollowsFocus(focusedWindow: focusedWindow)
         }
 
         // This handler will be executed by the Operation, in a queue.  Although async
@@ -506,7 +506,7 @@ extension WindowManager: ApplicationObservationDelegate {
             markScreen(screen, forReflowWithChange: .focusChanged(window: window))
         }
 
-        doMouseFollowsFocus(focusedWindow: window)
+//        doMouseFollowsFocus(focusedWindow: window)
     }
 
     func application(_ application: AnyApplication<Application>, didFindPotentiallyNewWindow window: Window) {

--- a/Amethyst/Model/Window.swift
+++ b/Amethyst/Model/Window.swift
@@ -261,6 +261,34 @@ extension AXWindow: WindowType {
         return isEqual(to: focused)
     }
 
+    /**
+     Focuses the window.
+     
+     This handles focusing and also moves the cursor to the window's frame if mouse-follows-focus is enabled.
+     
+     - Returns:
+     `true` if the window was successfully focused, `false` otherwise.
+     */
+    @discardableResult override func focus() -> Bool {
+        guard super.focus() else {
+            return false
+        }
+
+        guard UserConfiguration.shared.mouseFollowsFocus() else {
+            return true
+        }
+
+        let windowFrame = frame()
+        let mouseCursorPoint = NSPoint(x: windowFrame.midX, y: windowFrame.midY)
+        guard let mouseMoveEvent = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: mouseCursorPoint, mouseButton: .left) else {
+            return true
+        }
+        mouseMoveEvent.flags = CGEventFlags(rawValue: 0)
+        mouseMoveEvent.post(tap: CGEventTapLocation.cghidEventTap)
+
+        return true
+    }
+
     func moveScaled(to screen: Screen) {
         let screenFrame = screen.frameWithoutDockOrMenu()
         let currentFrame = frame()


### PR DESCRIPTION
Regresses #1013. I ran into a lot of issues with various events triggering spurious mouse moves; e.g., closing a dialog in a window would move the mouse out from under me. Probably need to take a positive set of events to trigger it rather than trying to cover a sufficient negative set of events.