### PR TITLE
Add support for throwing to spaces 11 and 12

### DIFF
--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -385,7 +385,7 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
         hotKeyNameToDefaultsKey.append(["Throw focused window to space left", CommandKey.throwSpaceLeft.rawValue])
         hotKeyNameToDefaultsKey.append(["Throw focused window to space right", CommandKey.throwSpaceRight.rawValue])
 
-        (1...10).forEach { spaceNumber in
+        (1...12).forEach { spaceNumber in
             let name = "Throw focused window to space \(spaceNumber)"
 
             hotKeyNameToDefaultsKey.append([name, "\(CommandKey.throwSpacePrefix.rawValue)-\(spaceNumber)"])

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -166,6 +166,8 @@
         "mod": "mod2",
         "key": "0"
     },
+    "throw-space-11": [],
+    "throw-space-12": [],
     "throw-space-left": {
         "mod": "mod2",
         "key": "left"

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -166,8 +166,6 @@
         "mod": "mod2",
         "key": "0"
     },
-    "throw-space-11": [],
-    "throw-space-12": [],
     "throw-space-left": {
         "mod": "mod2",
         "key": "left"

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ And defines the following commands, mostly a mapping to xmonad key combinations.
 | `mod2 + 8` | Throw focused window to space 8 |
 | `mod2 + 9` | Throw focused window to space 9 |
 | `mod2 + 0` | Throw focused window to space 10 |
+| `none`     | Throw focused window to space 11 |
+| `none`     | Throw focused window to space 12 |
 | `mod1 + w` | Focus Screen 1 |
 | `mod2 + w` | Throw focused window to screen 1 |
 | `mod1 + e` | Focus Screen 2 |


### PR DESCRIPTION
I run with 12 spaces. The only trick is to map throwing to the Function keys rather than to the numeric keys.

I'm not sure whether this works because I can't seem to run the tests locally. ~I was trying to follow [.travis.yml](https://github.com/timvisher/Amethyst/blob/51d2478008d21e04c64ccb5831da14aa35854fd0/.travis.yml#L8) but running bundle install complains that I don't have Ruby 2.4.1 installed and when I try to `rbenv install 2.4.1` it tells me its EOL.~ Welp that's what happens when you check out `master` rather than `development`. xD

So I'll throw this up as a Draft and see what happens.