### PR TITLE
Fix ghost windows which have nil Space value under BSP Layout 

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -334,12 +334,7 @@ final class WindowManager<Application: ApplicationType>: NSObject, Codable {
         guard let screen = window.screen() else {
             return
         }
-        let windowIDsArray = CGWindowsInfo.windowIDsArray(window)
-        guard let spaces = CGSCopySpacesForWindows(CGSMainConnectionID(), kCGSAllSpacesMask, windowIDsArray)?.takeRetainedValue() else {
-            return
-        }
-
-        let space = (spaces as NSArray as? [NSNumber])?.first?.intValue
+        let space = CGWindowsInfo.windowSpace(window)
 
         let windowChange: Change = windows.isWindowFloating(window) || space == nil ? .unknown : .add(window: window)
         markScreen(screen, forReflowWithChange: windowChange)

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -334,7 +334,7 @@ final class WindowManager<Application: ApplicationType>: NSObject, Codable {
         guard let screen = window.screen() else {
             return
         }
-        let windowIDsArray = [NSNumber(value: window.cgID() as UInt32)] as NSArray
+        let windowIDsArray = CGWindowsInfo.windowIDsArray(window)
         guard let spaces = CGSCopySpacesForWindows(CGSMainConnectionID(), kCGSAllSpacesMask, windowIDsArray)?.takeRetainedValue() else {
             return
         }

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -334,8 +334,14 @@ final class WindowManager<Application: ApplicationType>: NSObject, Codable {
         guard let screen = window.screen() else {
             return
         }
+        let windowIDsArray = [NSNumber(value: window.cgID() as UInt32)] as NSArray
+        guard let spaces = CGSCopySpacesForWindows(CGSMainConnectionID(), kCGSAllSpacesMask, windowIDsArray)?.takeRetainedValue() else {
+            return
+        }
 
-        let windowChange: Change = windows.isWindowFloating(window) ? .unknown : .add(window: window)
+        let space = (spaces as NSArray as? [NSNumber])?.first?.intValue
+
+        let windowChange: Change = windows.isWindowFloating(window) || space == nil ? .unknown : .add(window: window)
         markScreen(screen, forReflowWithChange: windowChange)
     }
 

--- a/Amethyst/Managers/Windows.swift
+++ b/Amethyst/Managers/Windows.swift
@@ -41,7 +41,7 @@ extension WindowManager {
             }
 
             let screenWindows = windows.filter { window in
-                let windowIDsArray = [NSNumber(value: window.cgID() as UInt32)] as NSArray
+                let windowIDsArray = CGWindowsInfo.windowIDsArray(window)
 
                 guard let spaces = CGSCopySpacesForWindows(CGSMainConnectionID(), kCGSAllSpacesMask, windowIDsArray)?.takeRetainedValue() else {
                     return false
@@ -127,7 +127,7 @@ extension WindowManager {
         }
 
         func regenerateActiveIDCache() {
-            let windowDescriptions = CGWindowsInfo(options: .optionOnScreenOnly, windowID: CGWindowID(0))
+            let windowDescriptions = CGWindowsInfo<Window>(options: .optionOnScreenOnly, windowID: CGWindowID(0))
             activeIDCache = windowDescriptions?.activeIDs() ?? Set()
         }
 

--- a/Amethyst/Managers/Windows.swift
+++ b/Amethyst/Managers/Windows.swift
@@ -41,13 +41,7 @@ extension WindowManager {
             }
 
             let screenWindows = windows.filter { window in
-                let windowIDsArray = CGWindowsInfo.windowIDsArray(window)
-
-                guard let spaces = CGSCopySpacesForWindows(CGSMainConnectionID(), kCGSAllSpacesMask, windowIDsArray)?.takeRetainedValue() else {
-                    return false
-                }
-
-                let space = (spaces as NSArray as? [NSNumber])?.first?.intValue
+                let space = CGWindowsInfo.windowSpace(window)
 
                 guard let windowScreen = window.screen(), currentSpace.id == space else {
                     return false

--- a/Amethyst/Model/CGInfo.swift
+++ b/Amethyst/Model/CGInfo.swift
@@ -11,7 +11,7 @@ import Silica
 import SwiftyJSON
 
 /// Windows info as taken from the underlying system.
-struct CGWindowsInfo {
+struct CGWindowsInfo<Window: WindowType> {
     /// An array of dictionaries of window information
     let descriptions: [[String: AnyObject]]
 
@@ -48,6 +48,10 @@ struct CGWindowsInfo {
         }
 
         return ids
+    }
+
+    static func windowIDsArray(_ window: Window) -> NSArray {
+        return [NSNumber(value: window.cgID() as UInt32)] as NSArray
     }
 }
 

--- a/Amethyst/Model/CGInfo.swift
+++ b/Amethyst/Model/CGInfo.swift
@@ -53,6 +53,16 @@ struct CGWindowsInfo<Window: WindowType> {
     static func windowIDsArray(_ window: Window) -> NSArray {
         return [NSNumber(value: window.cgID() as UInt32)] as NSArray
     }
+
+    static func windowSpace(_ window: Window) -> Int? {
+        let windowIDsArray = CGWindowsInfo.windowIDsArray(window)
+
+        guard let spaces = CGSCopySpacesForWindows(CGSMainConnectionID(), kCGSAllSpacesMask, windowIDsArray)?.takeRetainedValue() else {
+            return nil
+        }
+
+        return (spaces as NSArray as? [NSNumber])?.first?.intValue
+    }
 }
 
 struct CGScreensInfo<Window: WindowType> {

--- a/Amethyst/Model/WindowsInformation.swift
+++ b/Amethyst/Model/WindowsInformation.swift
@@ -21,10 +21,10 @@ extension CGRect {
 
 struct WindowsInformation<Window: WindowType> {
     let ids: Set<CGWindowID>
-    let descriptions: CGWindowsInfo?
+    let descriptions: CGWindowsInfo<Window>?
 
     init?(windows: [Window]) {
-        guard let descriptions = CGWindowsInfo(options: .optionOnScreenOnly, windowID: CGWindowID(0)) else {
+        guard let descriptions = CGWindowsInfo<Window>(options: .optionOnScreenOnly, windowID: CGWindowID(0)) else {
             return nil
         }
 
@@ -38,7 +38,7 @@ extension WindowsInformation {
     // additionally, return the full set of window descriptions (which is unsorted and may contain extra windows)
     fileprivate static func windowInformation(_ windows: [Window]) -> (IDs: Set<CGWindowID>, descriptions: [[String: AnyObject]]?) {
         let ids = Set(windows.map { $0.cgID() })
-        return (IDs: ids, descriptions: CGWindowsInfo(options: .optionOnScreenOnly, windowID: CGWindowID(0))?.descriptions)
+        return (IDs: ids, descriptions: CGWindowsInfo<Window>(options: .optionOnScreenOnly, windowID: CGWindowID(0))?.descriptions)
     }
 
     fileprivate static func onScreenWindowsAtPoint(_ point: CGPoint,
@@ -93,7 +93,7 @@ extension WindowsInformation {
                 continue
             }
 
-            guard let windowsAboveWindow = CGWindowsInfo(options: .optionOnScreenAboveWindow, windowID: windowID.uint32Value) else {
+            guard let windowsAboveWindow = CGWindowsInfo<Window>(options: .optionOnScreenAboveWindow, windowID: windowID.uint32Value) else {
                 continue
             }
 


### PR DESCRIPTION
Fix ghost windows which have nil Space value under BSP Layout (e.g. typing with Input Method).

A event about a window instance with a nil 'Space' property should be reported as unknown.

Fix #1246 