### PR TITLE
Replace `xcpretty` with `xcbeautify`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Dependencies
         run: |
           bundle install
+          brew bundle
       - name: Test
         run: |
-          set -o pipefail && xcodebuild -workspace Amethyst.xcworkspace -scheme Amethyst clean test | bundle exec xcpretty
+          set -o pipefail && xcodebuild -workspace Amethyst.xcworkspace -scheme Amethyst clean test | xcbeautify
+

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ Carthage
 AMKeys.h
 fastlane/report.xml
 *profraw
+
+# Homebrew
+Brewfile.lock.json
+

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,5 @@
+# run 'brew bundle' to install all listed packages
+
+# Build tools
+brew "xcbeautify" # Little beautifier tool for xcodebuild
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem 'fastlane'
-gem 'xcpretty'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,6 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane
-  xcpretty
 
 BUNDLED WITH
    2.2.33


### PR DESCRIPTION
Closes #1608

In this PR the usage of Homebrew is being introduced for the installation of `xcbeautify`. The installation of `fastlane` with Homebrew could also be evaluated.