### PR TITLE
Match identifiers first for floating windows

### DIFF
--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -555,7 +555,7 @@ class UserConfiguration: NSObject {
     }
 
     func runningApplicationFloatingBundle(_ runningApplication: BundleIdentifiable) -> FloatingBundle? {
-        let floatingBundles = self.floatingBundles()
+        let floatingBundles = self.floatingBundles().sorted { Int($0.id.contains("*")) < Int($1.id.contains("*")) }
 
         let bundleIdentifier = runningApplication.bundleIdentifier ?? ""
 

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -555,7 +555,7 @@ class UserConfiguration: NSObject {
     }
 
     func runningApplicationFloatingBundle(_ runningApplication: BundleIdentifiable) -> FloatingBundle? {
-        let floatingBundles = self.floatingBundles().sorted { Int($0.id.contains("*")) < Int($1.id.contains("*")) }
+        let floatingBundles = self.floatingBundles().sorted { $0.id != "*" && ($1.id == "*" || $1.id.contains("*") || !$0.id.contains("*")) }
 
         let bundleIdentifier = runningApplication.bundleIdentifier ?? ""
 


### PR DESCRIPTION
Hi ianyh,

Thank you for your hard work! Your app is truly fantastic. However, I've encountered a minor issue. While using it, I noticed that the behavior of floating windows seems to be influenced by the order of rules. For instance, consider the following rules:

```
* (With title rules, such as "MI 6")
com.apple.finder
```

In this setup, the first rule takes precedence, causing Finder windows to be unable to float properly. However, if I rearrange the rules like so:

```
com.apple.finder
* (With title rules, such as "MI 6")
```

Everything works perfectly fine. Therefore, I made a small adjustment accordingly. Since I'm not proficient in Swift, please feel free to correct any mistakes. Once again, thank you for creating such a wonderful app!