### PR TITLE
Fix unresponsive Floating preferences menu on Tahoe

### DIFF
--- a/Amethyst/Preferences/FloatingPreferencesViewController.swift
+++ b/Amethyst/Preferences/FloatingPreferencesViewController.swift
@@ -37,26 +37,13 @@ class FloatingPreferencesViewController: NSViewController, NSTableViewDataSource
         let layoutMenu = NSMenu(title: "")
         let selectMenuItem = NSMenuItem(title: "Select from applications...", action: #selector(selectFloatingApplication(_:)), keyEquivalent: "")
         let manualMenuItem = NSMenuItem(title: "Manually enter identifier...", action: #selector(manuallyEnterFloatingApplication(_:)), keyEquivalent: "")
+        selectMenuItem.target = self
+        manualMenuItem.target = self
 
         layoutMenu.addItem(selectMenuItem)
         layoutMenu.addItem(manualMenuItem)
 
-        let frame = sender.frame
-        let menuOrigin = sender.superview!.convert(NSPoint(x: frame.origin.x, y: frame.origin.y + frame.size.height + 40), to: nil)
-
-        let event = NSEvent.mouseEvent(
-            with: NSEvent.EventType.leftMouseDown,
-            location: menuOrigin,
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: sender.window!.windowNumber,
-            context: sender.window!.graphicsContext,
-            eventNumber: 0,
-            clickCount: 1,
-            pressure: 1
-        )
-
-        NSMenu.popUpContextMenu(layoutMenu, with: event!, for: sender)
+        layoutMenu.popUp(positioning: nil, at: NSPoint(x: sender.bounds.minX, y: sender.bounds.maxY), in: sender)
     }
 
     @objc func selectFloatingApplication(_ sender: AnyObject) {


### PR DESCRIPTION
Fixes #1828

## Summary
- Replace the fabricated mouse event and context-menu popup with an `NSMenu` anchored directly to the add button.
- Assign explicit targets to both menu actions.
- Prevent the menu-tracking state that could leave Preferences unresponsive on macOS Tahoe.

## Testing
- Built and launched the app locally on macOS Tahoe.
- Verified the `+` menu opens and dismisses while Preferences remains responsive.
- Verified removing a floating exception leaves Preferences responsive.
- Ran the complete test suite: 152 tests passed with 0 failures.