### PR TITLE
Add autominimize setting (AKA window limit)

### DIFF
--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -11,6 +11,7 @@ import Silica
 
 protocol ScreenManagerDelegate: class {
     associatedtype Window: WindowType
+    func applyWindowLimit(forScreenManager screenManager: ScreenManager<Self>, minimizingIn range: (_ windowCount: Int) -> Range<Int>)
     func activeWindowSet(forScreenManager screenManager: ScreenManager<Self>) -> WindowSet<Window>
     func onReflowInitiation()
     func onReflowCompletion()
@@ -179,7 +180,38 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
         }
 
         DispatchQueue.main.async {
+            self.minimizeWindows()
             self.reflow(windowChange)
+        }
+    }
+
+    private func minimizeWindows() {
+        let mainPaneCount = (currentLayout as? PanedLayout)?.mainPaneCount ?? 0
+
+        if UserConfiguration.shared.tilingEnabled, let windowLimit = UserConfiguration.shared.windowMaxCount() {
+            let shouldInsertAtFront = UserConfiguration.shared.sendNewWindowsToMainPane()
+            delegate?.applyWindowLimit(forScreenManager: self, minimizingIn: { windowCount in
+
+                if windowLimit > windowCount {
+                    // Not enough windows to minimize.
+                    return 0 ..< 0
+                }
+                if !(currentLayout is PanedLayout) {
+                    // Minimize from the back, for layouts like floating/fullscreen.
+                    return 0 ..< windowCount - windowLimit
+                }
+                if windowLimit <= mainPaneCount {
+                    // Don't minimize main panes. This allowing varying main pane count to pin windows.
+                    guard windowCount >= mainPaneCount else {return 0 ..< 0}
+                    return mainPaneCount ..< windowCount
+                }
+                // Minimize the oldest non-main panes.
+                if shouldInsertAtFront {
+                    return windowLimit ..< windowCount
+                } else {
+                    return mainPaneCount ..< windowCount + mainPaneCount - windowLimit
+                }
+            })
         }
     }
 
@@ -346,6 +378,13 @@ extension ScreenManager: Comparable {
 }
 
 extension WindowManager: ScreenManagerDelegate {
+    func applyWindowLimit(forScreenManager screenManager: ScreenManager<WindowManager<Application>>, minimizingIn range: (Int) -> Range<Int>) {
+        guard let screen = screenManager.screen else {return}
+        let windows = activeWindows(on: screen)
+        windows[range(windows.count)].forEach {
+            $0.minimize()
+        }
+    }
     func activeWindowSet(forScreenManager screenManager: ScreenManager<WindowManager<Application>>) -> WindowSet<Window> {
         return windows.windowSet(forActiveWindowsOnScreen: screenManager.screen!)
     }

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -384,7 +384,10 @@ extension ScreenManager: Comparable {
 extension WindowManager: ScreenManagerDelegate {
     func applyWindowLimit(forScreenManager screenManager: ScreenManager<WindowManager<Application>>, minimizingIn range: (Int) -> Range<Int>) {
         guard let screen = screenManager.screen else {return}
-        let windows = activeWindows(on: screen)
+        let windows =
+            screenManager.currentLayout is FloatingLayout
+            ? self.windows.activeWindows(onScreen: screen).filter { $0.shouldBeManaged() }
+            : activeWindows(on: screen)
         windows[range(windows.count)].forEach {
             $0.minimize()
         }

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -198,7 +198,11 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
                 }
                 if !(currentLayout is PanedLayout) {
                     // Minimize from the back, for layouts like floating/fullscreen.
-                    return 0 ..< windowCount - windowLimit
+                    if currentLayout is FloatingLayout {
+                        return windowLimit ..< windowCount
+                    } else {
+                        return 0 ..< windowCount - windowLimit
+                    }
                 }
                 if windowLimit <= mainPaneCount {
                     // Don't minimize main panes. This allowing varying main pane count to pin windows.

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -198,7 +198,7 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
                 }
                 if !(currentLayout is PanedLayout) {
                     // Minimize from the back, for layouts like floating/fullscreen.
-                    if currentLayout is FloatingLayout {
+                    if shouldInsertAtFront {
                         return windowLimit ..< windowCount
                     } else {
                         return 0 ..< windowCount - windowLimit

--- a/Amethyst/Managers/Windows.swift
+++ b/Amethyst/Managers/Windows.swift
@@ -71,8 +71,8 @@ extension WindowManager {
             } else {
                 windows.append(window)
             }
-            if let limit = UserConfiguration.shared.windowMaxCount(), windows.count > limit {
-                windows.filter {$0.shouldBeManaged() && $0.isOnScreen() && $0.screen() == window.screen()}.dropFirst(limit).forEach {
+            if let screen = window.screen(), let limit = UserConfiguration.shared.windowMaxCount() {
+                activeWindows(onScreen: screen).dropFirst(limit).forEach {
                     $0.minimize()
                 }
             }

--- a/Amethyst/Managers/Windows.swift
+++ b/Amethyst/Managers/Windows.swift
@@ -71,6 +71,11 @@ extension WindowManager {
             } else {
                 windows.append(window)
             }
+            if let limit = UserConfiguration.shared.windowMaxCount(), windows.count > limit {
+                windows.filter {$0.shouldBeManaged() && $0.isOnScreen() && $0.screen() == window.screen()}.dropFirst(limit).forEach {
+                    $0.minimize()
+                }
+            }
         }
 
         func remove(window: Window) {

--- a/Amethyst/Managers/Windows.swift
+++ b/Amethyst/Managers/Windows.swift
@@ -67,22 +67,9 @@ extension WindowManager {
 
         func add(window: Window, atFront shouldInsertAtFront: Bool) {
 
-            func applyWindowLimit() {
-                if UserConfiguration.shared.tilingEnabled,
-                   let screen = window.screen(),
-                   let windowLimit = UserConfiguration.shared.windowMaxCount() {
-                    let countToKeep = windowLimit - (shouldInsertAtFront ? 0 : 1)
-                    activeWindows(onScreen: screen).dropFirst(countToKeep).forEach {
-                        $0.minimize()
-                    }
-                }
-            }
-
             if shouldInsertAtFront {
                 windows.insert(window, at: 0)
-                applyWindowLimit()
             } else {
-                applyWindowLimit()
                 windows.append(window)
             }
         }

--- a/Amethyst/Managers/Windows.swift
+++ b/Amethyst/Managers/Windows.swift
@@ -68,7 +68,9 @@ extension WindowManager {
         func add(window: Window, atFront shouldInsertAtFront: Bool) {
 
             func applyWindowLimit() {
-                if let screen = window.screen(), let windowLimit = UserConfiguration.shared.windowMaxCount() {
+                if UserConfiguration.shared.tilingEnabled,
+                   let screen = window.screen(),
+                   let windowLimit = UserConfiguration.shared.windowMaxCount() {
                     let countToKeep = windowLimit - (shouldInsertAtFront ? 0 : 1)
                     activeWindows(onScreen: screen).dropFirst(countToKeep).forEach {
                         $0.minimize()

--- a/Amethyst/Managers/Windows.swift
+++ b/Amethyst/Managers/Windows.swift
@@ -66,15 +66,22 @@ extension WindowManager {
         // MARK: Adding and Removing
 
         func add(window: Window, atFront shouldInsertAtFront: Bool) {
+
+            func applyWindowLimit() {
+                if let screen = window.screen(), let windowLimit = UserConfiguration.shared.windowMaxCount() {
+                    let countToKeep = windowLimit - (shouldInsertAtFront ? 0 : 1)
+                    activeWindows(onScreen: screen).dropFirst(countToKeep).forEach {
+                        $0.minimize()
+                    }
+                }
+            }
+
             if shouldInsertAtFront {
                 windows.insert(window, at: 0)
+                applyWindowLimit()
             } else {
+                applyWindowLimit()
                 windows.append(window)
-            }
-            if let screen = window.screen(), let limit = UserConfiguration.shared.windowMaxCount() {
-                activeWindows(onScreen: screen).dropFirst(limit).forEach {
-                    $0.minimize()
-                }
             }
         }
 

--- a/Amethyst/Model/Window.swift
+++ b/Amethyst/Model/Window.swift
@@ -80,7 +80,9 @@ protocol WindowType: Equatable {
      `true` if the window was successfully focused, `false` otherwise.
      */
     @discardableResult func focus() -> Bool
-
+    
+    @discardableResult func minimize() -> Bool
+    
     /**
      Moves the window to a screen.
      
@@ -287,6 +289,11 @@ extension AXWindow: WindowType {
         mouseMoveEvent.post(tap: CGEventTapLocation.cghidEventTap)
 
         return true
+    }
+
+    @discardableResult func minimize() -> Bool {
+        super.minimize()
+        return isWindowMinimized()
     }
 
     func moveScaled(to screen: Screen) {

--- a/Amethyst/Model/Window.swift
+++ b/Amethyst/Model/Window.swift
@@ -80,9 +80,9 @@ protocol WindowType: Equatable {
      `true` if the window was successfully focused, `false` otherwise.
      */
     @discardableResult func focus() -> Bool
-    
+
     @discardableResult func minimize() -> Bool
-    
+
     /**
      Moves the window to a screen.
      

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -63,8 +63,8 @@
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.window-margins" id="OOA-MA-LCS"/>
                         <binding destination="XhK-Tn-zrU" name="value" keyPath="values.smart-window-margins" id="zRQ-9W-cK5"/>
+                        <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.window-margins" id="OOA-MA-LCS"/>
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3OU-K6-S5G">
@@ -167,10 +167,27 @@
                         <binding destination="N2H-cZ-f1m" name="value" keyPath="values.window-minimum-width" id="IQ2-rQ-gza"/>
                     </connections>
                 </stepper>
+                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MJk-MS-1xp">
+                    <rect key="frame" x="234" y="352" width="19" height="27"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <stepperCell key="cell" continuous="YES" alignment="left" maxValue="30" id="y24-P1-XzF"/>
+                    <connections>
+                        <binding destination="N2H-cZ-f1m" name="value" keyPath="values.window-max-count" id="bXm-k8-TOS"/>
+                    </connections>
+                </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JVK-ci-h9a">
                     <rect key="frame" x="33" y="333" width="155" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Minimum Width:" id="0ju-6y-OxU">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dtw-c2-sHK">
+                    <rect key="frame" x="33" y="358" width="155" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Maximum Window Count:" id="tjT-rh-6Es">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -385,6 +402,21 @@
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q7S-uK-u6Y">
+                    <rect key="frame" x="196" y="355" width="40" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="YGR-J5-VCh">
+                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="Z5V-Io-vQx">
+                            <real key="minimum" value="0.0"/>
+                        </numberFormatter>
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="value" keyPath="values.window-max-count" id="WIW-VS-GfJ"/>
+                    </connections>
                 </textField>
             </subviews>
             <point key="canvasLocation" x="561" y="253"/>

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -70,6 +70,7 @@ enum ConfigurationKey: String {
     case windowMarginSize = "window-margin-size"
     case windowMinimumHeight = "window-minimum-height"
     case windowMinimumWidth = "window-minimum-width"
+    case windowMaxCount = "window-max-count"
     case floatingBundleIdentifiers = "floating"
     case floatingBundleIdentifiersIsBlacklist = "floating-is-blacklist"
     case ignoreMenuBar = "ignore-menu-bar"
@@ -547,6 +548,11 @@ class UserConfiguration: NSObject {
 
     func windowMinimumWidth() -> CGFloat {
         return CGFloat(storage.float(forKey: .windowMinimumWidth))
+    }
+
+    func windowMaxCount() -> Int? {
+        let int = Int(storage.float(forKey: .windowMaxCount))
+        return int == 0 ? nil : int
     }
 
     func windowResizeStep() -> CGFloat {

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -217,6 +217,7 @@
     "window-margins": false,
     "window-minimum-height": 0,
     "window-minimum-width": 0,
+    "window-max-count": 0,
     "ignore-menu-bar": false,
     "use-canary-build": false,
     "new-windows-to-main": false,

--- a/AmethystTests/Model/TestWindow.swift
+++ b/AmethystTests/Model/TestWindow.swift
@@ -78,6 +78,10 @@ final class TestWindow: WindowType {
         return false
     }
 
+    func minimize() -> Bool {
+      return false
+    }
+
     func moveScaled(to screen: Screen) {
 
     }

--- a/AmethystTests/Tests/Managers/ScreenManagerTests.swift
+++ b/AmethystTests/Tests/Managers/ScreenManagerTests.swift
@@ -14,6 +14,9 @@ import Silica
 private final class TestDelegate: ScreenManagerDelegate {
     typealias Window = TestWindow
 
+    func applyWindowLimit(forScreenManager screenManager: ScreenManager<TestDelegate>, minimizingIn range: (Int) -> Range<Int>) {
+        fatalError()
+    }
     func activeWindowSet(forScreenManager screenManager: ScreenManager<TestDelegate>) -> WindowSet<TestWindow> {
         fatalError()
     }


### PR DESCRIPTION
A proof of concept implementation of #1075, to automatically minimise oldest windows above a certain threshold on a per-space basis, which is configurable in the General Preferences pane. Use a value of 0 to disable the feature, and the max is arbitrarily set to 30. My personal recommendation is using a limit of 3 in Tall layout, and switching to the fullscreen layout (rather than minimising manually) when you want to monotask.

A future direction might be to add a shortcut specifically to toggle the window limit between 1 and the current value, to avoid the need to switch to Fullscreen layout every time. It works for me because I'm only using Tall & Fullscreen, but I could see this becoming an issue.

This is my first time making a change in the Amethyst codebase, and I've had very little experience with AppKit! Feel free to just write the code yourself rather than use this PR; it wasn't a lot of work and I've no idea about the code style guidelines for this project.

If you do use this PR, there are a number of things which will needs doing, apart from a general code tidy-up:
* The addition of the preference to GeneralPreferencesViewController's Xib layout is a complete hack-job due to my inexperience. It's functional but needs lining up nicely at the very least.
* The current implementation does not detect and apply the limit when windows are moved across screens. The same is likely also true when moving windows between spaces.
* It does, however, account for tabs, and correctly applies the window limit on a per-screen basis.
* There may be other issues! I only use a fraction of Amethyst's capabilities, so this needs some proper testing.