### PR TITLE
Avoid destruction of sibling subtrees on BSP removal

### DIFF
--- a/Amethyst/Layout/Layouts/BinarySpacePartitioningLayout.swift
+++ b/Amethyst/Layout/Layouts/BinarySpacePartitioningLayout.swift
@@ -90,13 +90,13 @@ class TreeNode<Window: WindowType>: Codable {
         }
 
         guard let grandparent = parent.parent else {
-            if node == parent.left {
-                parent.windowID = parent.right?.windowID
-            } else {
-                parent.windowID = parent.left?.windowID
-            }
-            parent.left = nil
-            parent.right = nil
+            // Parent is the root node. Promote the sibling into the root.
+            let sibling: TreeNode? = (node == parent.left) ? parent.right : parent.left
+            parent.windowID = sibling?.windowID
+            parent.left = sibling?.left
+            parent.right = sibling?.right
+            parent.left?.parent = parent
+            parent.right?.parent = parent
             return
         }
 


### PR DESCRIPTION
When removing a window whose parent was the root node, only the
sibling's `windowID` was copied into the root. If the sibling was an
internal node (a subtree with children but no `windowID`), the entire
subtree was discarded — all windows in that branch silently disappeared
from the BSP tree.

Promote the full sibling structure into the root by copying its
`windowID`, left, and right children, and re-parenting them correctly.