### PR TITLE
Add support for throw-to-space-n for 13 <= n <= 16 (should resolve #1051)

### DIFF
--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -210,7 +210,7 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
             }
         }
 
-        (1...12).forEach { spaceNumber in
+        (1...16).forEach { spaceNumber in
             let commandKey = "\(CommandKey.throwSpacePrefix.rawValue)-\(spaceNumber)"
 
             self.constructCommandWithCommandKey(commandKey) {
@@ -385,7 +385,7 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
         hotKeyNameToDefaultsKey.append(["Throw focused window to space left", CommandKey.throwSpaceLeft.rawValue])
         hotKeyNameToDefaultsKey.append(["Throw focused window to space right", CommandKey.throwSpaceRight.rawValue])
 
-        (1...12).forEach { spaceNumber in
+        (1...16).forEach { spaceNumber in
             let name = "Throw focused window to space \(spaceNumber)"
 
             hotKeyNameToDefaultsKey.append([name, "\(CommandKey.throwSpacePrefix.rawValue)-\(spaceNumber)"])

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ And defines the following commands, mostly a mapping to xmonad key combinations.
 | `mod2 + 0` | Throw focused window to space 10 |
 | `none`     | Throw focused window to space 11 |
 | `none`     | Throw focused window to space 12 |
+| `none`     | Throw focused window to space 13 |
+| `none`     | Throw focused window to space 14 |
+| `none`     | Throw focused window to space 15 |
+| `none`     | Throw focused window to space 16 |
 | `mod1 + w` | Focus Screen 1 |
 | `mod2 + w` | Throw focused window to screen 1 |
 | `mod1 + e` | Focus Screen 2 |
@@ -184,7 +188,7 @@ The rotated version of *Column*, where each window takes up an entire row, exten
 #### Floating
 
 This mode makes all windows "floating", allowing you to move and resize them as if Amethyst were temporarily deactivated. Unlike the other modes, this will mean that windows can be placed "on top of" each other, obscuring your view of some windows.
- 
+
 #### Binary Space Partitioning (BSP)
 
 This layout does not have a main pane in the way that other layouts do. When adding windows, any given pane can be split evenly into two panes along whatever axis is longer. This is recursive such that pane A can be split in the middle into pane A on the left and pane B on the right; pane B can then be split into pane B on top and pane C on bottom; pane C can then be split into pane C on the left and pane D on the right; and so on.


### PR DESCRIPTION
16 is currently the maximum number of spaces that you can set shortcut for through Mac's mission control, even though 20 would be the perfect maximum for me

untested but hopefully simple enough

this is probably preference, but why not the default key for space 1-10 be mod1 + number % 10 and default key for space 11-1x be mod2 + number % 10?