### PR TITLE
feat: add delete keyboard key to non-printable characters map

### DIFF
--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -328,6 +328,7 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
         stringToKeyCodes["right"] = [kVK_RightArrow]
         stringToKeyCodes["down"] = [kVK_DownArrow]
         stringToKeyCodes["left"] = [kVK_LeftArrow]
+        stringToKeyCodes["delete"] = [kVK_Delete]
 
         return stringToKeyCodes
     }


### PR DESCRIPTION
This PR adds "delete" to the recognizable keyboard non-printable characters.

We can now use "delete" in configuration files. 