### PR TITLE
Add Layouts Submenu to Application Menu

### DIFF
--- a/Amethyst/AppDelegate.swift
+++ b/Amethyst/AppDelegate.swift
@@ -28,6 +28,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet var versionMenuItem: NSMenuItem?
     @IBOutlet var startAtLoginMenuItem: NSMenuItem?
     @IBOutlet var toggleGlobalTilingMenuItem: NSMenuItem?
+    @IBOutlet var layoutsMenuItem: NSMenuItem?
 
     private var isFirstLaunch = true
 
@@ -71,6 +72,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         hotKeyManager = HotKeyManager(userConfiguration: UserConfiguration.shared)
 
         hotKeyManager?.setUpWithWindowManager(windowManager!, configuration: UserConfiguration.shared, appDelegate: self)
+
+        // Populate layouts menu now that windowManager is initialized
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.populateLayoutsMenu()
+        }
     }
 
     override func awakeFromNib() {
@@ -93,6 +99,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         toggleGlobalTilingMenuItem?.title = "Disable"
 
         startAtLoginMenuItem?.state = (LoginServiceKit.isExistLoginItems(at: Bundle.main.bundlePath) ? .on : .off)
+
+        // Set up layouts menu delegate to refresh when opened
+        layoutsMenuItem?.submenu?.delegate = self
+
+        populateLayoutsMenu()
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
@@ -173,11 +184,87 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
     }
+
+    private func populateLayoutsMenu() {
+        guard let layoutsMenuItem = layoutsMenuItem,
+              let submenu = layoutsMenuItem.submenu else {
+            return
+        }
+
+        // Clear existing items
+        submenu.removeAllItems()
+
+        // Get enabled layout keys from user configuration
+        let enabledLayoutKeys = UserConfiguration.shared.layoutKeys()
+
+        // Get all available layouts with their display names
+        let availableLayouts = LayoutType<SIApplication.Window>.availableLayoutStrings()
+
+        // Get current layout
+        let focusedScreenManager = windowManager?.focusedScreenManager()
+        var currentLayoutKey = focusedScreenManager?.currentLayout?.layoutKey
+
+        // If no focused screen manager, fallback to the first screen manager
+        if focusedScreenManager == nil, let firstScreenManager = windowManager?.screenManager(at: 0) {
+            currentLayoutKey = firstScreenManager.currentLayout?.layoutKey
+        }
+
+        // Filter to only enabled layouts and add menu items
+        for layoutKey in enabledLayoutKeys {
+            guard let layoutInfo = availableLayouts.first(where: { $0.key == layoutKey }) else {
+                continue
+            }
+
+            let menuItem = NSMenuItem(title: layoutInfo.name, action: #selector(selectLayout(_:)), keyEquivalent: "")
+            menuItem.target = self
+            menuItem.representedObject = layoutKey
+
+            // Mark current layout with checkmark
+            let isCurrentLayout = layoutKey == currentLayoutKey
+            menuItem.state = isCurrentLayout ? .on : .off
+
+            submenu.addItem(menuItem)
+        }
+
+        // If no layouts are enabled, show a disabled message
+        if enabledLayoutKeys.isEmpty {
+            let noLayoutsItem = NSMenuItem(title: "No layouts enabled", action: nil, keyEquivalent: "")
+            noLayoutsItem.isEnabled = false
+            submenu.addItem(noLayoutsItem)
+        }
+    }
+
+    @IBAction func selectLayout(_ sender: NSMenuItem) {
+        guard let layoutKey = sender.representedObject as? String,
+              let windowManager = windowManager,
+              let screenManager = windowManager.focusedScreenManager() else {
+            return
+        }
+
+        screenManager.selectLayout(layoutKey)
+        // Menu will be refreshed automatically when next opened via NSMenuDelegate
+    }
 }
 
 extension AppDelegate: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
         windowManager?.preferencesDidClose()
+    }
+}
+
+extension AppDelegate: NSMenuDelegate {
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        // Refresh layouts menu when it's about to be shown
+        if menu == layoutsMenuItem?.submenu {
+            populateLayoutsMenu()
+        }
+    }
+
+    func menuWillOpen(_ menu: NSMenu) {
+        // Also refresh when menu is about to open
+        if menu == layoutsMenuItem?.submenu {
+            populateLayoutsMenu()
+        }
     }
 }
 

--- a/Amethyst/AppDelegate.swift
+++ b/Amethyst/AppDelegate.swift
@@ -72,11 +72,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         hotKeyManager = HotKeyManager(userConfiguration: UserConfiguration.shared)
 
         hotKeyManager?.setUpWithWindowManager(windowManager!, configuration: UserConfiguration.shared, appDelegate: self)
-
-        // Populate layouts menu now that windowManager is initialized
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.populateLayoutsMenu()
-        }
     }
 
     override func awakeFromNib() {
@@ -100,10 +95,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         startAtLoginMenuItem?.state = (LoginServiceKit.isExistLoginItems(at: Bundle.main.bundlePath) ? .on : .off)
 
-        // Set up layouts menu delegate to refresh when opened
-        layoutsMenuItem?.submenu?.delegate = self
-
-        populateLayoutsMenu()
+        // Set up status item menu delegate to refresh layouts when main menu is opened
+        statusItemMenu?.delegate = self
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
@@ -197,20 +190,43 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Get enabled layout keys from user configuration
         let enabledLayoutKeys = UserConfiguration.shared.layoutKeys()
 
+        // Check if no layouts are enabled and return early
+        if enabledLayoutKeys.isEmpty {
+            let noLayoutsItem = NSMenuItem(title: "No layouts enabled", action: nil, keyEquivalent: "")
+            noLayoutsItem.isEnabled = false
+            submenu.addItem(noLayoutsItem)
+            return
+        }
+
+        // Get screen manager: try focused screen first, then screen under mouse cursor, then first screen
+        let screenManager: ScreenManager<WindowManager<SIApplication>>? = {
+            if let focused = windowManager?.focusedScreenManager() {
+                return focused
+            }
+            // Fallback to screen containing mouse cursor (useful when clicking menu bar)
+            let mouseLocation = NSEvent.mouseLocation
+            if let nsScreen = NSScreen.screens.first(where: { NSMouseInRect(mouseLocation, $0.frame, false) }) {
+                let amScreen = AMScreen(screen: nsScreen)
+                return windowManager?.screenManager(for: amScreen)
+            }
+            return windowManager?.screenManager(at: 0)
+        }()
+
+        guard let screenManager = screenManager else {
+            let errorItem = NSMenuItem(title: "Unable to determine current screen", action: nil, keyEquivalent: "")
+            errorItem.isEnabled = false
+            submenu.addItem(errorItem)
+            return
+        }
+
         // Get all available layouts with their display names
         let availableLayouts = LayoutType<SIApplication.Window>.availableLayoutStrings()
 
-        // Get current layout
-        let focusedScreenManager = windowManager?.focusedScreenManager()
-        var currentLayoutKey = focusedScreenManager?.currentLayout?.layoutKey
+        // Get current layout index from the screen manager
+        let currentLayoutIndex = screenManager.currentLayoutIndexValue
 
-        // If no focused screen manager, fallback to the first screen manager
-        if focusedScreenManager == nil, let firstScreenManager = windowManager?.screenManager(at: 0) {
-            currentLayoutKey = firstScreenManager.currentLayout?.layoutKey
-        }
-
-        // Filter to only enabled layouts and add menu items
-        for layoutKey in enabledLayoutKeys {
+        // Add menu items for each enabled layout, using index to handle duplicate layout types
+        for (index, layoutKey) in enabledLayoutKeys.enumerated() {
             guard let layoutInfo = availableLayouts.first(where: { $0.key == layoutKey }) else {
                 continue
             }
@@ -218,19 +234,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let menuItem = NSMenuItem(title: layoutInfo.name, action: #selector(selectLayout(_:)), keyEquivalent: "")
             menuItem.target = self
             menuItem.representedObject = layoutKey
+            menuItem.tag = index
 
-            // Mark current layout with checkmark
-            let isCurrentLayout = layoutKey == currentLayoutKey
+            // Mark current layout with checkmark by comparing index (handles duplicate layout types)
+            let isCurrentLayout = index == currentLayoutIndex
             menuItem.state = isCurrentLayout ? .on : .off
 
             submenu.addItem(menuItem)
-        }
-
-        // If no layouts are enabled, show a disabled message
-        if enabledLayoutKeys.isEmpty {
-            let noLayoutsItem = NSMenuItem(title: "No layouts enabled", action: nil, keyEquivalent: "")
-            noLayoutsItem.isEnabled = false
-            submenu.addItem(noLayoutsItem)
         }
     }
 
@@ -253,16 +263,9 @@ extension AppDelegate: NSWindowDelegate {
 }
 
 extension AppDelegate: NSMenuDelegate {
-    func menuNeedsUpdate(_ menu: NSMenu) {
-        // Refresh layouts menu when it's about to be shown
-        if menu == layoutsMenuItem?.submenu {
-            populateLayoutsMenu()
-        }
-    }
-
     func menuWillOpen(_ menu: NSMenu) {
-        // Also refresh when menu is about to open
-        if menu == layoutsMenuItem?.submenu {
+        // Refresh layouts menu when main status item menu is about to open
+        if menu == statusItemMenu {
             populateLayoutsMenu()
         }
     }

--- a/Amethyst/AppDelegate.swift
+++ b/Amethyst/AppDelegate.swift
@@ -187,18 +187,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Clear existing items
         submenu.removeAllItems()
 
-        // Get enabled layout keys from user configuration
-        let enabledLayoutKeys = UserConfiguration.shared.layoutKeys()
-
-        // Check if no layouts are enabled and return early
-        if enabledLayoutKeys.isEmpty {
-            let noLayoutsItem = NSMenuItem(title: "No layouts enabled", action: nil, keyEquivalent: "")
-            noLayoutsItem.isEnabled = false
-            submenu.addItem(noLayoutsItem)
-            return
-        }
-
-        // Get screen manager: try focused screen first, then screen under mouse cursor, then first screen
+        // Get screen manager: try focused screen first, then screen under mouse cursor
         let screenManager: ScreenManager<WindowManager<SIApplication>>? = {
             if let focused = windowManager?.focusedScreenManager() {
                 return focused
@@ -209,7 +198,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 let amScreen = AMScreen(screen: nsScreen)
                 return windowManager?.screenManager(for: amScreen)
             }
-            return windowManager?.screenManager(at: 0)
+            return nil
         }()
 
         guard let screenManager = screenManager else {
@@ -219,24 +208,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        // Get all available layouts with their display names
-        let availableLayouts = LayoutType<SIApplication.Window>.availableLayoutStrings()
+        // Get layouts from the screen manager (not from global config)
+        let layouts = screenManager.layoutsInfo
+
+        // Check if no layouts are available and return early
+        if layouts.isEmpty {
+            let noLayoutsItem = NSMenuItem(title: "No layouts enabled", action: nil, keyEquivalent: "")
+            noLayoutsItem.isEnabled = false
+            submenu.addItem(noLayoutsItem)
+            return
+        }
 
         // Get current layout index from the screen manager
         let currentLayoutIndex = screenManager.currentLayoutIndexValue
 
-        // Add menu items for each enabled layout, using index to handle duplicate layout types
-        for (index, layoutKey) in enabledLayoutKeys.enumerated() {
-            guard let layoutInfo = availableLayouts.first(where: { $0.key == layoutKey }) else {
-                continue
-            }
-
+        // Add menu items for each layout in the screen manager
+        for (index, layoutInfo) in layouts.enumerated() {
             let menuItem = NSMenuItem(title: layoutInfo.name, action: #selector(selectLayout(_:)), keyEquivalent: "")
             menuItem.target = self
-            menuItem.representedObject = layoutKey
+            menuItem.representedObject = layoutInfo.key
             menuItem.tag = index
 
-            // Mark current layout with checkmark by comparing index (handles duplicate layout types)
+            // Mark current layout with checkmark by comparing index
             let isCurrentLayout = index == currentLayoutIndex
             menuItem.state = isCurrentLayout ? .on : .off
 

--- a/Amethyst/AppDelegate.swift
+++ b/Amethyst/AppDelegate.swift
@@ -219,19 +219,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        // Get current layout index from the screen manager
-        let currentLayoutIndex = screenManager.currentLayoutIndexValue
-
         // Add menu items for each layout in the screen manager
-        for (index, layoutInfo) in layouts.enumerated() {
+        for layoutInfo in layouts {
             let menuItem = NSMenuItem(title: layoutInfo.name, action: #selector(selectLayout(_:)), keyEquivalent: "")
             menuItem.target = self
             menuItem.representedObject = layoutInfo.key
-            menuItem.tag = index
-
-            // Mark current layout with checkmark by comparing index
-            let isCurrentLayout = index == currentLayoutIndex
-            menuItem.state = isCurrentLayout ? .on : .off
+            menuItem.state = layoutInfo.isSelected ? .on : .off
 
             submenu.addItem(menuItem)
         }

--- a/Amethyst/Base.lproj/MainMenu.xib
+++ b/Amethyst/Base.lproj/MainMenu.xib
@@ -26,6 +26,12 @@
                         <action selector="toggleGlobalTiling:" target="494" id="3aM-9U-hWx"/>
                     </connections>
                 </menuItem>
+                <menuItem title="Layouts" id="layouts-menu-item">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" id="layouts-submenu">
+                        <items/>
+                    </menu>
+                </menuItem>
                 <menuItem title="Start Amethyst on Login" id="549">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
@@ -73,6 +79,7 @@
                 <outlet property="statusItemMenu" destination="536" id="547"/>
                 <outlet property="toggleGlobalTilingMenuItem" destination="rjJ-w4-5Ht" id="4Dq-e8-R1M"/>
                 <outlet property="versionMenuItem" destination="bNZ-Ry-Q4Q" id="jXC-pY-N2a"/>
+                <outlet property="layoutsMenuItem" destination="layouts-menu-item" id="layouts-menu-outlet"/>
             </connections>
         </customObject>
         <customObject id="420" customClass="NSFontManager"/>

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -61,6 +61,11 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
         return currentLayoutIndex
     }
 
+    /// Returns layout info (key and name) for all layouts in this screen manager
+    var layoutsInfo: [(key: String, name: String)] {
+        return layouts.map { (key: $0.layoutKey, name: $0.layoutName) }
+    }
+
     private let layoutNameWindowController: LayoutNameWindowController
 
     init(screen: Screen, delegate: Delegate, userConfiguration: UserConfiguration) {

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -56,6 +56,11 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
         return layouts[currentLayoutIndex]
     }
 
+    /// The index of the current layout in the layouts array
+    var currentLayoutIndexValue: Int {
+        return currentLayoutIndex
+    }
+
     private let layoutNameWindowController: LayoutNameWindowController
 
     init(screen: Screen, delegate: Delegate, userConfiguration: UserConfiguration) {

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -9,6 +9,13 @@
 import Foundation
 import Silica
 
+/// Information about a layout for display in menus
+struct LayoutMenuItemInfo {
+    let key: String
+    let name: String
+    let isSelected: Bool
+}
+
 protocol ScreenManagerDelegate: AnyObject {
     associatedtype Window: WindowType
     func applyWindowLimit(forScreenManager screenManager: ScreenManager<Self>, minimizingIn range: (_ windowCount: Int) -> Range<Int>)
@@ -56,14 +63,15 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
         return layouts[currentLayoutIndex]
     }
 
-    /// The index of the current layout in the layouts array
-    var currentLayoutIndexValue: Int {
-        return currentLayoutIndex
-    }
-
-    /// Returns layout info (key and name) for all layouts in this screen manager
-    var layoutsInfo: [(key: String, name: String)] {
-        return layouts.map { (key: $0.layoutKey, name: $0.layoutName) }
+    /// Returns layout info for all layouts in this screen manager, including selection state
+    var layoutsInfo: [LayoutMenuItemInfo] {
+        return layouts.enumerated().map { index, layout in
+            LayoutMenuItemInfo(
+                key: layout.layoutKey,
+                name: layout.layoutName,
+                isSelected: index == currentLayoutIndex
+            )
+        }
     }
 
     private let layoutNameWindowController: LayoutNameWindowController


### PR DESCRIPTION
## Add Layouts Submenu to Application Menu

### Description
This PR introduces a new layouts submenu in the application menu, providing users with quick access to layout options directly from the menu bar.

Closes: https://github.com/ianyh/Amethyst/issues/1080

### Changes Made
- **AppDelegate.swift**: Added 87 lines of code to implement the layouts submenu functionality
- **MainMenu.xib**: Updated the interface builder file to include the new submenu structure

### What's New
- ✨ New layouts submenu in the application menu
- 🎯 Enhanced user experience with easier layout access
- 📱 Improved menu navigation for layout management

### Files Modified
- `Amethyst/AppDelegate.swift` (+87 lines)
- `Amethyst/Base.lproj/MainMenu.xib` (+7 lines)
