### PR TITLE
adds rest of layouts to sample config file

### DIFF
--- a/.amethyst.sample.yml
+++ b/.amethyst.sample.yml
@@ -2,6 +2,20 @@
 layouts:
     - tall
     - fullscreen
+    - tall-right
+    - wide
+    - two-pane
+    - 3column-left
+    - middle-wide
+    - 3column-right
+    - 4column-left
+    - 4column-right
+    - column
+    - row
+    - floating
+    - widescreen-tall
+    - widescreen-tall-right
+    - bsp
 
 # Add "command" to the default mods
 mod1:


### PR DESCRIPTION
When creating a config file for the first time, I tried to add the Two Pane layout with the keys `twopane`, `two_pane`, `twoPane` before cloning the repo and using grep to find out that the correct key was `two-pane`.

Having all layouts by default might save time for people who don't know what the proper consensus is for yaml files and such keys :)