### PR TITLE
Added option to disable screen padding on built-in display

### DIFF
--- a/Amethyst/Model/Screen.swift
+++ b/Amethyst/Model/Screen.swift
@@ -100,6 +100,12 @@ struct AMScreen: ScreenType {
             frame.size.height = windowMinimumHeight
         }
 
+         var isDisablePaddingOnBuiltinDisplay: Bool =
+             UserConfiguration.shared.disablePaddingOnBuiltinDisplay()
+         var isScreenBuiltin: boolean_t =
+             CGDisplayIsBuiltin(screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as! CGDirectDisplayID)
+         if isDisablePaddingOnBuiltinDisplay && isScreenBuiltin == 1 {return frame}
+
         let paddingTop = UserConfiguration.shared.screenPaddingTop()
         let paddingBottom = UserConfiguration.shared.screenPaddingBottom()
         let paddingLeft = UserConfiguration.shared.screenPaddingLeft()

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -418,6 +418,17 @@
                         <binding destination="XhK-Tn-zrU" name="value" keyPath="values.window-max-count" id="WIW-VS-GfJ"/>
                     </connections>
                 </textField>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IK4-QB-Sbo">
+                     <rect key="frame" x="192" y="93" width="280" height="18"/>
+                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                     <buttonCell key="cell" type="check" title="Disable screen padding on built-in display" bezelStyle="regularSquare" imagePosition="left" inset="2" id="9Vr-QQ-tmB">
+                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                         <font key="font" metaFont="system"/>
+                     </buttonCell>
+                     <connections>
+                         <binding destination="XhK-Tn-zrU" name="value" keyPath="values.disable-padding-on-builtin-display" id="LEd-HG-IyE"/>
+                     </connections>
+                 </button>
             </subviews>
             <point key="canvasLocation" x="561" y="253"/>
         </customView>

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -92,6 +92,7 @@ enum ConfigurationKey: String {
     case screenPaddingBottom = "screen-padding-bottom"
     case debugLayoutInfo = "debug-layout-info"
     case restoreLayoutsOnLaunch = "restore-layouts-on-launch"
+    case disablePaddingOnBuiltinDisplay = "disable-padding-on-builtin-display"
 }
 
 extension ConfigurationKey: CaseIterable {}
@@ -652,6 +653,10 @@ class UserConfiguration: NSObject {
 
     func sendNewWindowsToMainPane() -> Bool {
         return storage.bool(forKey: .newWindowsToMain)
+    }
+
+    func disablePaddingOnBuiltinDisplay() -> Bool {
+        return storage.bool(forKey: .disablePaddingOnBuiltinDisplay)
     }
 
     func followWindowsThrownBetweenSpaces() -> Bool {

--- a/docs/configuration-files.md
+++ b/docs/configuration-files.md
@@ -35,6 +35,7 @@ Amethyst will pick up a config file located at `~/.amethyst.yml`. A sample can b
 | `screen-padding-bottom` | Padding to apply between windows and the bottom edge of the screen (in px, default `0`).
 | `restore-layouts-on-launch` | `true` to maintain layout state across application executions (default `true`). |
 | `debug-layout-info` | `true` to display some optional debug information in the layout HUD (default `false`). |
+| `disable-screen-padding-on-inbuilt` |  `true` to disable screen padding on in-built display (default `false`). |
 
 ## Commands
 


### PR DESCRIPTION
Screen padding is often used on external displays to better position content in the line of sight, however the effects are not desirable on a laptop screen.

This option adds the ability to disable screen padding for the in-built display, whilst still having it enabled on external monitors. The checkbox option is disabled by default. 

The feature is useful when not using clamshell mode, ie when the built-in display is being used alongside external displays. Likewise, when working solely from the laptop, this feature eliminates the need to manually decrement the padding that was configured for external monitors.

<img width="660" alt="general-preferences" src="https://user-images.githubusercontent.com/41560607/184815379-bbf3bfaf-2ee0-4410-9d7c-21b73349ba30.png">
