### PR TITLE
Extend the backoff for waiting on application launch

### DIFF
--- a/Amethyst/Model/ApplicationObservation.swift
+++ b/Amethyst/Model/ApplicationObservation.swift
@@ -165,7 +165,7 @@ struct ApplicationObservation<Delegate: ApplicationObservationDelegate> {
     func addObservers() -> Observable<Void> {
         return _addObservers().retry { errorTrigger in
             errorTrigger.enumerated().flatMap { count, error -> Observable<Int> in
-                guard count < 4 else {
+                guard count < 6 else {
                     return .error(error)
                 }
 


### PR DESCRIPTION
I think this is the source of a variety of issues in which applications launch and refuse to tile.