### PR TITLE
Add shortcuts for enable/disable tiling

### DIFF
--- a/.amethyst.sample.yml
+++ b/.amethyst.sample.yml
@@ -217,6 +217,16 @@ toggle-tiling:
   mod: mod2
   key: t
 
+# Turn on tiling.
+# enable-tiling:
+#   mod: mod2
+#   key: <NONE>
+
+# Turn off tiling.
+# disable-tiling:
+#   mod: mod2
+#   key: <NONE>
+
 # Rerun the current layout's algorithm.
 reevaluate-windows:
   mod: mod1

--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -235,6 +235,18 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
             windowManager.markAllScreensForReflow(withChange: .unknown)
         }
 
+        constructCommandWithCommandKey(CommandKey.enableTiling.rawValue) {
+            guard !self.userConfiguration.tilingEnabled else { return }
+            self.userConfiguration.tilingEnabled = true
+            windowManager.markAllScreensForReflow(withChange: .unknown)
+        }
+
+        constructCommandWithCommandKey(CommandKey.disableTiling.rawValue) {
+            guard self.userConfiguration.tilingEnabled else { return }
+            self.userConfiguration.tilingEnabled = false
+            windowManager.markAllScreensForReflow(withChange: .unknown)
+        }
+
         constructCommandWithCommandKey(CommandKey.reevaluateWindows.rawValue) {
             windowManager.reevaluateWindows()
         }
@@ -405,6 +417,8 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
         hotKeyNameToDefaultsKey.append(["Display current layout", CommandKey.displayCurrentLayout.rawValue])
         hotKeyNameToDefaultsKey.append(["Toggle focus follows mouse", CommandKey.toggleFocusFollowsMouse.rawValue])
         hotKeyNameToDefaultsKey.append(["Toggle global tiling", CommandKey.toggleTiling.rawValue])
+        hotKeyNameToDefaultsKey.append(["Enable global tiling", CommandKey.enableTiling.rawValue])
+        hotKeyNameToDefaultsKey.append(["Disable global tiling", CommandKey.disableTiling.rawValue])
 
         for (layoutKey, layoutName) in LayoutType<Application.Window>.availableLayoutStrings() {
             let commandName = "Select \(layoutName) layout"

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -130,6 +130,8 @@ enum CommandKey: String {
     case toggleFloat = "toggle-float"
     case displayCurrentLayout = "display-current-layout"
     case toggleTiling = "toggle-tiling"
+    case enableTiling = "enable-tiling"
+    case disableTiling = "disable-tiling"
     case reevaluateWindows = "reevaluate-windows"
     case toggleFocusFollowsMouse = "toggle-focus-follows-mouse"
     case relaunchAmethyst = "relaunch-amethyst"

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -190,6 +190,8 @@
         "mod": "mod2",
         "key": "t"
     },
+    "enable-tiling": false,
+    "disable-tiling": false,
     "display-current-layout": {
         "mod": "mod1",
         "key": "i"

--- a/docs/configuration-files.md
+++ b/docs/configuration-files.md
@@ -85,6 +85,8 @@ A mod is a list of keyboard modifiers. Namely, `option`, `control`, `shift`, and
 | `toggle-float` | Toggle the floating state of the currently focused window; i.e., if it was floating make it tiled and if it was tiled make it floating. |
 | `display-current-layout` | Display the layout HUD with the current layout on each screen. |
 | `toggle-tiling` | Turn on or off tiling entirely. |
+| `enable-tiling` | Turn on tiling. |
+| `disable-tiling` | Turn off tiling. |
 | `reevaluate-windows` | Rerun the current layout's algorithm. |
 | `toggle-focus-follows-mouse` | Turn on or off `focus-follows-mouse`. |
 | `relaunch-amethyst` | Automatically quit and reopen Amethyst. |


### PR DESCRIPTION
## Summary

Adds enable-tiling and disable-tiling keyboard shortcuts for explicit tiling control. Both shortcuts are idempotent (no-op if already in the desired state).

Closes #1815

## Motivation

The existing toggle-tiling shortcut is harder to use with external tools like [FlashSpace](https://github.com/wojciech-kulik/FlashSpace). Explicit enable/disable shortcuts allow scripts to reliably control tiling state without tracking the current toggle state.

## Changes

- Added enable-tiling and disable-tiling command keys to HotKeyManager
- Updated configuration files and documentation

> [!NOTE]
> I don't know Swift, so I implemented those changes with AI. However, I read all of the code and tested the changes in a local development build. If anything is amiss, please let me know, and I'm happy to make changes.

<img width="866" height="212" alt="Screenshot 2025-10-09 at 9 13 27 PM" src="https://github.com/user-attachments/assets/6cb93206-364c-4019-8c72-bbf7c138abc7" />
