### PR TITLE
add regex support to floating windows title matching

### DIFF
--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -418,7 +418,13 @@ class UserConfiguration: NSObject {
         // If the title matches it is included
         //   - Blacklist means floating
         //   - Whitelist means not floating
-        if floatingBundle.windowTitles.contains(title) {
+        if floatingBundle.windowTitles.contains(where: { windowTitle in
+            if title.range(of: windowTitle, options: .regularExpression) != nil {
+                return true
+            } else {
+                return false
+            }
+        }) {
             return .reliable(DefaultFloat.from(useIdentifiersAsBlacklist))
         }
 


### PR DESCRIPTION
Fixes: https://github.com/ianyh/Amethyst/issues/981

Add regex support to the current matching of floating windows title. 
This shouldn't break current configurations.