### PR TITLE
fix: Mouse cursor doesn't follow correctly when swapping windows

### DIFF
--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -238,6 +238,8 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
             return
         }
 
+        let mouseFollowsFocus = userConfiguration.mouseFollowsFocus()
+
         let completeOperation = BlockOperation()
 
         // The complete operation should execute the completion delegate call
@@ -248,6 +250,12 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
 
             DispatchQueue.main.async {
                 self?.delegate?.onReflowCompletion()
+                if mouseFollowsFocus {
+                    if case .windowSwap(let window, _) = event {
+                        window.focus()
+                    }
+                }
+
             }
         }
 

--- a/Amethyst/Managers/WindowTransitionCoordinator.swift
+++ b/Amethyst/Managers/WindowTransitionCoordinator.swift
@@ -59,8 +59,7 @@ class WindowTransitionCoordinator<Target: WindowTransitionTarget> {
             guard let lastMainWindow = target?.lastMainWindowForCurrentSpace() else {
                 return
             }
-            target?.executeTransition(.switchWindows(focusedWindow, lastMainWindow))
-            lastMainWindow.focus()
+            target?.executeTransition(.switchWindows(lastMainWindow, focusedWindow))
             return
         }
 


### PR DESCRIPTION
When swapping windows, the mouse cursor would stay in the previous position of the window.
This PR fixes the problem by delaying the focus call