### PR TITLE
Add Send Window to Main Pane Toggle Hotkey and HUD

### DIFF
--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -259,6 +259,13 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
             appDelegate?.relaunch(self)
         }
 
+        constructCommandWithCommandKey(CommandKey.toggleNewWindowsToMain.rawValue) {
+            self.userConfiguration.toggleNewWindowsToMain()
+            DispatchQueue.main.async {
+                windowManager.displayNewWindowsToMainHUD()
+            }
+        }
+
         constructCommandWithCommandKey(CommandKey.increaseWindowMaxCount.rawValue) {
             self.userConfiguration.increaseWindowMaxCount()
             windowManager.markAllScreensForReflow(withChange: .unknown)
@@ -437,6 +444,7 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
         hotKeyNameToDefaultsKey.append(["Toggle global tiling", CommandKey.toggleTiling.rawValue])
         hotKeyNameToDefaultsKey.append(["Enable global tiling", CommandKey.enableTiling.rawValue])
         hotKeyNameToDefaultsKey.append(["Disable global tiling", CommandKey.disableTiling.rawValue])
+        hotKeyNameToDefaultsKey.append(["Toggle new windows to main pane sending", CommandKey.toggleNewWindowsToMain.rawValue])
 
         for (layoutKey, layoutName) in LayoutType<Application.Window>.availableLayoutStrings() {
             let commandName = "Select \(layoutName) layout"

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -322,6 +322,19 @@ extension WindowManager {
         }
     }
 
+    func displayNewWindowsToMainHUD() {
+        guard userConfiguration.enablesNewWindowsToMainHUD() else {
+            return
+        }
+
+        for screenManager in screens.screenManagers {
+            let isEnabled = userConfiguration.sendNewWindowsToMainPane()
+            let statusText = isEnabled ? "On" : "Off"
+            let title = "New Windows to Main Pane: \(statusText)"
+            screenManager.displayCustomHUD(title: title)
+        }
+    }
+
     func displayWindowCountHUD() {
         guard userConfiguration.enablesWindowCountHUD() else {
             return

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -13,11 +13,11 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customView id="LsO-9M-hEw" userLabel="General Preferences">
-            <rect key="frame" x="0.0" y="0.0" width="548" height="560"/>
+            <rect key="frame" x="0.0" y="0.0" width="548" height="580"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="luh-Gm-ZV0">
-                    <rect key="frame" x="79" y="321" width="109" height="17"/>
+                    <rect key="frame" x="79" y="341" width="109" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Margins:" id="LnD-6G-RSL">
                         <font key="font" metaFont="system"/>
@@ -26,7 +26,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tXC-cK-Yql">
-                    <rect key="frame" x="193" y="320" width="265" height="18"/>
+                    <rect key="frame" x="193" y="340" width="265" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enabled" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="59W-1k-G1j">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -37,7 +37,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ric-uO-1Cb">
-                    <rect key="frame" x="196" y="292" width="40" height="22"/>
+                    <rect key="frame" x="196" y="312" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" usesSingleLineMode="YES" id="Qi6-Bv-Yh1">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="gi8-52-60I">
@@ -56,7 +56,7 @@
                     </connections>
                 </textField>
                 <button verticalHuggingPriority="750" id="aFO-Xs-m2t">
-                    <rect key="frame" x="194" y="268" width="163" height="18"/>
+                    <rect key="frame" x="194" y="288" width="163" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Smart Window Margins" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ZRJ-ZP-g2F">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -68,7 +68,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3OU-K6-S5G">
-                    <rect key="frame" x="193" y="225" width="336" height="42"/>
+                    <rect key="frame" x="193" y="245" width="336" height="42"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="When enabled, margins will not be applied on fullscreen layout or when there is only one window" id="4nQ-Bx-cFB">
                         <font key="font" metaFont="label" size="11"/>
@@ -77,7 +77,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pwW-SE-wmY">
-                    <rect key="frame" x="251" y="295" width="19" height="17"/>
+                    <rect key="frame" x="251" y="315" width="19" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="Qfs-D0-k4Z">
                         <font key="font" metaFont="system"/>
@@ -86,7 +86,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VsK-s4-pep">
-                    <rect key="frame" x="234" y="289" width="19" height="27"/>
+                    <rect key="frame" x="234" y="309" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="100" doubleValue="1" id="kSN-EK-HUy"/>
                     <connections>
@@ -95,7 +95,7 @@
                     </connections>
                 </stepper>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Va2-yZ-Rd5">
-                    <rect key="frame" x="195" y="346" width="40" height="22"/>
+                    <rect key="frame" x="195" y="366" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="h2u-LR-IWG">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="U0n-fW-sVR">
@@ -110,7 +110,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DW3-mi-ftN">
-                    <rect key="frame" x="250" y="349" width="19" height="17"/>
+                    <rect key="frame" x="250" y="369" width="19" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="hSf-ej-InP">
                         <font key="font" metaFont="system"/>
@@ -119,7 +119,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AUp-dd-yza">
-                    <rect key="frame" x="233" y="343" width="19" height="27"/>
+                    <rect key="frame" x="233" y="363" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="10" maxValue="5000" id="8qr-vt-jVF"/>
                     <connections>
@@ -127,7 +127,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1nR-DJ-LYU">
-                    <rect key="frame" x="29" y="348" width="159" height="17"/>
+                    <rect key="frame" x="29" y="368" width="159" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Minimum Height:" id="mfB-fg-Gyl">
                         <font key="font" metaFont="system"/>
@@ -136,7 +136,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gyf-rg-uCJ">
-                    <rect key="frame" x="195" y="372" width="40" height="22"/>
+                    <rect key="frame" x="195" y="392" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="w0U-n3-qzM">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="R7z-Le-F75">
@@ -151,7 +151,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qmJ-gR-Sn1">
-                    <rect key="frame" x="250" y="375" width="19" height="17"/>
+                    <rect key="frame" x="250" y="395" width="19" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="vw6-0c-vUA">
                         <font key="font" metaFont="system"/>
@@ -160,7 +160,7 @@
                     </textFieldCell>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zRv-u5-qob">
-                    <rect key="frame" x="233" y="369" width="19" height="27"/>
+                    <rect key="frame" x="233" y="389" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="10" maxValue="5000" id="5XK-xo-aFK"/>
                     <connections>
@@ -168,7 +168,7 @@
                     </connections>
                 </stepper>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MJk-MS-1xp">
-                    <rect key="frame" x="234" y="393" width="19" height="27"/>
+                    <rect key="frame" x="234" y="413" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" maxValue="30" id="y24-P1-XzF"/>
                     <connections>
@@ -176,7 +176,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JVK-ci-h9a">
-                    <rect key="frame" x="33" y="374" width="155" height="17"/>
+                    <rect key="frame" x="33" y="394" width="155" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Minimum Width:" id="0ju-6y-OxU">
                         <font key="font" metaFont="system"/>
@@ -185,7 +185,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dtw-c2-sHK">
-                    <rect key="frame" x="33" y="399" width="155" height="17"/>
+                    <rect key="frame" x="33" y="419" width="155" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Maximum Window Count:" id="tjT-rh-6Es">
                         <font key="font" metaFont="system"/>
@@ -194,7 +194,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aBS-2b-SAH">
-                    <rect key="frame" x="264" y="211" width="40" height="22"/>
+                    <rect key="frame" x="264" y="231" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="right" title="0" placeholderString="0" drawsBackground="YES" usesSingleLineMode="YES" id="WdP-se-3sK">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="NeO-ui-ZjP"/>
@@ -207,7 +207,7 @@
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZIo-fZ-aA2">
-                    <rect key="frame" x="302" y="209" width="19" height="27"/>
+                    <rect key="frame" x="302" y="229" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="5" maxValue="5000" id="JaW-te-IlJ"/>
                     <connections>
@@ -215,7 +215,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yRU-2t-8Ss">
-                    <rect key="frame" x="319" y="214" width="23" height="17"/>
+                    <rect key="frame" x="319" y="234" width="23" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="px" id="Cim-aU-dOb">
                         <font key="font" metaFont="system"/>
@@ -224,7 +224,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G9Q-nh-ohh">
-                    <rect key="frame" x="264" y="157" width="40" height="22"/>
+                    <rect key="frame" x="264" y="177" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="right" title="0" placeholderString="0" drawsBackground="YES" usesSingleLineMode="YES" id="V9T-4b-d2u">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="MC2-Tt-9Ep"/>
@@ -237,7 +237,7 @@
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XnN-yy-z4d">
-                    <rect key="frame" x="302" y="155" width="19" height="27"/>
+                    <rect key="frame" x="302" y="175" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="5" maxValue="5000" id="A8C-jQ-r9M"/>
                     <connections>
@@ -245,7 +245,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tR7-ZK-BJ1">
-                    <rect key="frame" x="319" y="160" width="23" height="17"/>
+                    <rect key="frame" x="319" y="180" width="23" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="px" id="POe-gx-hyp">
                         <font key="font" metaFont="system"/>
@@ -254,7 +254,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X5C-59-n7f">
-                    <rect key="frame" x="336" y="183" width="40" height="22"/>
+                    <rect key="frame" x="336" y="203" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="right" title="0" placeholderString="0" drawsBackground="YES" usesSingleLineMode="YES" id="dIm-1r-QMy">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="60d-hq-KK6"/>
@@ -267,7 +267,7 @@
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zhb-4B-fZW">
-                    <rect key="frame" x="374" y="181" width="19" height="27"/>
+                    <rect key="frame" x="374" y="201" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="5" maxValue="5000" id="slo-1Z-5AM"/>
                     <connections>
@@ -275,7 +275,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BZo-E0-dkW">
-                    <rect key="frame" x="391" y="186" width="23" height="17"/>
+                    <rect key="frame" x="391" y="206" width="23" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="px" id="Lpd-Mr-7br">
                         <font key="font" metaFont="system"/>
@@ -284,7 +284,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CJB-Px-reM">
-                    <rect key="frame" x="194" y="183" width="40" height="22"/>
+                    <rect key="frame" x="194" y="203" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="right" title="0" placeholderString="0" drawsBackground="YES" usesSingleLineMode="YES" id="KNK-Rf-z97">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="cJj-vJ-pVq"/>
@@ -297,7 +297,7 @@
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gA8-3I-b6U">
-                    <rect key="frame" x="232" y="181" width="19" height="27"/>
+                    <rect key="frame" x="232" y="201" width="19" height="27"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <stepperCell key="cell" continuous="YES" alignment="left" increment="5" maxValue="5000" id="zqe-Hg-SVJ"/>
                     <connections>
@@ -305,7 +305,7 @@
                     </connections>
                 </stepper>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9LL-fQ-X4s">
-                    <rect key="frame" x="249" y="186" width="23" height="17"/>
+                    <rect key="frame" x="249" y="206" width="23" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="px" id="HYL-Bb-2dr">
                         <font key="font" metaFont="system"/>
@@ -314,7 +314,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TON-41-ZcD">
-                    <rect key="frame" x="85" y="188" width="103" height="17"/>
+                    <rect key="frame" x="85" y="208" width="103" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="justified" title="Screen Padding:" id="HDC-ka-f0i">
                         <font key="font" metaFont="system"/>
@@ -323,15 +323,15 @@
                     </textFieldCell>
                 </textField>
                 <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="vr5-JE-vwO">
-                    <rect key="frame" x="172" y="124" width="200" height="5"/>
+                    <rect key="frame" x="172" y="144" width="200" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </box>
                 <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="sO2-ls-SUu">
-                    <rect key="frame" x="172" y="422" width="200" height="5"/>
+                    <rect key="frame" x="172" y="442" width="200" height="5"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </box>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jbq-77-1YW">
-                    <rect key="frame" x="192" y="79" width="249" height="18"/>
+                    <rect key="frame" x="192" y="99" width="249" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Display layout when changing layouts" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="UVr-KG-wFB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -342,7 +342,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ej5-FV-H6Q">
-                    <rect key="frame" x="192" y="59" width="255" height="18"/>
+                    <rect key="frame" x="192" y="79" width="255" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Display layout when changing spaces" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="o6e-e0-t64">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -350,6 +350,17 @@
                     </buttonCell>
                     <connections>
                         <binding destination="XhK-Tn-zrU" name="value" keyPath="values.enables-layout-hud-on-space-change" id="1rV-d7-6jx"/>
+                    </connections>
+                </button>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="new-win-hud">
+                    <rect key="frame" x="192" y="59" width="350" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Notify when toggling new windows to main pane" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="new-win-hud-cell">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="value" keyPath="values.enables-new-windows-to-main-hud" id="new-win-hud-bind"/>
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wnd-cnt-hud">
@@ -365,7 +376,7 @@
                 </button>
 
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MKd-ZG-j26">
-                    <rect key="frame" x="28" y="79" width="160" height="17"/>
+                    <rect key="frame" x="28" y="99" width="160" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Heads Up Display:" id="dFS-Je-lML">
                         <font key="font" metaFont="system"/>
@@ -374,7 +385,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pGc-zn-uC7">
-                    <rect key="frame" x="192" y="514" width="133" height="18"/>
+                    <rect key="frame" x="192" y="534" width="133" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Ignore menu bars" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="LKn-n5-1ay">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -385,7 +396,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xay-gW-zGw">
-                    <rect key="frame" x="192" y="494" width="223" height="18"/>
+                    <rect key="frame" x="192" y="514" width="223" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Send new windows to main pane" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="stG-cM-1bg">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -396,7 +407,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hed-5T-mt5">
-                    <rect key="frame" x="192" y="474" width="265" height="18"/>
+                    <rect key="frame" x="192" y="494" width="265" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Follow thrown windows between spaces" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="1GI-LA-8ET">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -407,7 +418,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eDY-rg-FIm">
-                    <rect key="frame" x="132" y="513" width="56" height="17"/>
+                    <rect key="frame" x="132" y="533" width="56" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="General:" id="oHM-Bk-m8H">
                         <font key="font" metaFont="system"/>
@@ -416,7 +427,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q7S-uK-u6Y">
-                    <rect key="frame" x="196" y="396" width="40" height="22"/>
+                    <rect key="frame" x="196" y="416" width="40" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="YGR-J5-VCh">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="Z5V-Io-vQx">
@@ -431,7 +442,7 @@
                     </connections>
                 </textField>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IK4-QB-Sbo">
-                    <rect key="frame" x="192" y="134" width="280" height="18"/>
+                    <rect key="frame" x="192" y="154" width="280" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Disable screen padding on built-in display" bezelStyle="regularSquare" imagePosition="left" inset="2" id="9Vr-QQ-tmB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -442,7 +453,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W2T-GM-Abn">
-                    <rect key="frame" x="192" y="452" width="265" height="18"/>
+                    <rect key="frame" x="192" y="472" width="265" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Hide menu bar icon" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Tdh-J4-2ut">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -86,6 +86,7 @@ enum ConfigurationKey: String {
     case layoutHUD = "enables-layout-hud"
     case layoutHUDOnSpaceChange = "enables-layout-hud-on-space-change"
     case windowCountHUD = "enables-window-count-hud"
+    case newWindowsToMainHUD = "enables-new-windows-to-main-hud"
     case useCanaryBuild = "use-canary-build"
     case newWindowsToMain = "new-windows-to-main"
     case followSpaceThrownWindows = "follow-space-thrown-windows"
@@ -138,6 +139,7 @@ enum CommandKey: String {
     case relaunchAmethyst = "relaunch-amethyst"
     case increaseWindowMaxCount = "increase-window-max-count"
     case decreaseWindowMaxCount = "decrease-window-max-count"
+    case toggleNewWindowsToMain = "toggle-new-windows-to-main"
 }
 
 protocol UserConfigurationDelegate: AnyObject {
@@ -650,6 +652,10 @@ class UserConfiguration: NSObject {
         return storage.bool(forKey: .windowCountHUD)
     }
 
+    func enablesNewWindowsToMainHUD() -> Bool {
+        return storage.bool(forKey: .newWindowsToMainHUD)
+    }
+
     func useCanaryBuild() -> Bool {
         return storage.bool(forKey: .useCanaryBuild)
     }
@@ -713,6 +719,11 @@ class UserConfiguration: NSObject {
         let newCount = max(0, currentCount - 1)
 
         setConfigurationValueWithKVO(Float(newCount), forKey: .windowMaxCount)
+    }
+
+    func toggleNewWindowsToMain() {
+        let currentValue = sendNewWindowsToMainPane()
+        setConfigurationValueWithKVO(!currentValue, forKey: .newWindowsToMain)
     }
 
     func windowResizeStep() -> CGFloat {

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -215,6 +215,7 @@
     "focus-follows-mouse": false,
     "enables-layout-hud": true,
     "enables-layout-hud-on-space-change": true,
+    "enables-new-windows-to-main-hud": false,
     "enables-window-count-hud": false,
     "window-margin-size": 0,
     "window-resize-step": 5,

--- a/docs/configuration-files.md
+++ b/docs/configuration-files.md
@@ -28,6 +28,7 @@ Amethyst will pick up a config file located at `~/.amethyst.yml` or `~/.config/a
 | `enables-layout-hud` | `true` to display the name of the layout when a new layout is selected (default `true`). |
 | `enables-layout-hud-on-space-change` | `true` to display the name of the layout when moving to a new space (default `true`). |
 | `enables-window-count-hud` | `true` to display notifications when window max count changes (default `false`). |
+| `enables-new-windows-to-main-hud` | `true` to display notifications when new windows to main setting changes (default `false`). |
 | `use-canary-build` | `true` to get updates to beta versions of the software (default `false`). |
 | `new-windows-to-main` | `true` to insert new windows into the first position and `false` to insert new windows into the last position (default `false`). |
 | `follow-space-thrown-windows` | `true` to automatically move to a space when throwing a window to it (default `true`). | 
@@ -66,6 +67,7 @@ A mod is a list of keyboard modifiers. Namely, `option`, `control`, `shift`, and
 | `decrease-main` | Decrease the number of windows in the main pane. Note that not all layouts respond to this command. |
 | `increase-window-max-count` | Increase the maximum number of windows allowed on screen before additional windows are minimized. |
 | `decrease-window-max-count` | Decrease the maximum number of windows allowed on screen before additional windows are minimized. |
+| `toggle-new-windows-to-main` | Toggle whether new windows are inserted at the beginning (main pane) or end of the window list. |
 | `command1` | General purpose command for custom layouts. Functionality is layout-dependent. |
 | `command2` | General purpose command for custom layouts. Functionality is layout-dependent. |
 | `command3` | General purpose command for custom layouts. Functionality is layout-dependent. |


### PR DESCRIPTION
## Add Send Window to Main Pane Toggle Hotkey and HUD

### Overview
This PR introduces a new hotkey command that allows users to quickly toggle the "send new windows to main pane" setting without navigating to preferences, along with optional visual feedback via HUD notifications.

Closes https://github.com/ianyh/Amethyst/issues/1800

This PR is built on the 'HUD System Refactor' commit from https://github.com/ianyh/Amethyst/pull/1802

### Features Added

#### 🔥 New Hotkey Command
- **Command**: `toggle-new-windows-to-main`
- **Functionality**: Toggles between sending new windows to the main pane or secondary panes
- **Real-time feedback**: Shows current state via HUD notification (when enabled)

#### 🎯 HUD Notification System
- **Visual feedback**: Displays "New Windows to Main Pane: On/Off" when toggled
- **Configurable**: Users can enable/disable notifications via preferences

#### ⚙️ Preferences Integration
- **New setting**: "Notify when toggling new windows to main pane" checkbox in General preferences
- **Default behavior**: HUD notifications disabled by default to avoid overwhelming users
- **KVO compliance**: Proper change notifications for UI updates

### Technical Implementation

#### Modified Files
- **`HotKeyManager.swift`**: Added hotkey registration and command handler
- **`WindowManager.swift`**: Implemented HUD display logic
- **`UserConfiguration.swift`**: Added toggle method and HUD preference support
- **`GeneralPreferencesViewController.xib`**: Added HUD notification preference checkbox
- **`default.amethyst`**: Added default configuration value
- **`docs/configuration-files.md`**: Updated documentation

### Benefits
- **Improved UX**: Quick access to frequently-used setting without opening preferences
- **Non-intrusive**: HUD notifications are opt-in
- **Discoverable**: Listed in hotkey preferences for easy customization

This enhancement addresses user requests for quicker access to window placement controls while maintaining Amethyst's clean, non-intrusive design philosophy.