### PR TITLE
Fix: Stabilize reflow during Space transitions and window tracking order

### DIFF
--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -98,6 +98,10 @@ struct WindowSet<Window: WindowType> {
             return
         }
 
+        guard isWindowWithIDActive(frameAssignment.window.id), !isWindowWithIDFloating(frameAssignment.window.id) else {
+            return
+        }
+
         frameAssignment.perform(withWindow: window)
     }
 }

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -230,6 +230,12 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
             return
         }
 
+        // During rapid Space transitions, activation/focus notifications can arrive before
+        // this screen manager updates its tracked Space. Skip reflow if state is stale.
+        guard let currentSpace = CGSpacesInfo<Window>.currentSpaceForScreen(screen), currentSpace.id == space?.id else {
+            return
+        }
+
         guard let windows = delegate?.activeWindowSet(forScreenManager: self) else {
             return
         }

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -594,6 +594,10 @@ extension WindowManager: ApplicationObservationDelegate {
     }
 
     func application(_ application: AnyApplication<Application>, didFindPotentiallyNewWindow window: Window) {
+        guard !windows.isWindowTracked(window) else {
+            return
+        }
+
         swapInTab(window: window)
     }
 

--- a/Amethyst/Managers/Windows.swift
+++ b/Amethyst/Managers/Windows.swift
@@ -84,14 +84,14 @@ extension WindowManager {
         }
 
         func remove(window: Window) {
-            for (_, lastMainWindow) in lastMainWindows where lastMainWindow == window {
+            for (_, lastMainWindow) in lastMainWindows where lastMainWindow?.id() == window.id() {
                 if let currentFocusedSpace = CGSpacesInfo<Window>.currentFocusedSpace() {
                     let secondWindow = activeWindowOnCurrentScreen(atIndex: 1)
                     lastMainWindows[currentFocusedSpace.id] = secondWindow
                 }
             }
 
-            guard let windowIndex = windows.firstIndex(of: window) else {
+            guard let windowIndex = windows.firstIndex(where: { $0.id() == window.id() }) else {
                 return
             }
 
@@ -101,12 +101,15 @@ extension WindowManager {
         @discardableResult func swap(window: Window, withWindow otherWindow: Window) -> Bool {
             if let currentFocusedSpace = CGSpacesInfo<Window>.currentFocusedSpace(),
                let firstActiveWindow = activeWindowOnCurrentScreen(atIndex: 0) {
-                if firstActiveWindow == window || firstActiveWindow == otherWindow {
+                if firstActiveWindow.id() == window.id() || firstActiveWindow.id() == otherWindow.id() {
                     lastMainWindows[currentFocusedSpace.id] = firstActiveWindow
                 }
             }
 
-            guard let windowIndex = windows.firstIndex(of: window), let otherWindowIndex = windows.firstIndex(of: otherWindow) else {
+            guard
+                let windowIndex = windows.firstIndex(where: { $0.id() == window.id() }),
+                let otherWindowIndex = windows.firstIndex(where: { $0.id() == otherWindow.id() })
+            else {
                 return false
             }
 
@@ -123,7 +126,7 @@ extension WindowManager {
         // MARK: Window States
 
         func isWindowTracked(_ window: Window) -> Bool {
-            return windows.contains(window)
+            return windows.contains(where: { $0.id() == window.id() })
         }
 
         func isWindowActive(_ window: Window) -> Bool {

--- a/Amethyst/Model/Window.swift
+++ b/Amethyst/Model/Window.swift
@@ -245,7 +245,9 @@ extension AXWindow: WindowType {
     }
 
     func pid() -> pid_t {
-        return processIdentifier()
+        // Some window operations can surface elements owned by a helper process.
+        // Use AXParent's PID when available so identity checks stay stable.
+        return forKey("AXParent" as CFString)?.processIdentifier() ?? processIdentifier()
     }
 
     /**


### PR DESCRIPTION
  ## Summary
  1. In `4 Column Left`, window order kept changing over time even when no new windows were added.
  2. When switching Spaces via Dock to an app in a`Floating`-designated Space, an unintended rearrangement could run on arrival (windows shifting/reordering and overlapping).

  ## Problem Details
  - Reflow could run during Space transitions while the tracked Space state was stale.
  - Window tracking/swap/remove logic could become unstable due to equality checks based on window objects instead of stable IDs.
  - Potentially new windows could be processed again even if already tracked.

  ## Fixes
  - Run reflow only when `ScreenManager`'s tracked Space matches the actual current Space.
  - Skip frame assignment for windows that are inactive or floating.
  - Ignore newly discovered windows if they are already tracked.
  - Use window IDs for tracked/remove/swap comparisons to stabilize ordering.

 ### Follow-up
- [This guard](https://github.com/ianyh/Amethyst/pull/1839/changes/BASE..21db785d9f4d4427b8104b618799ede3078ce1a0#diff-e9290deac9df0562f5227e32a3d6e82b85b99238df9374798ad81cc6d976b3e4R597-R599) is a temporary mitigation and not the final fix.