### PR TITLE
Support a fifth screen

### DIFF
--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -198,7 +198,7 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
             }
         }
 
-        (1...4).forEach { screenNumber in
+        (1...5).forEach { screenNumber in
             let focusCommandKey = "\(CommandKey.focusScreenPrefix.rawValue)-\(screenNumber)"
             let throwCommandKey = "\(CommandKey.throwScreenPrefix.rawValue)-\(screenNumber)"
 
@@ -392,7 +392,7 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
             hotKeyNameToDefaultsKey.append([name, "\(CommandKey.throwSpacePrefix.rawValue)-\(spaceNumber)"])
         }
 
-        (1...4).forEach { screenNumber in
+        (1...5).forEach { screenNumber in
             let focusCommandName = "Focus screen \(screenNumber)"
             let throwCommandName = "Throw focused window to screen \(screenNumber)"
             let focusCommandKey = "\(CommandKey.focusScreenPrefix.rawValue)-\(screenNumber)"

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -62,6 +62,10 @@
         "mod": "mod1",
         "key": "q"
     },
+    "focus-screen-5": {
+        "mod": "mod1",
+        "key": "g"
+    },
     "throw-screen-1": {
         "mod": "mod2",
         "key": "w"
@@ -77,6 +81,10 @@
     "throw-screen-4": {
         "mod": "mod2",
         "key": "q"
+    },
+    "throw-screen-5": {
+        "mod": "mod2",
+        "key": "g"
     },
     "shrink-main": {
         "mod": "mod1",

--- a/AmethystTests/Tests/Managers/HotKeyManagerTests.swift
+++ b/AmethystTests/Tests/Managers/HotKeyManagerTests.swift
@@ -17,7 +17,7 @@ class HotKeyManagerTests: QuickSpec {
             it("has the right number of screens") {
                 let keyMapping = HotKeyManager<SIApplication>.hotKeyNameToDefaultsKey()
                 let screenCommands = keyMapping.filter { $0[1].hasPrefix(CommandKey.focusScreenPrefix.rawValue) }
-                expect(screenCommands.count).to(equal(6))
+                expect(screenCommands.count).to(equal(7))
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ And defines the following commands, mostly a mapping to xmonad key combinations.
 | `mod2 + r` | Throw focused window to screen 3 |
 | `mod1 + q` | Focus Screen 4 |
 | `mod2 + q` | Throw focused window to screen 4 |
+| `mod1 + g` | Focus Screen 5 |
+| `mod2 + g` | Throw focused window to screen 5 |
 | `mod1 + t` | Toggle float for focused window |
 | `mod1 + i` | Display current layout |
 | `mod2 + t` | Toggle global tiling |


### PR DESCRIPTION
As mentioned in https://github.com/ianyh/Amethyst/issues/1584, MacOS now supports up to 5 displays. This PR adds support for interacting with a fifth screen.