### PR TITLE
Log JavaScript exceptions in custom layouts

### DIFF
--- a/Amethyst/Layout/Layouts/CustomLayout.swift
+++ b/Amethyst/Layout/Layouts/CustomLayout.swift
@@ -54,6 +54,13 @@ class CustomLayout<Window: WindowType>: StatefulLayout<Window> {
             return nil
         }
 
+        context.exceptionHandler = { (_: JSContext!, value: JSValue!) in
+            let name = value.objectForKeyedSubscript("name").toString() ?? ""
+            let message = value.objectForKeyedSubscript("message").toString() ?? ""
+            let stack = value.objectForKeyedSubscript("stack").toString() ?? ""
+            log.error("\(name): \(message)\n\(stack)")
+        }
+
         context.evaluateScript("var console = { log: function(message) { _consoleLog(message) } }")
         let consoleLog: @convention(block) (String) -> Void = { message in
             log.debug(message)


### PR DESCRIPTION
Fixes https://github.com/ianyh/Amethyst/issues/1427

# Description

This introduces an exception handler into the `JSContext` used for custom layouts. The exception handler prints uncaught exceptions from the JavaScript into the log so that custom layouts can be developed more easily.

The stack trace does not appear to have file / line information, but having an error type, message, and partial stack trace is better than nothing.

# Example

This is an example of how this appears in the logs:
```
18:31:34.805 ❤️ ERROR CustomLayout.context():61 - ReferenceError: Can't find variable: foo
getFrameAssignments@
```

# Related work
https://github.com/ianyh/Amethyst/pull/1322 introduced the ability to log data from javascript in custom layouts.