### PR TITLE
Scan for untracked windows after tab close

### DIFF
--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -773,6 +773,25 @@ extension WindowManager: ApplicationObservationDelegate {
         remove(window: window)
     }
 
+    func application(_ application: AnyApplication<Application>, didDestroyWindow window: Window) {
+        remove(window: window)
+
+        // In apps with native macOS tabs, each tab is its own window and only the visible
+        // one is tracked. Closing the active tab destroys the tracked window and reveals a
+        // sibling that may never have been tracked, and the app may fire no notification
+        // for it. Pick up any window of this app that is now on screen and untracked.
+        application.dropWindowsCache()
+        for candidate in application.windows() {
+            guard candidate != window else { continue }
+            guard windows.isWindowActive(candidate) else { continue }
+            guard !windows.isWindowTracked(candidate) else { continue }
+
+            pendingTabDetection.removeValue(forKey: candidate.id())
+            earlyFocusedWindows.remove(candidate.id())
+            add(window: candidate)
+        }
+    }
+
     func application(_ application: AnyApplication<Application>, didFocusWindow window: Window) {
         guard let screen = window.screen() else {
             return

--- a/Amethyst/Model/ApplicationObservation.swift
+++ b/Amethyst/Model/ApplicationObservation.swift
@@ -37,6 +37,16 @@ protocol ApplicationObservationDelegate: AnyObject {
     func application(_ application: AnyApplication<Application>, didRemoveWindow window: Window)
 
     /**
+     Called when a window's accessibility element has been destroyed (e.g. the window
+     was closed), as opposed to minimized.
+
+     - Parameters:
+         - application: The application the event occurred in.
+         - window: The window that was destroyed.
+     */
+    func application(_ application: AnyApplication<Application>, didDestroyWindow window: Window)
+
+    /**
      Called when the application has focused a window.
      
      - Parameters:
@@ -350,7 +360,7 @@ struct ApplicationObservation<Delegate: ApplicationObservationDelegate> {
         case .mainWindowChanged:
             delegate?.application(application, didFindPotentiallyNewWindow: window)
         case .elementDestroyed:
-            delegate?.application(application, didRemoveWindow: window)
+            delegate?.application(application, didDestroyWindow: window)
         }
     }
 }


### PR DESCRIPTION
- When closing the active tab in apps with native macOS tabs (e.g. Ghostty), the newly revealed tab may never have been tracked, and the app may not fire a notification Amethyst observes for it. Amethyst loses track of the remaining window, leaving a hole in the layout.
- After removing a destroyed window, scan the same application for windows that are now on screen and untracked, and add them.
- This is a targeted mini-reevaluate scoped to just the affected application.

How the scan is kept narrow:
- Element destruction gets its own `didDestroyWindow` delegate callback, so minimizing a window (which also routes through `didRemoveWindow`) does not trigger the scan or re-track the minimized window.
- The application's window cache is dropped before scanning, matching the existing scans on unhide and space change.
- Candidates are filtered to windows other than the destroyed one that are active and on screen (`isWindowActive`), then to untracked ones, before `add(window:)` runs. That costs a few cheap attribute reads per window in the app; the full add path only runs for on-screen windows that aren't tracked, which in the common case is just the surviving tab.
- Any pending tab-detection state for the survivor is cleared before adding it, so a late focus event cannot run tab detection against it and swap it for a stale window.

Related issues: #1335 (kitty doesn't tile — same class of native-tab lifecycle issue), #1398 (apps randomly don't tile)