### PR TITLE
Issue 1306: Fix "Follow thrown windows between spaces" setting not working

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -659,7 +659,9 @@ extension WindowManager: WindowTransitionTarget {
             let newFrame = targetScreen.frameWithoutDockOrMenu()
             window.setFrame(newFrame, withThreshold: CGSize(width: 25, height: 25))
             markScreen(targetScreen, forReflowWithChange: .add(window: window))
-            window.focus()
+            if UserConfiguration.shared.followWindowsThrownBetweenSpaces() {
+                window.focus()
+            }
         case .resetFocus:
             if let screen = screens.screenManagers.first?.screen {
                 executeTransition(.focusScreen(screen))


### PR DESCRIPTION
This PR resolves Issue #1306 (Throw a window to other spaces will follow the window to that space even when the settings is unchecked.)

It looks to me like PR #1209 broke the "follow thrown windows between spaces" setting by adding a new call to `window.focus` that was not gated by a check for `UserConfiguration.shared.followWindowsThrownBetweenSpaces()`.

Adding this check restores the expected behavior. This code builds and runs locally.

Pinging @dozzman as the author of PR #1209, just want to make sure adding this check doesn't break anything (I can't imagine it would, though).

Also thanks @ianyh for making contributing easy – I was able to get the project up and running in no time.