### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Getting Amethyst
 Amethyst is available for direct download on the [releases page](https://github.com/ianyh/Amethyst/releases) or using [homebrew cask](https://github.com/Homebrew/homebrew-cask).
 
 ```
-brew cask install amethyst
+brew install --cask amethyst
 ```
 
 Note: that Amethyst now is only supported on macOS 10.12+.


### PR DESCRIPTION
Calling `brew cask install` is disabled in Homebrew 2.7.0. Instead, we should use `brew install --cask`.

From https://github.com/Homebrew/discussions/discussions/340#discussioncomment-232364:
> This is expected behavior. `brew cask <command>` was deprecated in favor of `brew <command> --cask` in Homebrew 2.6.0. Now that 2.7.0 has been released, they have been disabled. This was documented in the release notes and on the Homebrew blog in addition to the messages at the command-line. This is the typical cycle for breaking changes like this. First, we show a message saying "this will break here's how to fix it." Next, it stops working but with a message letting users know why it's not working (it was disabled) and with instructions for future use. Finally, these messages are totally removed. We generally move one step forward with each major/minor release.
> 
> The Homebrew maintainers don't have any connection with the anisble modules, so it's on the ansible folks to handle this. I agree, they should probably catch deprecation warnings. If they had, this likely wouldn't be an issue. Otherwise, they'll continue to be surprised when things break.