### PR TITLE
add configurable small-window-size threshold

### DIFF
--- a/.amethyst.sample.yml
+++ b/.amethyst.sample.yml
@@ -279,8 +279,11 @@ ignore-menu-bar: false
 # true if menu bar icon should be hidden (default false).
 hide-menu-bar-icon: false
 
-# true if windows smaller than a 500px square should be floating by default (default true)
+# true if windows smaller than the small-window-size threshold should be floating by default (default true)
 float-small-windows: true
+
+# Pixel threshold for float-small-windows. Windows with both width and height below this value are considered small (in px, default 500).
+small-window-size: 500
 
 # true if the mouse should move position to the center of a window when it becomes focused (default false). Note that this is largely incompatible with focus-follows-mouse.
 mouse-follows-focus: false

--- a/Amethyst/Model/Window.swift
+++ b/Amethyst/Model/Window.swift
@@ -268,8 +268,9 @@ extension AXWindow: WindowType {
     func shouldFloat() -> Bool {
         let userConfiguration = UserConfiguration.shared
         let frame = self.frame()
+        let threshold = userConfiguration.smallWindowSize()
 
-        if userConfiguration.floatSmallWindows() && frame.size.width < 500 && frame.size.height < 500 {
+        if userConfiguration.floatSmallWindows() && frame.size.width < threshold && frame.size.height < threshold {
             return true
         }
 

--- a/Amethyst/Preferences/FloatingPreferencesViewController.xib
+++ b/Amethyst/Preferences/FloatingPreferencesViewController.xib
@@ -115,6 +115,52 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sWs-Th-001" userLabel="Small Window Size Label">
+                    <rect key="frame" x="340" y="401" width="83" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="smaller than" id="sWs-Th-002">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.float-small-windows" id="sWs-Th-003"/>
+                    </connections>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sWs-Th-004" userLabel="Small Window Size Input">
+                    <rect key="frame" x="428" y="399" width="50" height="22"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" usesSingleLineMode="YES" id="sWs-Th-005">
+                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="0" id="sWs-Th-006">
+                            <real key="minimum" value="1"/>
+                            <real key="maximum" value="10000"/>
+                        </numberFormatter>
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="value" keyPath="values.small-window-size" id="sWs-Th-007"/>
+                        <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.float-small-windows" id="sWs-Th-008"/>
+                    </connections>
+                </textField>
+                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sWs-Th-009" userLabel="Small Window Size Stepper">
+                    <rect key="frame" x="478" y="396" width="19" height="27"/>
+                    <stepperCell key="cell" continuous="YES" alignment="left" increment="50" minValue="1" maxValue="10000" doubleValue="500" id="sWs-Th-010"/>
+                    <connections>
+                        <binding destination="N2H-cZ-f1m" name="value" keyPath="values.small-window-size" id="sWs-Th-011"/>
+                        <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.float-small-windows" id="sWs-Th-012"/>
+                    </connections>
+                </stepper>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sWs-Th-013" userLabel="px Label">
+                    <rect key="frame" x="499" y="401" width="20" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="sWs-Th-014">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.float-small-windows" id="sWs-Th-015"/>
+                    </connections>
+                </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Q7b-oi-oDI">
                     <rect key="frame" x="192" y="369" width="294" height="28"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="This option is recommended to avoid tiling dialogs for some applications." id="GHB-Qd-gAx">
@@ -376,6 +422,14 @@
                 <constraint firstAttribute="bottom" secondItem="U6O-Ka-pXq" secondAttribute="bottom" constant="30" id="fQN-cG-rch"/>
                 <constraint firstItem="U6O-Ka-pXq" firstAttribute="top" secondItem="Dvu-vy-f2R" secondAttribute="bottom" constant="8" id="jTW-ge-qN6"/>
                 <constraint firstItem="9hq-U6-t9B" firstAttribute="centerY" secondItem="Mqz-bw-Kwm" secondAttribute="centerY" id="qde-oI-Gox"/>
+                <constraint firstItem="sWs-Th-001" firstAttribute="leading" secondItem="9hq-U6-t9B" secondAttribute="trailing" constant="8" id="sWs-Cn-001"/>
+                <constraint firstItem="sWs-Th-001" firstAttribute="centerY" secondItem="9hq-U6-t9B" secondAttribute="centerY" id="sWs-Cn-002"/>
+                <constraint firstItem="sWs-Th-004" firstAttribute="leading" secondItem="sWs-Th-001" secondAttribute="trailing" constant="4" id="sWs-Cn-003"/>
+                <constraint firstItem="sWs-Th-004" firstAttribute="centerY" secondItem="9hq-U6-t9B" secondAttribute="centerY" id="sWs-Cn-004"/>
+                <constraint firstItem="sWs-Th-009" firstAttribute="leading" secondItem="sWs-Th-004" secondAttribute="trailing" constant="0" id="sWs-Cn-005"/>
+                <constraint firstItem="sWs-Th-009" firstAttribute="centerY" secondItem="9hq-U6-t9B" secondAttribute="centerY" id="sWs-Cn-006"/>
+                <constraint firstItem="sWs-Th-013" firstAttribute="leading" secondItem="sWs-Th-009" secondAttribute="trailing" constant="2" id="sWs-Cn-007"/>
+                <constraint firstItem="sWs-Th-013" firstAttribute="centerY" secondItem="9hq-U6-t9B" secondAttribute="centerY" id="sWs-Cn-008"/>
                 <constraint firstItem="cfp-8K-Cdt" firstAttribute="leading" secondItem="ZH0-nz-Yiv" secondAttribute="trailing" constant="1" id="rvY-DC-e48"/>
                 <constraint firstItem="Mqz-bw-Kwm" firstAttribute="top" secondItem="LsO-9M-hEw" secondAttribute="top" constant="30" id="saa-p3-iK6"/>
                 <constraint firstItem="KqU-3F-KwY" firstAttribute="leading" secondItem="U6O-Ka-pXq" secondAttribute="leading" constant="1" id="tZl-oJ-mAu"/>

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -79,6 +79,7 @@ enum ConfigurationKey: String {
     case floatingBundleIdentifiersIsBlacklist = "floating-is-blacklist"
     case ignoreMenuBar = "ignore-menu-bar"
     case floatSmallWindows = "float-small-windows"
+    case smallWindowSize = "small-window-size"
     case mouseFollowsFocus = "mouse-follows-focus"
     case focusFollowsMouse = "focus-follows-mouse"
     case mouseSwapsWindows = "mouse-swaps-windows"
@@ -616,6 +617,11 @@ class UserConfiguration: NSObject {
 
     func floatSmallWindows() -> Bool {
         return storage.bool(forKey: .floatSmallWindows)
+    }
+
+    func smallWindowSize() -> CGFloat {
+        let size = CGFloat(storage.float(forKey: .smallWindowSize))
+        return size > 0 ? size : 500
     }
 
     func mouseFollowsFocus() -> Bool {

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -211,6 +211,7 @@
     "floating": [],
     "floating-is-blacklist": true,
     "float-small-windows": true,
+    "small-window-size": 500,
     "mouse-follows-focus": false,
     "focus-follows-mouse": false,
     "enables-layout-hud": true,

--- a/AmethystTests/Tests/Configuration/UserConfigurationTests.swift
+++ b/AmethystTests/Tests/Configuration/UserConfigurationTests.swift
@@ -504,6 +504,42 @@ class UserConfigurationTests: QuickSpec {
             }
         }
 
+        describe("small window size") {
+            it("returns default value when not set") {
+                let storage = TestConfigurationStorage()
+                let configuration = UserConfiguration(storage: storage)
+
+                expect(configuration.smallWindowSize()).to(equal(500))
+            }
+
+            it("returns configured value when set") {
+                let storage = TestConfigurationStorage()
+                let configuration = UserConfiguration(storage: storage)
+
+                storage.set(Float(300), forKey: .smallWindowSize)
+
+                expect(configuration.smallWindowSize()).to(equal(300))
+            }
+
+            it("returns default value when set to zero") {
+                let storage = TestConfigurationStorage()
+                let configuration = UserConfiguration(storage: storage)
+
+                storage.set(Float(0), forKey: .smallWindowSize)
+
+                expect(configuration.smallWindowSize()).to(equal(500))
+            }
+
+            it("returns default value when set to negative") {
+                let storage = TestConfigurationStorage()
+                let configuration = UserConfiguration(storage: storage)
+
+                storage.set(Float(-100), forKey: .smallWindowSize)
+
+                expect(configuration.smallWindowSize()).to(equal(500))
+            }
+        }
+
         describe("load configuration") {
             it("default configuration does not override existing configuration") {
                 let storage = TestConfigurationStorage()

--- a/docs/configuration-files.md
+++ b/docs/configuration-files.md
@@ -20,7 +20,8 @@ Amethyst will pick up a config file located at `~/.amethyst.yml` or `~/.config/a
 | `floating` | List of bundle identifiers for applications to either be automatically floating or automatically tiled based on `floating-is-blacklist` (default `[]`). |
 | `floating-is-blacklist` | Boolean flag determining behavior of the `floating` list. `true` if the applications should be floating and all others tiled. `false` if the applications should be tiled and all others floating (default `true`). |
 | `ignore-menu-bar` | `true` if screen frames should exclude the status bar. `false` if the screen frames should include the status bar (default `false`). |
-| `float-small-windows` | `true` if windows smaller than a 500px square should be floating by default (default `true`) |
+| `float-small-windows` | `true` if windows smaller than the `small-window-size` threshold should be floating by default (default `true`). |
+| `small-window-size` | Pixel threshold for `float-small-windows`. Windows with both width and height below this value are considered small (in px, default `500`). |
 | `mouse-follows-focus` | `true` if the mouse should move position to the center of a window when it becomes focused (default `false`). Note that this is largely incompatible with `focus-follows-mouse`. |
 | `focus-follows-mouse` | `true` if the windows underneath the mouse should become focused as the mouse moves (default `false`). Note that this is largely incompatible with `mouse-follows-focus` |
 | `mouse-swaps-windows` | `true` if dragging and dropping windows on to each other should swap their positions (default `false`). |


### PR DESCRIPTION
Add a new `small-window-size` configuration option that allows users to customize the pixel threshold for the `float-small-windows` feature. Previously hardcoded at 500px, users can now set any value via YAML config or the Floating preferences UI.

Changes:
- Add `smallWindowSize` ConfigurationKey and accessor method
- Update Window.shouldFloat() to use configurable threshold
- Add default value (500) in default.amethyst
- Add UI controls (text field + stepper) in Floating preferences
- Update documentation and sample config
- Add unit tests for smallWindowSize

Closes: ianyh/Amethyst#1557

🤖 Generated with [Claude Code](https://claude.com/claude-code)