### PR TITLE
Main window toggle

### DIFF
--- a/Amethyst/Managers/FocusTransitionCoordinator.swift
+++ b/Amethyst/Managers/FocusTransitionCoordinator.swift
@@ -116,8 +116,12 @@ class FocusTransitionCoordinator<Target: FocusTransitionTarget> {
         guard let windows = target?.windows(onScreen: screen), !windows.isEmpty else {
             return
         }
-
-        windows[0].focus()
+        
+        if focusedWindow.id() == windows[0].id() {
+            target?.lastFocusedWindow(on: screen)!.focus()
+        } else {
+            windows[0].focus()
+        }
     }
 
     func focusScreen(at screenIndex: Int) {

--- a/Amethyst/Managers/FocusTransitionCoordinator.swift
+++ b/Amethyst/Managers/FocusTransitionCoordinator.swift
@@ -118,7 +118,7 @@ class FocusTransitionCoordinator<Target: FocusTransitionTarget> {
         }
         
         if focusedWindow.id() == windows[0].id() {
-            target?.lastFocusedWindow(on: screen)!.focus()
+            (target?.lastFocusedWindow(on: screen) ?? windows[0]).focus()
         } else {
             windows[0].focus()
         }


### PR DESCRIPTION
This PR proposes changing the behavior of the `Move focus to main window` command, default  ⌥⇧M, if the main window is already focused. The current default behavior is to do nothing. This PR changes the behavior to switch focus back to the last focused window. This allows the user to easily toggle between the main window and another, which is especially useful in the Two Pane Layout.