### PR TITLE
Fixing the middle-wide layout focus sequence

### DIFF
--- a/Amethyst/Layout/Layouts/ThreeColumnLayout.swift
+++ b/Amethyst/Layout/Layouts/ThreeColumnLayout.swift
@@ -54,7 +54,7 @@ struct TriplePaneArrangement {
         self.panePosition = {
             switch mainPane {
             case .left:   return [.main: .left, .secondary: .middle, .tertiary: .right]
-            case .middle: return [.main: .middle, .secondary: .left, .tertiary: .right]
+            case .middle: return [.main: .middle, .secondary: .right, .tertiary: .left]
             case .right:  return [.main: .right, .secondary: .left, .tertiary: .middle]
             }
         }()


### PR DESCRIPTION
Fixes #1189 

Basically, it goes in the wrong direction because the left column is marked as the "secondary", and when going clockwise it goes in the sequence `main` -> `secondary` -> `terciary`... So if we just switch secondary to `right` and terciary to `left`, it should go in the right direction.