### PR TITLE
Add useful configuration tip back into the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Amethyst must be given permissions to use the accessibility APIs under the Priva
 
 ![Accessibility permissions](https://ianyh.com/amethyst/images/accessibility-window.png)
 
+**_Important note_**: You will probably want to disable `Automatically rearrange Spaces based on most recent use` (found under Mission Control in System Preferences). This setting is enabled by default, and will cause your Spaces to swap places based on use. This makes keyboard navigation between Spaces unpredictable.
+
+<p align="center">
+  <img style="text-align: center" width="500px" src="https://user-images.githubusercontent.com/11782590/127423014-1faa4a7f-9225-42ea-b400-56b994e2796f.png" />
+</p>
+
 Keyboard Shortcuts
 ------------------
 


### PR DESCRIPTION
So I found this annoying behaviour, when the `Automatically rearrange Spaces based on most recent use` is on in mission control settings. Which was on by default on my macbook.

![image](https://user-images.githubusercontent.com/11782590/127423014-1faa4a7f-9225-42ea-b400-56b994e2796f.png)

This just adds a small note to make sure this setting is disabled, so others don't get annoyed like I did! 👍 

Fixes: #73

Thanks for all your work, amazing project ❤️ 