### PR TITLE
Fix ghost window when typing with Input Method under BSP Layout.

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -334,8 +334,14 @@ final class WindowManager<Application: ApplicationType>: NSObject, Codable {
         guard let screen = window.screen() else {
             return
         }
+        let windowIDsArray = [NSNumber(value: window.cgID() as UInt32)] as NSArray
+        guard let spaces = CGSCopySpacesForWindows(CGSMainConnectionID(), kCGSAllSpacesMask, windowIDsArray)?.takeRetainedValue() else {
+            return
+        }
 
-        let windowChange: Change = windows.isWindowFloating(window) ? .unknown : .add(window: window)
+        let space = (spaces as NSArray as? [NSNumber])?.first?.intValue
+
+        let windowChange: Change = windows.isWindowFloating(window) || space == nil ? .unknown : .add(window: window)
         markScreen(screen, forReflowWithChange: windowChange)
     }
 


### PR DESCRIPTION
A event about a window instance with a nil 'space' property should be reported as unknown.

Fix #1246 