### PR TITLE
Add Hotkeys and HUD for Adjusting Maximum Window Count Setting

### DIFF
--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -247,6 +247,22 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
             appDelegate?.relaunch(self)
         }
 
+        constructCommandWithCommandKey(CommandKey.increaseWindowMaxCount.rawValue) {
+            self.userConfiguration.increaseWindowMaxCount()
+            windowManager.markAllScreensForReflow(withChange: .unknown)
+            DispatchQueue.main.async {
+                windowManager.displayWindowCountHUD()
+            }
+        }
+
+        constructCommandWithCommandKey(CommandKey.decreaseWindowMaxCount.rawValue) {
+            self.userConfiguration.decreaseWindowMaxCount()
+            windowManager.markAllScreensForReflow(withChange: .unknown)
+            DispatchQueue.main.async {
+                windowManager.displayWindowCountHUD()
+            }
+        }
+
         LayoutType<Application.Window>.availableLayoutStrings().forEach { (layoutKey, _) in
             self.constructCommandWithCommandKey(UserConfiguration.constructLayoutKeyString(layoutKey)) {
                 let screenManager: ScreenManager<WindowManager<Application>>? = windowManager.focusedScreenManager()
@@ -367,6 +383,8 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
         hotKeyNameToDefaultsKey.append(["Expand main pane", CommandKey.expandMain.rawValue])
         hotKeyNameToDefaultsKey.append(["Increase main pane count", CommandKey.increaseMain.rawValue])
         hotKeyNameToDefaultsKey.append(["Decrease main pane count", CommandKey.decreaseMain.rawValue])
+        hotKeyNameToDefaultsKey.append(["Increase window max count", CommandKey.increaseWindowMaxCount.rawValue])
+        hotKeyNameToDefaultsKey.append(["Decrease window max count", CommandKey.decreaseWindowMaxCount.rawValue])
         hotKeyNameToDefaultsKey.append(["Custom layout command 1", CommandKey.command1.rawValue])
         hotKeyNameToDefaultsKey.append(["Custom layout command 2", CommandKey.command2.rawValue])
         hotKeyNameToDefaultsKey.append(["Custom layout command 3", CommandKey.command3.rawValue])

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -341,11 +341,26 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
     }
 
     func displayLayoutHUD() {
+        guard userConfiguration.enablesLayoutHUD(), space?.type == CGSSpaceTypeUser else {
+            return
+        }
+
+        let currentLayoutName = currentLayout.flatMap({ $0.layoutName }) ?? "None"
+        let currentLayoutDescription = currentLayout?.layoutDescription ?? ""
+
+        displayCustomHUD(title: currentLayoutName, description: currentLayoutDescription)
+    }
+
+    @objc func hideLayoutHUD(_ sender: AnyObject) {
+        layoutNameWindowController.close()
+    }
+
+    func displayCustomHUD(title: String, description: String = "") {
         guard let screen = screen else {
             return
         }
 
-        guard userConfiguration.enablesLayoutHUD(), space?.type == CGSSpaceTypeUser else {
+        guard space?.type == CGSSpaceTypeUser else {
             return
         }
 
@@ -358,22 +373,19 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
             return
         }
 
+        // Use new displayNotification method with dynamic sizing
+        layoutNameWindow.displayNotification(title: title, description: description)
+
+        // Center the window after resizing
         let screenFrame = screen.frame()
         let screenCenter = CGPoint(x: screenFrame.midX, y: screenFrame.midY)
         let windowOrigin = CGPoint(
             x: screenCenter.x - layoutNameWindow.frame.width / 2.0,
             y: screenCenter.y - layoutNameWindow.frame.height / 2.0
         )
-
-        layoutNameWindow.layoutNameField?.stringValue = currentLayout.flatMap({ $0.layoutName }) ?? "None"
-        layoutNameWindow.layoutDescriptionLabel?.stringValue = currentLayout?.layoutDescription ?? ""
         layoutNameWindow.setFrameOrigin(NSPointFromCGPoint(windowOrigin))
 
         layoutNameWindowController.showWindow(self)
-    }
-
-    @objc func hideLayoutHUD(_ sender: AnyObject) {
-        layoutNameWindowController.close()
     }
 }
 

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -322,6 +322,19 @@ extension WindowManager {
         }
     }
 
+    func displayWindowCountHUD() {
+        guard userConfiguration.enablesWindowCountHUD() else {
+            return
+        }
+
+        for screenManager in screens.screenManagers {
+            let currentCount = userConfiguration.windowMaxCount() ?? 0
+            let countText = currentCount == 0 ? "Unlimited" : "\(currentCount)"
+            let title = "Window Max Count: \(countText)"
+            screenManager.displayCustomHUD(title: title)
+        }
+    }
+
     func add(runningApplication: NSRunningApplication) {
         switch runningApplication.isManageable {
         case .manageable:

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -13,11 +13,11 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customView id="LsO-9M-hEw" userLabel="General Preferences">
-            <rect key="frame" x="0.0" y="0.0" width="548" height="540"/>
+            <rect key="frame" x="0.0" y="0.0" width="548" height="560"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="luh-Gm-ZV0">
-                    <rect key="frame" x="79" y="301" width="109" height="17"/>
+                    <rect key="frame" x="79" y="321" width="109" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Margins:" id="LnD-6G-RSL">
                         <font key="font" metaFont="system"/>
@@ -26,7 +26,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tXC-cK-Yql">
-                    <rect key="frame" x="193" y="300" width="265" height="18"/>
+                    <rect key="frame" x="193" y="320" width="265" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enabled" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="59W-1k-G1j">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -37,7 +37,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ric-uO-1Cb">
-                    <rect key="frame" x="196" y="272" width="40" height="22"/>
+                    <rect key="frame" x="196" y="292" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" usesSingleLineMode="YES" id="Qi6-Bv-Yh1">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="gi8-52-60I">
@@ -56,7 +56,7 @@
                     </connections>
                 </textField>
                 <button verticalHuggingPriority="750" id="aFO-Xs-m2t">
-                    <rect key="frame" x="194" y="248" width="163" height="18"/>
+                    <rect key="frame" x="194" y="268" width="163" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Smart Window Margins" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ZRJ-ZP-g2F">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -68,7 +68,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3OU-K6-S5G">
-                    <rect key="frame" x="193" y="205" width="336" height="42"/>
+                    <rect key="frame" x="193" y="225" width="336" height="42"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="When enabled, margins will not be applied on fullscreen layout or when there is only one window" id="4nQ-Bx-cFB">
                         <font key="font" metaFont="label" size="11"/>
@@ -77,7 +77,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pwW-SE-wmY">
-                    <rect key="frame" x="251" y="275" width="19" height="17"/>
+                    <rect key="frame" x="251" y="295" width="19" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="Qfs-D0-k4Z">
                         <font key="font" metaFont="system"/>
@@ -86,7 +86,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VsK-s4-pep">
-                    <rect key="frame" x="234" y="269" width="19" height="27"/>
+                    <rect key="frame" x="234" y="289" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="100" doubleValue="1" id="kSN-EK-HUy"/>
                     <connections>
@@ -95,7 +95,7 @@
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Va2-yZ-Rd5">
-                    <rect key="frame" x="195" y="326" width="40" height="22"/>
+                    <rect key="frame" x="195" y="346" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="h2u-LR-IWG">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="U0n-fW-sVR">
@@ -110,7 +110,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DW3-mi-ftN">
-                    <rect key="frame" x="250" y="329" width="19" height="17"/>
+                    <rect key="frame" x="250" y="349" width="19" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="hSf-ej-InP">
                         <font key="font" metaFont="system"/>
@@ -119,7 +119,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AUp-dd-yza">
-                    <rect key="frame" x="233" y="323" width="19" height="27"/>
+                    <rect key="frame" x="233" y="343" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="10" maxValue="5000" id="8qr-vt-jVF"/>
                     <connections>
@@ -127,7 +127,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1nR-DJ-LYU">
-                    <rect key="frame" x="29" y="328" width="159" height="17"/>
+                    <rect key="frame" x="29" y="348" width="159" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Minimum Height:" id="mfB-fg-Gyl">
                         <font key="font" metaFont="system"/>
@@ -136,7 +136,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gyf-rg-uCJ">
-                    <rect key="frame" x="195" y="352" width="40" height="22"/>
+                    <rect key="frame" x="195" y="372" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="w0U-n3-qzM">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="R7z-Le-F75">
@@ -151,7 +151,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qmJ-gR-Sn1">
-                    <rect key="frame" x="250" y="355" width="19" height="17"/>
+                    <rect key="frame" x="250" y="375" width="19" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="vw6-0c-vUA">
                         <font key="font" metaFont="system"/>
@@ -160,7 +160,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zRv-u5-qob">
-                    <rect key="frame" x="233" y="349" width="19" height="27"/>
+                    <rect key="frame" x="233" y="369" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="10" maxValue="5000" id="5XK-xo-aFK"/>
                     <connections>
@@ -168,7 +168,7 @@
                     </connections>
                 </stepper>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MJk-MS-1xp">
-                    <rect key="frame" x="234" y="373" width="19" height="27"/>
+                    <rect key="frame" x="234" y="393" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" maxValue="30" id="y24-P1-XzF"/>
                     <connections>
@@ -176,7 +176,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JVK-ci-h9a">
-                    <rect key="frame" x="33" y="354" width="155" height="17"/>
+                    <rect key="frame" x="33" y="374" width="155" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Minimum Width:" id="0ju-6y-OxU">
                         <font key="font" metaFont="system"/>
@@ -185,7 +185,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dtw-c2-sHK">
-                    <rect key="frame" x="33" y="379" width="155" height="17"/>
+                    <rect key="frame" x="33" y="399" width="155" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Maximum Window Count:" id="tjT-rh-6Es">
                         <font key="font" metaFont="system"/>
@@ -194,7 +194,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aBS-2b-SAH">
-                    <rect key="frame" x="264" y="191" width="40" height="22"/>
+                    <rect key="frame" x="264" y="211" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="right" title="0" placeholderString="0" drawsBackground="YES" usesSingleLineMode="YES" id="WdP-se-3sK">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="NeO-ui-ZjP"/>
@@ -207,7 +207,7 @@
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZIo-fZ-aA2">
-                    <rect key="frame" x="302" y="189" width="19" height="27"/>
+                    <rect key="frame" x="302" y="209" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="5" maxValue="5000" id="JaW-te-IlJ"/>
                     <connections>
@@ -215,7 +215,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yRU-2t-8Ss">
-                    <rect key="frame" x="319" y="194" width="23" height="17"/>
+                    <rect key="frame" x="319" y="214" width="23" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="px" id="Cim-aU-dOb">
                         <font key="font" metaFont="system"/>
@@ -224,7 +224,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G9Q-nh-ohh">
-                    <rect key="frame" x="264" y="137" width="40" height="22"/>
+                    <rect key="frame" x="264" y="157" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="right" title="0" placeholderString="0" drawsBackground="YES" usesSingleLineMode="YES" id="V9T-4b-d2u">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="MC2-Tt-9Ep"/>
@@ -237,7 +237,7 @@
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XnN-yy-z4d">
-                    <rect key="frame" x="302" y="135" width="19" height="27"/>
+                    <rect key="frame" x="302" y="155" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="5" maxValue="5000" id="A8C-jQ-r9M"/>
                     <connections>
@@ -245,7 +245,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tR7-ZK-BJ1">
-                    <rect key="frame" x="319" y="140" width="23" height="17"/>
+                    <rect key="frame" x="319" y="160" width="23" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="px" id="POe-gx-hyp">
                         <font key="font" metaFont="system"/>
@@ -254,7 +254,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X5C-59-n7f">
-                    <rect key="frame" x="336" y="163" width="40" height="22"/>
+                    <rect key="frame" x="336" y="183" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="right" title="0" placeholderString="0" drawsBackground="YES" usesSingleLineMode="YES" id="dIm-1r-QMy">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="60d-hq-KK6"/>
@@ -267,7 +267,7 @@
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zhb-4B-fZW">
-                    <rect key="frame" x="374" y="161" width="19" height="27"/>
+                    <rect key="frame" x="374" y="181" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="5" maxValue="5000" id="slo-1Z-5AM"/>
                     <connections>
@@ -275,7 +275,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BZo-E0-dkW">
-                    <rect key="frame" x="391" y="166" width="23" height="17"/>
+                    <rect key="frame" x="391" y="186" width="23" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="px" id="Lpd-Mr-7br">
                         <font key="font" metaFont="system"/>
@@ -284,7 +284,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CJB-Px-reM">
-                    <rect key="frame" x="194" y="163" width="40" height="22"/>
+                    <rect key="frame" x="194" y="183" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="right" title="0" placeholderString="0" drawsBackground="YES" usesSingleLineMode="YES" id="KNK-Rf-z97">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="cJj-vJ-pVq"/>
@@ -297,7 +297,7 @@
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gA8-3I-b6U">
-                    <rect key="frame" x="232" y="161" width="19" height="27"/>
+                    <rect key="frame" x="232" y="181" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="5" maxValue="5000" id="zqe-Hg-SVJ"/>
                     <connections>
@@ -305,7 +305,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9LL-fQ-X4s">
-                    <rect key="frame" x="249" y="166" width="23" height="17"/>
+                    <rect key="frame" x="249" y="186" width="23" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="px" id="HYL-Bb-2dr">
                         <font key="font" metaFont="system"/>
@@ -314,7 +314,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TON-41-ZcD">
-                    <rect key="frame" x="85" y="168" width="103" height="17"/>
+                    <rect key="frame" x="85" y="188" width="103" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="justified" title="Screen Padding:" id="HDC-ka-f0i">
                         <font key="font" metaFont="system"/>
@@ -323,15 +323,15 @@
                     </textFieldCell>
                 </textField>
                 <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="vr5-JE-vwO">
-                    <rect key="frame" x="172" y="104" width="200" height="5"/>
+                    <rect key="frame" x="172" y="124" width="200" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </box>
                 <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="sO2-ls-SUu">
-                    <rect key="frame" x="172" y="402" width="200" height="5"/>
+                    <rect key="frame" x="172" y="422" width="200" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </box>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jbq-77-1YW">
-                    <rect key="frame" x="192" y="59" width="249" height="18"/>
+                    <rect key="frame" x="192" y="79" width="249" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Display layout when changing layouts" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="UVr-KG-wFB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -342,7 +342,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ej5-FV-H6Q">
-                    <rect key="frame" x="192" y="39" width="255" height="18"/>
+                    <rect key="frame" x="192" y="59" width="255" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Display layout when changing spaces" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="o6e-e0-t64">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -352,8 +352,20 @@
                         <binding destination="XhK-Tn-zrU" name="value" keyPath="values.enables-layout-hud-on-space-change" id="1rV-d7-6jx"/>
                     </connections>
                 </button>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wnd-cnt-hud">
+                    <rect key="frame" x="192" y="39" width="320" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Notify when changing maximum window count" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="wnd-cnt-hud-cell">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="value" keyPath="values.enables-window-count-hud" id="wnd-cnt-hud-bind"/>
+                    </connections>
+                </button>
+
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MKd-ZG-j26">
-                    <rect key="frame" x="28" y="59" width="160" height="17"/>
+                    <rect key="frame" x="28" y="79" width="160" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Heads Up Display:" id="dFS-Je-lML">
                         <font key="font" metaFont="system"/>
@@ -362,7 +374,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pGc-zn-uC7">
-                    <rect key="frame" x="192" y="494" width="133" height="18"/>
+                    <rect key="frame" x="192" y="514" width="133" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Ignore menu bars" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="LKn-n5-1ay">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -373,7 +385,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xay-gW-zGw">
-                    <rect key="frame" x="192" y="474" width="223" height="18"/>
+                    <rect key="frame" x="192" y="494" width="223" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Send new windows to main pane" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="stG-cM-1bg">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -384,7 +396,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hed-5T-mt5">
-                    <rect key="frame" x="192" y="454" width="265" height="18"/>
+                    <rect key="frame" x="192" y="474" width="265" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Follow thrown windows between spaces" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="1GI-LA-8ET">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -395,7 +407,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eDY-rg-FIm">
-                    <rect key="frame" x="132" y="493" width="56" height="17"/>
+                    <rect key="frame" x="132" y="513" width="56" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="General:" id="oHM-Bk-m8H">
                         <font key="font" metaFont="system"/>
@@ -404,7 +416,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q7S-uK-u6Y">
-                    <rect key="frame" x="196" y="376" width="40" height="22"/>
+                    <rect key="frame" x="196" y="396" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="YGR-J5-VCh">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="Z5V-Io-vQx">
@@ -419,7 +431,7 @@
                     </connections>
                 </textField>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IK4-QB-Sbo">
-                    <rect key="frame" x="192" y="114" width="280" height="18"/>
+                    <rect key="frame" x="192" y="134" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Disable screen padding on built-in display" bezelStyle="regularSquare" imagePosition="left" inset="2" id="9Vr-QQ-tmB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -430,7 +442,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W2T-GM-Abn">
-                    <rect key="frame" x="192" y="432" width="265" height="18"/>
+                    <rect key="frame" x="192" y="452" width="265" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Hide menu bar icon" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Tdh-J4-2ut">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -85,6 +85,7 @@ enum ConfigurationKey: String {
     case mouseResizesWindows = "mouse-resizes-windows"
     case layoutHUD = "enables-layout-hud"
     case layoutHUDOnSpaceChange = "enables-layout-hud-on-space-change"
+    case windowCountHUD = "enables-window-count-hud"
     case useCanaryBuild = "use-canary-build"
     case newWindowsToMain = "new-windows-to-main"
     case followSpaceThrownWindows = "follow-space-thrown-windows"
@@ -133,6 +134,8 @@ enum CommandKey: String {
     case reevaluateWindows = "reevaluate-windows"
     case toggleFocusFollowsMouse = "toggle-focus-follows-mouse"
     case relaunchAmethyst = "relaunch-amethyst"
+    case increaseWindowMaxCount = "increase-window-max-count"
+    case decreaseWindowMaxCount = "decrease-window-max-count"
 }
 
 protocol UserConfigurationDelegate: AnyObject {
@@ -641,6 +644,10 @@ class UserConfiguration: NSObject {
         return storage.bool(forKey: .layoutHUDOnSpaceChange)
     }
 
+    func enablesWindowCountHUD() -> Bool {
+        return storage.bool(forKey: .windowCountHUD)
+    }
+
     func useCanaryBuild() -> Bool {
         return storage.bool(forKey: .useCanaryBuild)
     }
@@ -680,6 +687,34 @@ class UserConfiguration: NSObject {
     func windowMaxCount() -> Int? {
         let int = Int(storage.float(forKey: .windowMaxCount))
         return int == 0 ? nil : int
+    }
+
+    func increaseWindowMaxCount() {
+        let currentCount = windowMaxCount() ?? 0
+        let newCount = currentCount + 1
+
+        // Use KVO-compliant method to trigger UI updates
+        if storage is UserDefaults {
+            UserDefaults.standard.willChangeValue(forKey: ConfigurationKey.windowMaxCount.rawValue)
+            storage.set(Float(newCount), forKey: .windowMaxCount)
+            UserDefaults.standard.didChangeValue(forKey: ConfigurationKey.windowMaxCount.rawValue)
+        } else {
+            storage.set(Float(newCount), forKey: .windowMaxCount)
+        }
+    }
+
+    func decreaseWindowMaxCount() {
+        let currentCount = windowMaxCount() ?? 1
+        let newCount = max(0, currentCount - 1)
+
+        // Use KVO-compliant method to trigger UI updates
+        if storage is UserDefaults {
+            UserDefaults.standard.willChangeValue(forKey: ConfigurationKey.windowMaxCount.rawValue)
+            storage.set(Float(newCount), forKey: .windowMaxCount)
+            UserDefaults.standard.didChangeValue(forKey: ConfigurationKey.windowMaxCount.rawValue)
+        } else {
+            storage.set(Float(newCount), forKey: .windowMaxCount)
+        }
     }
 
     func windowResizeStep() -> CGFloat {

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -689,32 +689,28 @@ class UserConfiguration: NSObject {
         return int == 0 ? nil : int
     }
 
+    private func setConfigurationValueWithKVO(_ value: Any?, forKey key: ConfigurationKey) {
+        if let userDefaults = storage as? UserDefaults {
+            userDefaults.willChangeValue(forKey: key.rawValue)
+            userDefaults.set(value, forKey: key)
+            userDefaults.didChangeValue(forKey: key.rawValue)
+        } else {
+            storage.set(value, forKey: key)
+        }
+    }
+
     func increaseWindowMaxCount() {
         let currentCount = windowMaxCount() ?? 0
         let newCount = currentCount + 1
 
-        // Use KVO-compliant method to trigger UI updates
-        if storage is UserDefaults {
-            UserDefaults.standard.willChangeValue(forKey: ConfigurationKey.windowMaxCount.rawValue)
-            storage.set(Float(newCount), forKey: .windowMaxCount)
-            UserDefaults.standard.didChangeValue(forKey: ConfigurationKey.windowMaxCount.rawValue)
-        } else {
-            storage.set(Float(newCount), forKey: .windowMaxCount)
-        }
+        setConfigurationValueWithKVO(Float(newCount), forKey: .windowMaxCount)
     }
 
     func decreaseWindowMaxCount() {
         let currentCount = windowMaxCount() ?? 1
         let newCount = max(0, currentCount - 1)
 
-        // Use KVO-compliant method to trigger UI updates
-        if storage is UserDefaults {
-            UserDefaults.standard.willChangeValue(forKey: ConfigurationKey.windowMaxCount.rawValue)
-            storage.set(Float(newCount), forKey: .windowMaxCount)
-            UserDefaults.standard.didChangeValue(forKey: ConfigurationKey.windowMaxCount.rawValue)
-        } else {
-            storage.set(Float(newCount), forKey: .windowMaxCount)
-        }
+        setConfigurationValueWithKVO(Float(newCount), forKey: .windowMaxCount)
     }
 
     func windowResizeStep() -> CGFloat {

--- a/Amethyst/View/LayoutNameWindow.swift
+++ b/Amethyst/View/LayoutNameWindow.swift
@@ -33,4 +33,47 @@ class LayoutNameWindow: NSWindow {
         backgroundColor = NSColor.clear
         level = .floating
     }
+
+    // Display custom notification with dynamic sizing
+    func displayNotification(title: String, description: String) {
+        // layoutDescriptionLabel?.isHidden = false
+        layoutNameField?.stringValue = title
+        layoutDescriptionLabel?.stringValue = description
+
+        // Calculate size needed for both name and description
+        let longerText = title.count > description.count ? title : description
+        resizeToFitText(text: longerText)
+    }
+
+    // Dynamic window resizing based on text content
+    private func resizeToFitText(text: String) {
+        guard let textField = layoutNameField else { return }
+
+        // Calculate text width with current font
+        let font = textField.font ?? NSFont.systemFont(ofSize: 20)
+        let textSize = text.size(withAttributes: [.font: font])
+
+        // Add padding (40px on each side + extra space)
+        let minWidth: CGFloat = 200
+        let maxWidth: CGFloat = 500
+        let padding: CGFloat = 80
+        let calculatedWidth = textSize.width + padding
+
+        // Constrain width between min and max
+        let newWidth = max(minWidth, min(maxWidth, calculatedWidth))
+
+        // Keep the same height
+        let currentFrame = frame
+        let newFrame = NSRect(
+            x: currentFrame.origin.x,
+            y: currentFrame.origin.y,
+            width: newWidth,
+            height: currentFrame.height
+        )
+
+        setFrame(newFrame, display: true, animate: false)
+
+        // Update content view layer frame
+        contentView?.layer?.frame = NSRectToCGRect(contentView!.frame)
+    }
 }

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -213,6 +213,7 @@
     "focus-follows-mouse": false,
     "enables-layout-hud": true,
     "enables-layout-hud-on-space-change": true,
+    "enables-window-count-hud": false,
     "window-margin-size": 0,
     "window-resize-step": 5,
     "window-margins": false,

--- a/docs/configuration-files.md
+++ b/docs/configuration-files.md
@@ -27,6 +27,7 @@ Amethyst will pick up a config file located at `~/.amethyst.yml` or `~/.config/a
 | `mouse-resizes-windows` | `true` if changing the frame of a window with the mouse should update the layout to accommodate the change (default `false`). Note that not all layouts will be able to respond to the change. |
 | `enables-layout-hud` | `true` to display the name of the layout when a new layout is selected (default `true`). |
 | `enables-layout-hud-on-space-change` | `true` to display the name of the layout when moving to a new space (default `true`). |
+| `enables-window-count-hud` | `true` to display notifications when window max count changes (default `false`). |
 | `use-canary-build` | `true` to get updates to beta versions of the software (default `false`). |
 | `new-windows-to-main` | `true` to insert new windows into the first position and `false` to insert new windows into the last position (default `false`). |
 | `follow-space-thrown-windows` | `true` to automatically move to a space when throwing a window to it (default `true`). | 
@@ -63,6 +64,8 @@ A mod is a list of keyboard modifiers. Namely, `option`, `control`, `shift`, and
 | `expand-main` | Expand the main pane by a percentage of the screen dimension as defined by `window-resize-step`. Note that not all layouts respond to this command. |
 | `increase-main` | Increase the number of windows in the main pane. Note that not all layouts respond to this command. |
 | `decrease-main` | Decrease the number of windows in the main pane. Note that not all layouts respond to this command. |
+| `increase-window-max-count` | Increase the maximum number of windows allowed on screen before additional windows are minimized. |
+| `decrease-window-max-count` | Decrease the maximum number of windows allowed on screen before additional windows are minimized. |
 | `command1` | General purpose command for custom layouts. Functionality is layout-dependent. |
 | `command2` | General purpose command for custom layouts. Functionality is layout-dependent. |
 | `command3` | General purpose command for custom layouts. Functionality is layout-dependent. |


### PR DESCRIPTION
## Add Window Limit Hotkey Controls and Enhanced HUD System

### 🚀 Summary

This PR introduces keyboard hotkey controls for adjusting the window limit feature and enhances the existing HUD system to be more universal and responsive. Users can now dynamically increase/decrease the maximum window count per screen using keyboard shortcuts, with immediate visual feedback through an improved HUD display.

Closes https://github.com/ianyh/Amethyst/issues/1799

### 🎯 What's Changed

#### 1. Universal HUD System Refactor (`cf34654`)

- **Enhanced `LayoutNameWindow`** with dynamic width sizing
  - Added `displayNotification(title:description:)` method for flexible HUD content
  - Implemented `resizeToFitText()` for automatic window sizing based on text length
  - Supports min/max width constraints (200px - 500px) with padding

- **Improved `ScreenManager`** with universal HUD capabilities
  - Added `displayCustomHUD(title:description:)` for reusable HUD functionality
  - Refactored existing `displayLayoutHUD()` to use the new universal system
  - Better separation of concerns between HUD display logic and content

#### 2. Window Count Hotkey Controls (`ac5ae4a`)

- **New Hotkey Commands**
  - `increase-window-max-count`: Increment window limit by 1
  - `decrease-window-max-count`: Decrement window limit by 1 (minimum 0 for unlimited)

- **Enhanced User Configuration**
  - Added `increaseWindowMaxCount()` and `decreaseWindowMaxCount()` methods
  - Implemented KVO-compliant updates for real-time UI synchronization
  - Added `enablesWindowCountHUD()` configuration option

- **Window Count HUD Display**
  - Added `displayWindowCountHUD()` method in `WindowManager`
  - Shows current limit as "Window Max Count: X" or "Unlimited" when set to 0
  - Utilizes the new universal HUD system for consistent styling

- **UI Integration**
  - Extended General Preferences view with new hotkey options
  - Updated default configuration and documentation

### 🎮 How to Use

1. **Configure Hotkeys**: Go to Preferences → Shortcuts and set your preferred key combinations for:
   - "Increase window max count"
   - "Decrease window max count"

2. **Enable HUD Feedback**: In General preferences, enable "Notify when changing maximum window count" to see visual feedback when adjusting limits

3. **Adjust Window Limits**: Use your configured hotkeys to dynamically adjust the maximum window count
   - Current count is displayed in a centered HUD
   - Setting to 0 shows "Unlimited"
   - Changes take effect immediately with automatic screen reflow

### 🔧 Technical Details

- **Architecture**: Builds upon the existing window limit foundation documented in `docs/window-limit.md`
- **HUD System**: Centralized, reusable HUD component with dynamic sizing
- **Configuration**: KVO-compliant for real-time preference updates

### 📝 Configuration

The feature adds these new configuration options:
- `enables-window-count-hud`: Boolean to enable/disable HUD feedback
- `increase-window-max-count`: Hotkey binding for incrementing limit
- `decrease-window-max-count`: Hotkey binding for decrementing limit

### ✨ Benefits

- **Enhanced UX**: Quick adjustment of window limits without opening preferences
- **Visual Feedback**: Immediate confirmation of current window limit settings
- **Flexible HUD**: Reusable HUD system for future notification needs
- **Accessibility**: Keyboard-driven workflow for power users

This enhancement makes the existing window limit feature more accessible and user-friendly, providing a smooth workflow for users who frequently adjust their workspace constraints.