### PR TITLE
Throw window to any space across multiple screens.

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -642,7 +642,7 @@ extension WindowManager: WindowTransitionTarget {
         case let .moveWindowToSpaceAtIndex(window, spaceIndex):
             guard
                 let screen = window.screen(),
-                let spaces = CGSpacesInfo<Window>.spacesForScreen(screen, includeOnlyUserSpaces: true),
+                let spaces = CGSpacesInfo<Window>.spacesForAllScreens(includeOnlyUserSpaces: true),
                 spaceIndex < spaces.count
             else {
                 return

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -649,9 +649,16 @@ extension WindowManager: WindowTransitionTarget {
             }
 
             let targetSpace = spaces[spaceIndex]
-
+            guard let targetScreen = CGSpacesInfo<Window>.screenForSpace(space: targetSpace) else {
+                return
+            }
             markScreen(screen, forReflowWithChange: .remove(window: window))
             window.move(toSpace: targetSpace.id)
+            // necessary to set frame here as window is expected to be at origin when moved, can be improved.
+            let newFrame = targetScreen.frameWithoutDockOrMenu()
+            window.setFrame(newFrame, withThreshold: CGSize(width: 25, height: 25))
+            markScreen(targetScreen, forReflowWithChange: .add(window: window))
+            window.focus()
         case .resetFocus:
             if let screen = screens.screenManagers.first?.screen {
                 executeTransition(.focusScreen(screen))

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -654,7 +654,7 @@ extension WindowManager: WindowTransitionTarget {
             }
             markScreen(screen, forReflowWithChange: .remove(window: window))
             window.move(toSpace: targetSpace.id)
-            // necessary to set frame here as window is expected to be at origin when moved, can be improved.
+            // necessary to set frame here as window is expected to be at origin relative to targe screen when moved, can be improved.
             let newFrame = targetScreen.frameWithoutDockOrMenu()
             window.setFrame(newFrame, withThreshold: CGSize(width: 25, height: 25))
             markScreen(targetScreen, forReflowWithChange: .add(window: window))

--- a/Amethyst/Model/CGInfo.swift
+++ b/Amethyst/Model/CGInfo.swift
@@ -161,6 +161,15 @@ struct CGSpacesInfo<Window: WindowType> {
         return currentSpaceForScreen(screen)
     }
 
+    static func screenForSpace(space: Space) -> Screen? {
+        for screen in Screen.availableScreens {
+            if (spacesForScreen(screen)?.contains { $0.id == space.id } ?? false) {
+                return screen
+            }
+        }
+        return nil
+    }
+
     static func space(fromScreenDescription screenDictionary: JSON) -> Space {
         return space(fromSpaceDescription: screenDictionary["Current Space"])
     }


### PR DESCRIPTION
This PR adjusts the behaviour of throwing windows between spaces such that:
- You can throw a window to another space by using the space/desktop number visible from Mission Control.
- Throwing windows between spaces on different screens now works as expected (least surprise, matching XMonad behaviour).

Currently throwing windows between spaces only works between spaces on the same screen. You cannot throw a window to a space belonging to a different screen. This is confusing when managing windows in a multi-screen setup i.e. instead of throwing a window to space X (where X is the Mission Control space number) which exists on screen A directly, you must first throw the window to screen A and then throw it to space X' which is the index of space X local to screen A. It creates more steps when issuing keyboard commands as explained in the example. Its also confusing from the fact that the space numbers shown in Mission Control do not reflect the space numbers used when throwing windows in a multi-screen setup. Finally the current behaviour deviates from the existing XMonad behaviour which allows throwing windows to arbitrary workspaces, regardless of which screen it is currently visible on.