### PR TITLE
Fix swapping with two windows visible for two-pane layout

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -670,11 +670,8 @@ extension WindowManager: WindowTransitionTarget {
         return windows.isWindowFloating(window)
     }
 
-    func getCurrentLayout() -> Layout<Application.Window>? {
-        guard let screenManager: ScreenManager<WindowManager<Application>> = focusedScreenManager(), let layout = screenManager.currentLayout else {
-            return nil
-        }
-        return layout
+    func currentLayout() -> Layout<Application.Window>? {
+        return focusedScreenManager()?.currentLayout
     }
 
     func activeWindows(on screen: Screen) -> [Window] {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -670,6 +670,13 @@ extension WindowManager: WindowTransitionTarget {
         return windows.isWindowFloating(window)
     }
 
+    func getCurrentLayout() -> Layout<Application.Window>? {
+        guard let screenManager: ScreenManager<WindowManager<Application>> = focusedScreenManager(), let layout = screenManager.currentLayout else {
+            return nil
+        }
+        return layout
+    }
+
     func activeWindows(on screen: Screen) -> [Window] {
         return windows.activeWindows(onScreen: screen).filter { window in
             return window.shouldBeManaged() && !self.windows.isWindowFloating(window)

--- a/Amethyst/Managers/WindowTransitionCoordinator.swift
+++ b/Amethyst/Managers/WindowTransitionCoordinator.swift
@@ -26,7 +26,7 @@ protocol WindowTransitionTarget: class {
     func executeTransition(_ transition: WindowTransition<Window>)
 
     func isWindowFloating(_ window: Window) -> Bool
-    func getCurrentLayout() -> Layout<Application.Window>?
+    func currentLayout() -> Layout<Application.Window>?
     func screen(at index: Int) -> Screen?
     func activeWindows(on screen: Screen) -> [Window]
     func nextScreenIndexClockwise(from screen: Screen) -> Int
@@ -52,7 +52,7 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
 
         if windows.count == 1 {
             return
-        } else if windows.count == 2 || target?.getCurrentLayout()?.layoutKey == TwoPaneLayout<Window>.layoutKey {
+        } else if windows.count == 2 || target?.currentLayout()?.layoutKey == TwoPaneLayout<Window>.layoutKey {
             // Swap the two visible windows, keep focus on the main window if it already was there
             target?.executeTransition(.switchWindows(focusedWindow, windows[1 - focusedIndex]))
             if focusedWindow == windows[0] {

--- a/Amethyst/Managers/WindowTransitionCoordinator.swift
+++ b/Amethyst/Managers/WindowTransitionCoordinator.swift
@@ -50,12 +50,14 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
             return
         }
 
-        let twoPaneLayoutActive = target?.getCurrentLayout()?.layoutKey == TwoPaneLayout<Window>.layoutKey
         if windows.count == 1 {
             return
-        } else if windows.count == 2 || twoPaneLayoutActive {
-            // Swap the two visible windows
+        } else if windows.count == 2 || target?.getCurrentLayout()?.layoutKey == TwoPaneLayout<Window>.layoutKey {
+            // Swap the two visible windows, keep focus on the main window if it already was there
             target?.executeTransition(.switchWindows(focusedWindow, windows[1 - focusedIndex]))
+            if focusedWindow == windows[0] {
+                windows[1 - focusedIndex].focus()
+            }
         } else {
             // Swap focused window with main window
             target?.executeTransition(.switchWindows(focusedWindow, windows[0]))

--- a/Amethyst/Managers/WindowTransitionCoordinator.swift
+++ b/Amethyst/Managers/WindowTransitionCoordinator.swift
@@ -26,6 +26,7 @@ protocol WindowTransitionTarget: class {
     func executeTransition(_ transition: WindowTransition<Window>)
 
     func isWindowFloating(_ window: Window) -> Bool
+    func getCurrentLayout() -> Layout<Application.Window>?
     func screen(at index: Int) -> Screen?
     func activeWindows(on screen: Screen) -> [Window]
     func nextScreenIndexClockwise(from screen: Screen) -> Int
@@ -49,13 +50,14 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
             return
         }
 
-        // if there are 2 windows, we can always swap.  Just make sure we don't swap focusedWindow with itself.
-        switch windows.count {
-        case 1:
+        let twoPaneLayoutActive = target?.getCurrentLayout()?.layoutKey == TwoPaneLayout<Window>.layoutKey
+        if windows.count == 1 {
             return
-        case 2:
+        } else if windows.count == 2 || twoPaneLayoutActive {
+            // Swap the two visible windows
             target?.executeTransition(.switchWindows(focusedWindow, windows[1 - focusedIndex]))
-        default:
+        } else {
+            // Swap focused window with main window
             target?.executeTransition(.switchWindows(focusedWindow, windows[0]))
         }
     }


### PR DESCRIPTION
Closes #1234 .

This PR lets you use the 'Swap focused window with main window' hotkey to swap the two windows visible in the two-pane layout. 

This already works in any layout when only two windows are present on a screen. The two-pane layout is a bit different here as there are always only two windows visible even though more might be open.