### PR TITLE
Switch to previous main window when main is selected

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -688,6 +688,17 @@ extension WindowManager: WindowTransitionTarget {
 
         return (screenManagerIndex == 0 ? screens.screenManagers.count - 1 : screenManagerIndex - 1)
     }
+
+    func lastMainWindowForCurrentSpace() -> Window? {
+        guard let screenManager = screens.focusedScreenManager(),
+              let currentFocusedSpace = CGSpacesInfo<Window>.currentFocusedSpace(),
+              let lastMainWindow = windows.lastMainWindows[currentFocusedSpace.id]
+        else {
+            return nil
+        }
+        log.debug("Get last main window on space \(currentFocusedSpace.id) = \(lastMainWindow?.title() ?? "nil")")
+        return lastMainWindow
+    }
 }
 
 // MARK: Focus Transition

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -696,7 +696,6 @@ extension WindowManager: WindowTransitionTarget {
         else {
             return nil
         }
-        log.debug("Get last main window on space \(currentFocusedSpace.id) = \(lastMainWindow?.title() ?? "nil")")
         return lastMainWindow
     }
 }

--- a/Amethyst/Managers/WindowTransitionCoordinator.swift
+++ b/Amethyst/Managers/WindowTransitionCoordinator.swift
@@ -59,14 +59,12 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
             guard let lastMainWindow = target?.lastMainWindowForCurrentSpace() else {
                 return
             }
-            log.debug("Swapping to last main window \(lastMainWindow.title())")
             target?.executeTransition(.switchWindows(focusedWindow, lastMainWindow))
             lastMainWindow.focus()
             return
         }
 
         if focusedIndex != 0 {
-            log.debug("Swapping with main window \(windows[0].title())")
             // Swap focused window with main window if other window is focused
             target?.executeTransition(.switchWindows(focusedWindow, windows[0]))
         }

--- a/Amethyst/Managers/Windows.swift
+++ b/Amethyst/Managers/Windows.swift
@@ -78,18 +78,12 @@ extension WindowManager {
         }
 
         @discardableResult func swap(window: Window, withWindow otherWindow: Window) -> Bool {
-            guard let currentFocusedSpace = CGSpacesInfo<Window>.currentFocusedSpace() else {
-                return false
-            }
-            guard let currentScreen = window.screen() else {
-                return false
-            }
-
-            let activeWindows = activeWindows(onScreen: currentScreen)
-            log.debug("Windows: \(activeWindows.map({ $0.title() }))")
-            if (activeWindows[0] == window || activeWindows[0] == otherWindow) {
-                log.debug("Setting last main window for space \(currentFocusedSpace.id) to \(activeWindows[0].title())")
-                lastMainWindows[currentFocusedSpace.id] = activeWindows[0]
+            if let currentFocusedSpace = CGSpacesInfo<Window>.currentFocusedSpace(),
+               let currentScreen = window.screen() {
+                let activeWindows = activeWindows(onScreen: currentScreen)
+                if activeWindows[0] == window || activeWindows[0] == otherWindow {
+                    lastMainWindows[currentFocusedSpace.id] = activeWindows[0]
+                }
             }
 
             guard let windowIndex = windows.index(of: window), let otherWindowIndex = windows.index(of: otherWindow) else {


### PR DESCRIPTION
The idea is to save the previous main windows on a stack and switch to the previous main window when invoking the "Swap focused window with main window" and the main window is already focused. If there are no previous main windows then the first clockwise window is used instead.

I see this as a draft PR and would like to hear what you think about the approach. No support for multiple desktops / screens yet.

Closes #1377, closes #1378