### PR TITLE
Allow handling apps just by windows title without bundle identifier (Android Emulator Example)

### DIFF
--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -533,7 +533,7 @@ class UserConfiguration: NSObject {
     func runningApplicationFloatingBundle(_ runningApplication: BundleIdentifiable) -> FloatingBundle? {
         let floatingBundles = self.floatingBundles()
 
-        let bundleIdentifier = runningApplication.bundleIdentifier ?? "*"
+        let bundleIdentifier = runningApplication.bundleIdentifier ?? ""
 
         for floatingBundle in floatingBundles {
             if floatingBundle.id.contains("*") {

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -533,13 +533,11 @@ class UserConfiguration: NSObject {
     func runningApplicationFloatingBundle(_ runningApplication: BundleIdentifiable) -> FloatingBundle? {
         let floatingBundles = self.floatingBundles()
 
+        let bundleIdentifier = runningApplication.bundleIdentifier ?? "*"
+
         for floatingBundle in floatingBundles {
             if floatingBundle.id.contains("*") {
                 do {
-                    guard let bundleIdentifier = runningApplication.bundleIdentifier else {
-                        continue
-                    }
-
                     let pattern = floatingBundle.id
                         .replacingOccurrences(of: ".", with: "\\.")
                         .replacingOccurrences(of: "*", with: ".*")


### PR DESCRIPTION
Currently android emulator doesn't have bundle identifier and it's not available as app package so there is no way to add it to floating list. This pull request allow providing * as bundle identifier and matching just by window title.

<img width="477" alt="Screenshot 2023-01-23 at 21 20 07" src="https://user-images.githubusercontent.com/1000144/214143268-f42d98a9-80b1-4b67-9215-1ca80e75cea4.png">
<img width="660" alt="Screenshot 2023-01-23 at 21 22 57" src="https://user-images.githubusercontent.com/1000144/214143277-a4d85846-c16b-47a8-8929-204e069c2000.png">
