### PR TITLE
Make main window focus behaviour more consistent

### DIFF
--- a/Amethyst/Managers/WindowTransitionCoordinator.swift
+++ b/Amethyst/Managers/WindowTransitionCoordinator.swift
@@ -52,12 +52,12 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
 
         if windows.count == 1 {
             return
-        } else if windows.count == 2 || target?.currentLayout()?.layoutKey == TwoPaneLayout<Window>.layoutKey {
-            // Swap the two visible windows, keep focus on the main window if it already was there
-            target?.executeTransition(.switchWindows(focusedWindow, windows[1 - focusedIndex]))
-            if focusedWindow == windows[0] {
-                windows[1 - focusedIndex].focus()
-            }
+        }
+
+        if focusedIndex == 0 {
+            // If main window is focused - swap the two top-most windows, keep focus on the main window
+            target?.executeTransition(.switchWindows(focusedWindow, windows[1]))
+            windows[1].focus()
         } else {
             // Swap focused window with main window
             target?.executeTransition(.switchWindows(focusedWindow, windows[0]))

--- a/Amethyst/Managers/WindowTransitionCoordinator.swift
+++ b/Amethyst/Managers/WindowTransitionCoordinator.swift
@@ -50,7 +50,7 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
             return
         }
 
-        if windows.count == 1 {
+        if windows.count <= 1 {
             return
         }
 

--- a/Amethyst/Managers/WindowTransitionCoordinator.swift
+++ b/Amethyst/Managers/WindowTransitionCoordinator.swift
@@ -54,12 +54,15 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
             return
         }
 
-        if focusedIndex == 0 {
-            // If main window is focused - swap the two top-most windows, keep focus on the main window
+        if focusedIndex == 0 && target?.currentLayout()?.layoutKey == TwoPaneLayout<Window>.layoutKey {
+            // If main window is focused and layout is two-pane - swap the two top-most windows, keep focus on the main window
             target?.executeTransition(.switchWindows(focusedWindow, windows[1]))
             windows[1].focus()
-        } else {
-            // Swap focused window with main window
+            return
+        }
+
+        if focusedIndex != 0 {
+            // Swap focused window with main window if other window is focused
             target?.executeTransition(.switchWindows(focusedWindow, windows[0]))
         }
     }


### PR DESCRIPTION
* Focusing window 2+ in two-pane layout and invoking the shortcut caused a crash! (sorry)
* It's not completely clear what the shortcut should do depending on selection in two-pane layout.

I think this should simplify things - when the main window is focused and you invoke the "Swap with main window" shortcut it swaps the two top-most windows in the `windows` array. This makes the shortcut a convenient way to switch back and forth between two windows.