### PR TITLE
Fix tiling after reopening apps that keep windows alive

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -450,6 +450,7 @@ extension WindowManager {
 
         guard !windows.isWindowTracked(window) else {
             log.debug("Window was already tracked: \(window)")
+            refreshTrackedWindow(window, application: application)
             return
         }
 
@@ -485,8 +486,46 @@ extension WindowManager {
                     return .timer(.milliseconds((count ^ 2 * 100)), scheduler: MainScheduler.instance)
                 }
             }
+            .subscribe(
+                onError: { error in
+                    log.error("Failed to track window: \(window) - \(error)")
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    /**
+     Re-points an already-tracked window at a live AX element.
+
+     Apps that hide their windows on close (e.g., Telegram, Slack) can invalidate the
+     tracked element while the window — identified by (pid, CGWindowID) — lives on and
+     is revived later. The stale element still answers identity checks (the pid is baked
+     into the element ref and Silica caches the CGWindowID) but fails every attribute
+     read, so it can neither be laid out nor be replaced by normal tracking. When an
+     event hands us a live element for a window we already track, swap it in, move the
+     destroyed observation over to it, and re-tile.
+     */
+    private func refreshTrackedWindow(_ window: Window, application: AnyApplication<Application>) {
+        guard let staleWindow = windows.refreshWindow(window) else {
+            return
+        }
+
+        log.debug("Refreshed stale element for tracked window: \(window)")
+
+        // The destroyed observation belongs to the element, not the window identity.
+        // Drop the stale element's observation so a late notification from it cannot
+        // remove the live window, and observe the new element instead.
+        let observation = ApplicationObservation(application: application, delegate: self)
+        observation.removeObserversForWindow(staleWindow)
+        observation
+            .addObserversForWindow(window)
             .subscribe()
             .disposed(by: disposeBag)
+
+        windows.regenerateActiveIDCache()
+        if let screen = window.screen() {
+            markScreenForReflow(screen)
+        }
     }
 
     private func determineFloatForWindow(_ window: Window, application: AnyApplication<Application>, force: Bool) throws {
@@ -515,7 +554,7 @@ extension WindowManager {
         }
 
         if let otherWindow = otherWindow {
-            _ = windows.replace(window: window, withWindow: otherWindow)
+            _ = windows.replace(window: otherWindow, withWindow: window)
             distributeEventToScreen(screen, change: .tabChange(window: window, previousWindow: otherWindow))
         } else {
             windows.add(window: window, atFront: userConfiguration.sendNewWindowsToMainPane())
@@ -783,6 +822,7 @@ extension WindowManager: ApplicationObservationDelegate {
         if pendingTabDetection.removeValue(forKey: window.id()) != nil {
             completeTabDetection(for: window, on: screen)
         } else if windows.isWindowTracked(window) {
+            refreshTrackedWindow(window, application: application)
             distributeEventToScreen(screen, change: .focusChanged(window: window))
             markScreenForReflow(screen)
         } else {
@@ -798,6 +838,7 @@ extension WindowManager: ApplicationObservationDelegate {
 
     func application(_ application: AnyApplication<Application>, didFindPotentiallyNewWindow window: Window) {
         guard !windows.isWindowTracked(window) else {
+            refreshTrackedWindow(window, application: application)
             return
         }
 

--- a/Amethyst/Managers/Windows.swift
+++ b/Amethyst/Managers/Windows.swift
@@ -108,6 +108,26 @@ extension WindowManager {
             windows.remove(at: windowIndex)
         }
 
+        /**
+         Swaps the stored instance of an already-tracked window for `window`, which has
+         the same identity but a fresh AX element. Order and floating state are untouched.
+         See `WindowManager.refreshTrackedWindow` for why elements go stale.
+
+         - Returns: The replaced instance, or `nil` if the window is untracked or already
+         stored as this exact element.
+         */
+        func refreshWindow(_ window: Window) -> Window? {
+            guard let index = windows.firstIndex(where: { $0.id() == window.id() }),
+                  windows[index] != window else {
+                return nil
+            }
+
+            let staleWindow = windows[index]
+            windows[index] = window
+            return staleWindow
+        }
+
+        /// Replaces `window` in the tracking order with `otherWindow`, dropping `window`.
         @discardableResult func replace(window: Window, withWindow otherWindow: Window) -> Bool {
             if let currentFocusedSpace = CGSpacesInfo<Window>.currentFocusedSpace(),
                let firstActiveWindow = activeWindowOnCurrentScreen(atIndex: 0) {
@@ -116,16 +136,16 @@ extension WindowManager {
                 }
             }
 
-            guard let otherWindowIndex = windows.firstIndex(of: otherWindow) else {
+            guard let windowIndex = windows.firstIndex(of: window) else {
                 windows.append(otherWindow)
                 return false
             }
 
-            let windowIndex = windows.firstIndex(of: window)
-            windows[otherWindowIndex] = window
+            let otherWindowIndex = windows.firstIndex(of: otherWindow)
+            windows[windowIndex] = otherWindow
 
-            if let windowIndex {
-                windows.remove(at: windowIndex)
+            if let otherWindowIndex {
+                windows.remove(at: otherWindowIndex)
             }
 
             return true


### PR DESCRIPTION
## Summary

Fixes a window-tracking issue where apps such as Telegram, Slack, Claude, and potentially Kitty can stop tiling after a window is closed or hidden, then later shown again.

Some apps keep the same underlying window alive instead of destroying it. When the window is shown again, Amethyst can receive a new accessibility element for the same `(pid, CGWindowID)` while still tracking the old element. The old element still matches by identity, but reads such as frame, title, and screen can fail. As a result, the live element is rejected as already tracked, and the window is not laid out.

This should theoretically address [ianyh/Amethyst#1335](https://github.com/ianyh/Amethyst/issues/1335). That thread includes a Telegram report with the same visible behaviour, and the kitty workaround of setting `macos_quit_when_last_window_closed yes` points at the same class of lifecycle issue: forcing the app to quit avoids reusing a hidden/retained window after the last window is closed. I have not reproduced the kitty case locally, so I am not treating that issue as definitively fixed.

## Changes

- Refresh the stored tracked window when a live accessibility element arrives for the same window identity.
- Preserve window order and floating state while replacing the stale element.
- Move the window-destroyed observer from the old element to the new element.
- Regenerate the active window ID cache and reflow the affected screen after a refresh.
- Fix `Windows.replace(window:withWindow:)` so it replaces the first argument with the second, matching the method name and tab detection call sites.
- Log window tracking failures instead of silently swallowing failed subscriptions.

## Disclosure

This bug had been annoying me for a while, and I used it as a chance to try Claude Fable 5 while debugging and preparing the fix. I am not an expert in macOS accessibility or window-server internals, but I walked through the behaviour, the fix makes sense to me, and I tested it locally.

## Testing

- Ran the full Amethyst test suite.
- Manually verified with Telegram that reopening the window returns it to the layout.
- Verified that `mod+z` can recover the window after reopening.

## Known limitation

Closing one of these hidden windows still may not immediately reflow the remaining windows, because macOS does not appear to send an accessibility notification for that hide transition. This PR focuses on adopting the live window when it reappears.
