### PR TITLE
Animate Windows As They Move Between Tiles

### DIFF
--- a/.amethyst.sample.yml
+++ b/.amethyst.sample.yml
@@ -237,6 +237,11 @@ toggle-focus-follows-mouse:
   mod: mod2
   key: x
 
+# Turn on or off animate-windows (unbound by default; uncomment and set a mod and key to enable).
+# toggle-animate-windows:
+#   mod: mod2
+#   key: <NONE>
+
 # Automatically quit and reopen Amethyst.
 relaunch-amethyst:
   mod: mod2
@@ -278,6 +283,14 @@ ignore-menu-bar: false
 
 # true if menu bar icon should be hidden (default false).
 hide-menu-bar-icon: false
+
+# true if windows should animate to their new frames when the layout changes (default false). Granting Amethyst the
+# Screen Recording permission enables smooth snapshot-based motion; without it the real windows are moved instead.
+# Respects the system Reduce Motion setting.
+animate-windows: false
+
+# Duration of the window movement animation in seconds, between 0.05 and 1.0 (default 0.3)
+window-animation-duration: 0.3
 
 # true if windows smaller than the small-window-size threshold should be floating by default (default true)
 float-small-windows: true

--- a/Amethyst.xcodeproj/project.pbxproj
+++ b/Amethyst.xcodeproj/project.pbxproj
@@ -38,6 +38,10 @@
 		401BC8B61CE9259000F89B3F /* LayoutType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401BC8B51CE9259000F89B3F /* LayoutType.swift */; };
 		401BC8BA1CE9319500F89B3F /* FocusFollowsMouseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401BC8B91CE9319500F89B3F /* FocusFollowsMouseManager.swift */; };
 		401C35AF2241BBDD0019ED07 /* ReflowOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401C35AE2241BBDD0019ED07 /* ReflowOperation.swift */; };
+		DA1A0002AE0B000000000002 /* AnimatedReflowOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1A0001AE0B000000000001 /* AnimatedReflowOperation.swift */; };
+		DA1A0006AE0B000000000006 /* WindowCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1A0005AE0B000000000005 /* WindowCapture.swift */; };
+		DA1A000AAE0B00000000000A /* BackdropCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1A0009AE0B000000000009 /* BackdropCapture.swift */; };
+		DA1A0008AE0B000000000008 /* ReflowAnimationOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1A0007AE0B000000000007 /* ReflowAnimationOverlay.swift */; };
 		401C35B12244626E0019ED07 /* ApplicationObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401C35B02244626E0019ED07 /* ApplicationObservation.swift */; };
 		401C35B32244650F0019ED07 /* MouseState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401C35B22244650F0019ED07 /* MouseState.swift */; };
 		401C35B522482EAF0019ED07 /* WindowTransitionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401C35B422482EAF0019ED07 /* WindowTransitionCoordinator.swift */; };
@@ -53,6 +57,8 @@
 		402F6FA62A81C9E30036B512 /* SkyLight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 402F6FA52A81C9E30036B512 /* SkyLight.framework */; };
 		403E1A2A2337173600DB7B2A /* FloatingLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403E1A292337173600DB7B2A /* FloatingLayoutTests.swift */; };
 		403E1A2C233719E500DB7B2A /* TallLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403E1A2B233719E500DB7B2A /* TallLayoutTests.swift */; };
+		DA1A0004AE0B000000000004 /* AnimatedReflowOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1A0003AE0B000000000003 /* AnimatedReflowOperationTests.swift */; };
+		DA1A000BAE0B00000000000B /* EnhancedUserInterfaceSuppressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1A000CAE0B00000000000C /* EnhancedUserInterfaceSuppressionTests.swift */; };
 		4045416F268FFDA000861BE8 /* CustomLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4045416E268FFDA000861BE8 /* CustomLayout.swift */; };
 		404541712697C14A00861BE8 /* CustomLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404541702697C14A00861BE8 /* CustomLayoutTests.swift */; };
 		404541742697C22A00861BE8 /* null.js in Resources */ = {isa = PBXBuildFile; fileRef = 404541732697C22A00861BE8 /* null.js */; };
@@ -172,6 +178,10 @@
 		401BC8B51CE9259000F89B3F /* LayoutType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutType.swift; sourceTree = "<group>"; };
 		401BC8B91CE9319500F89B3F /* FocusFollowsMouseManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FocusFollowsMouseManager.swift; sourceTree = "<group>"; };
 		401C35AE2241BBDD0019ED07 /* ReflowOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflowOperation.swift; sourceTree = "<group>"; };
+		DA1A0001AE0B000000000001 /* AnimatedReflowOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedReflowOperation.swift; sourceTree = "<group>"; };
+		DA1A0005AE0B000000000005 /* WindowCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCapture.swift; sourceTree = "<group>"; };
+		DA1A0009AE0B000000000009 /* BackdropCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackdropCapture.swift; sourceTree = "<group>"; };
+		DA1A0007AE0B000000000007 /* ReflowAnimationOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflowAnimationOverlay.swift; sourceTree = "<group>"; };
 		401C35B02244626E0019ED07 /* ApplicationObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationObservation.swift; sourceTree = "<group>"; };
 		401C35B22244650F0019ED07 /* MouseState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseState.swift; sourceTree = "<group>"; };
 		401C35B422482EAF0019ED07 /* WindowTransitionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowTransitionCoordinator.swift; sourceTree = "<group>"; };
@@ -189,6 +199,8 @@
 		40378E22238F39B900D11E22 /* Amethyst.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Amethyst.entitlements; sourceTree = "<group>"; };
 		403E1A292337173600DB7B2A /* FloatingLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingLayoutTests.swift; sourceTree = "<group>"; };
 		403E1A2B233719E500DB7B2A /* TallLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TallLayoutTests.swift; sourceTree = "<group>"; };
+		DA1A0003AE0B000000000003 /* AnimatedReflowOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedReflowOperationTests.swift; sourceTree = "<group>"; };
+		DA1A000CAE0B00000000000C /* EnhancedUserInterfaceSuppressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedUserInterfaceSuppressionTests.swift; sourceTree = "<group>"; };
 		4045416E268FFDA000861BE8 /* CustomLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomLayout.swift; sourceTree = "<group>"; };
 		404541702697C14A00861BE8 /* CustomLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomLayoutTests.swift; sourceTree = "<group>"; };
 		404541732697C22A00861BE8 /* null.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = null.js; sourceTree = "<group>"; };
@@ -506,6 +518,7 @@
 				40B0D144232D2E630021E0A7 /* FullscreenLayoutTests.swift */,
 				40D491D723367590007E0CCB /* RowLayoutTests.swift */,
 				403E1A2B233719E500DB7B2A /* TallLayoutTests.swift */,
+				DA1A0003AE0B000000000003 /* AnimatedReflowOperationTests.swift */,
 				40AB5BE823AB0A2B00E29346 /* TallRightLayoutTests.swift */,
 				40AB5BEC23AC3CF800E29346 /* ThreeColumnLayoutTests.swift */,
 				AAAC6BAB2677DF7B00BEC1B0 /* TwoPaneLayoutTests.swift */,
@@ -540,10 +553,19 @@
 			children = (
 				4085824A1EA673950075A2C3 /* Managers */,
 				404BE9CF1CFBDEFD00D6C537 /* Layout */,
+				DA1A000DAE0B00000000000D /* Model */,
 				401BC8AB1CE8F84500F89B3F /* Preferences */,
 				40111CC7223370E1003D20BD /* Categories */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		DA1A000DAE0B00000000000D /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				DA1A000CAE0B00000000000C /* EnhancedUserInterfaceSuppressionTests.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		40B0D149232D94410021E0A7 /* Model */ = {
@@ -562,6 +584,9 @@
 				401C35AD2241BA760019ED07 /* Layouts */,
 				4029C4F01C112478001E4788 /* Layout.swift */,
 				401C35AE2241BBDD0019ED07 /* ReflowOperation.swift */,
+				DA1A0001AE0B000000000001 /* AnimatedReflowOperation.swift */,
+				DA1A0005AE0B000000000005 /* WindowCapture.swift */,
+				DA1A0009AE0B000000000009 /* BackdropCapture.swift */,
 			);
 			path = Layout;
 			sourceTree = "<group>";
@@ -580,6 +605,7 @@
 			children = (
 				40B3927B1814967F009A296B /* LayoutNameWindow.xib */,
 				401BC8A51CE8E65D00F89B3F /* LayoutNameWindow.swift */,
+				DA1A0007AE0B000000000007 /* ReflowAnimationOverlay.swift */,
 				4058C46E1C4B119500B19D26 /* LayoutNameWindowController.swift */,
 				40C1357B1F202AEE00FF9FA7 /* PreferencesWindow.swift */,
 			);
@@ -808,6 +834,10 @@
 				F46629C4272AD7A30040C275 /* FourColumnLayout.swift in Sources */,
 				401BC8A61CE8E65D00F89B3F /* LayoutNameWindow.swift in Sources */,
 				401C35AF2241BBDD0019ED07 /* ReflowOperation.swift in Sources */,
+				DA1A0002AE0B000000000002 /* AnimatedReflowOperation.swift in Sources */,
+				DA1A0006AE0B000000000006 /* WindowCapture.swift in Sources */,
+				DA1A000AAE0B00000000000A /* BackdropCapture.swift in Sources */,
+				DA1A0008AE0B000000000008 /* ReflowAnimationOverlay.swift in Sources */,
 				401BC8B41CE9250800F89B3F /* HotKeyRegistrar.swift in Sources */,
 				40637073224EF9B20081299D /* Change.swift in Sources */,
 				40CEF4301C2B8D21004C3297 /* ScreenManager.swift in Sources */,
@@ -865,6 +895,8 @@
 				40B0D14B232D944C0021E0A7 /* TestWindow.swift in Sources */,
 				40D491D823367590007E0CCB /* RowLayoutTests.swift in Sources */,
 				403E1A2C233719E500DB7B2A /* TallLayoutTests.swift in Sources */,
+				DA1A0004AE0B000000000004 /* AnimatedReflowOperationTests.swift in Sources */,
+				DA1A000BAE0B00000000000B /* EnhancedUserInterfaceSuppressionTests.swift in Sources */,
 				404541712697C14A00861BE8 /* CustomLayoutTests.swift in Sources */,
 				4000DB10239CA07000365A0C /* WideLayoutTests.swift in Sources */,
 				40AB5BEB23AB182300E29346 /* WidescreenTallLayoutTests.swift in Sources */,
@@ -1055,6 +1087,11 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-weak_framework",
+					ScreenCaptureKit,
+				);
 				MARKETING_VERSION = 0.24.3;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
@@ -1100,6 +1137,11 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-weak_framework",
+					ScreenCaptureKit,
+				);
 				MARKETING_VERSION = 0.24.3;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";

--- a/Amethyst/Events/HotKeyManager.swift
+++ b/Amethyst/Events/HotKeyManager.swift
@@ -255,6 +255,13 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
             self.userConfiguration.toggleFocusFollowsMouse()
         }
 
+        constructCommandWithCommandKey(CommandKey.toggleAnimateWindows.rawValue) {
+            self.userConfiguration.toggleAnimateWindows()
+            DispatchQueue.main.async {
+                windowManager.displayAnimateWindowsHUD()
+            }
+        }
+
         constructCommandWithCommandKey(CommandKey.relaunchAmethyst.rawValue) { [weak appDelegate] in
             appDelegate?.relaunch(self)
         }
@@ -434,6 +441,7 @@ class HotKeyManager<Application: ApplicationType>: NSObject {
         hotKeyNameToDefaultsKey.append(["Toggle float for focused window", CommandKey.toggleFloat.rawValue])
         hotKeyNameToDefaultsKey.append(["Display current layout", CommandKey.displayCurrentLayout.rawValue])
         hotKeyNameToDefaultsKey.append(["Toggle focus follows mouse", CommandKey.toggleFocusFollowsMouse.rawValue])
+        hotKeyNameToDefaultsKey.append(["Toggle window movement animation", CommandKey.toggleAnimateWindows.rawValue])
         hotKeyNameToDefaultsKey.append(["Toggle global tiling", CommandKey.toggleTiling.rawValue])
         hotKeyNameToDefaultsKey.append(["Enable global tiling", CommandKey.enableTiling.rawValue])
         hotKeyNameToDefaultsKey.append(["Disable global tiling", CommandKey.disableTiling.rawValue])

--- a/Amethyst/Layout/AnimatedReflowOperation.swift
+++ b/Amethyst/Layout/AnimatedReflowOperation.swift
@@ -1,0 +1,1298 @@
+//
+//  AnimatedReflowOperation.swift
+//  Amethyst
+//
+//  Created by Don Patterson on 9/8/26.
+//  Copyright © 2026 Ian Ynda-Hummel. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+import os.log
+
+/// Unified-log channel for animation timing, readable with `log stream --info --predicate 'subsystem == "com.amethyst.Amethyst"'` even in release builds.
+private let animationLog = OSLog(subsystem: "com.amethyst.Amethyst", category: "animation")
+
+/// Records an animation event on both channels: the app's logger, which only prints in debug builds, and the unified log, which is all a release build has.
+private func logAnimation(_ message: String) {
+    log.debug(message)
+    os_log("%{public}s", log: animationLog, type: .info, message)
+}
+
+/// How long to wait for slow applications to apply their last frame before moving on.
+private let defaultWriterDrainTimeout: TimeInterval = 1.0
+
+/// How long a proxy takes to correct itself when an application only reports its real size after the glide has ended.
+private let lateCorrectionDuration: TimeInterval = 0.1
+
+/// The least time a proxy takes to dissolve into a fresh capture, even when the glide is about to end; shorter reads as a snap.
+private let minimumDissolveDuration: TimeInterval = 0.15
+
+/// How long after an application accepts its new frame to wait before capturing it again. The accessibility call returns before many applications have redrawn, and a capture taken too early shows stale or empty content.
+private let redrawSettleDelay: TimeInterval = 0.06
+
+/// Pure interpolation helpers for animated reflows.
+enum FrameInterpolation {
+    /// Sinusoidal ease-in-out: gentle start and finish, with peak velocity only about 1.6x linear so no single frame jumps far even at low tick rates.
+    static func easeInOutSine(_ progress: CGFloat) -> CGFloat {
+        let clamped = min(max(progress, 0), 1)
+        return (1 - cos(clamped * .pi)) / 2
+    }
+
+    /**
+     Linearly interpolates between two rects.
+
+     Each edge is interpolated and rounded independently, so every edge of the result lies between the corresponding edges of `start` and `end`, and consecutive ticks either produce a visibly different frame or an identical one that can be skipped.
+     */
+    static func interpolate(from start: CGRect, to end: CGRect, progress: CGFloat) -> CGRect {
+        func lerp(_ startValue: CGFloat, _ endValue: CGFloat) -> CGFloat {
+            return (startValue + (endValue - startValue) * progress).rounded()
+        }
+
+        let minX = lerp(start.minX, end.minX)
+        let minY = lerp(start.minY, end.minY)
+        let maxX = lerp(start.maxX, end.maxX)
+        let maxY = lerp(start.maxY, end.maxY)
+
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+
+    /// Rounds a rect to integral points.
+    static func integral(_ rect: CGRect) -> CGRect {
+        return interpolate(from: rect, to: rect, progress: 0)
+    }
+
+    /**
+     A live window frame rounded to integral points, or `nil` if it could not be read.
+
+     An accessibility frame read fails when the application is hung or the window has gone, and Silica reports that as the null rect, whose coordinates are infinite. Doing arithmetic on it yields NaN, which traps when converted to an integer and is rejected by Core Animation, so every read goes through here.
+     */
+    static func readable(_ rect: CGRect) -> CGRect? {
+        guard !rect.isNull, !rect.isInfinite, [rect.minX, rect.minY, rect.width, rect.height].allSatisfy({ $0.isFinite }) else {
+            return nil
+        }
+        return integral(rect)
+    }
+}
+
+/**
+ Applies frame writes for one application on a serial queue of its own.
+
+ Accessibility writes block until the target application has processed them, and applications differ wildly in how quickly they do so. Each writer always applies the newest frame requested for each of its windows and drops any frames it could not keep up with, so a slow application only lowers its own frame rate instead of holding every other window back.
+ */
+final class ApplicationFrameWriter<Window: WindowType> {
+    struct Write {
+        let window: Window
+        let frame: CGRect
+        let includingSize: Bool
+    }
+
+    struct Statistics {
+        var requested = 0
+        var applied = 0
+        var totalWriteTime: TimeInterval = 0
+
+        var averageWriteTime: TimeInterval {
+            return applied == 0 ? 0 : totalWriteTime / TimeInterval(applied)
+        }
+    }
+
+    let pid: pid_t
+
+    /// `nil` applies writes inline on the caller's thread, which keeps tests deterministic.
+    private let queue: DispatchQueue?
+    private let group: DispatchGroup
+    private let now: () -> TimeInterval
+    private let beginWrite: (Window) -> Bool
+    private let endWrite: (Window) -> Void
+    private let lock = NSLock()
+    private var pending: [Int: Write] = [:]
+    private var isDraining = false
+    private var statistics = Statistics()
+
+    /**
+     - Parameters:
+         - beginWrite: Asked immediately before each frame is written; answering `false` leaves the window alone, because it was handed to another screen while its frame waited its turn.
+         - endWrite: Told once the frame has been written, so whoever is waiting to take the window over knows it is free.
+     */
+    init(
+        pid: pid_t,
+        group: DispatchGroup,
+        inline: Bool,
+        now: @escaping () -> TimeInterval,
+        beginWrite: @escaping (Window) -> Bool = { _ in true },
+        endWrite: @escaping (Window) -> Void = { _ in }
+    ) {
+        self.pid = pid
+        self.group = group
+        self.now = now
+        self.beginWrite = beginWrite
+        self.endWrite = endWrite
+        self.queue = inline ? nil : DispatchQueue(label: "Amethyst.ApplicationFrameWriter.\(pid)", qos: .userInteractive)
+    }
+
+    /// Requests writes keyed by window. A later request for the same window supersedes an earlier one that has not been applied yet, except that a size the earlier one carried is kept.
+    func write(_ writes: [Int: Write]) {
+        lock.lock()
+        for (key, write) in writes {
+            // A position-only write always carries the size the earlier resize intended, so folding the resize into it loses nothing.
+            if let earlier = pending[key], earlier.includingSize, !write.includingSize {
+                pending[key] = Write(window: write.window, frame: write.frame, includingSize: true)
+            } else {
+                pending[key] = write
+            }
+            statistics.requested += 1
+        }
+        let shouldStartDraining = !isDraining && !pending.isEmpty
+        if shouldStartDraining {
+            isDraining = true
+        }
+        lock.unlock()
+
+        guard shouldStartDraining else {
+            return
+        }
+
+        group.enter()
+        if let queue = queue {
+            queue.async { self.drain() }
+        } else {
+            drain()
+        }
+    }
+
+    /// Whether every requested write has been applied.
+    var isIdle: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return pending.isEmpty && !isDraining
+    }
+
+    /// Drops frames that have not been applied yet, for cancellation.
+    func discardPending() {
+        lock.lock()
+        pending.removeAll()
+        lock.unlock()
+    }
+
+    func statisticsSnapshot() -> Statistics {
+        lock.lock()
+        defer { lock.unlock() }
+        return statistics
+    }
+
+    func resetStatistics() {
+        lock.lock()
+        statistics = Statistics()
+        lock.unlock()
+    }
+
+    private func drain() {
+        while true {
+            lock.lock()
+            let batch = pending
+            pending.removeAll()
+            if batch.isEmpty {
+                isDraining = false
+                lock.unlock()
+                group.leave()
+                return
+            }
+            lock.unlock()
+
+            for write in batch.values {
+                // The window may have been handed to another screen while this frame waited behind a slow application, so
+                // ownership is checked again here, immediately before the write.
+                guard beginWrite(write.window) else {
+                    continue
+                }
+
+                let start = now()
+                write.window.setAnimationFrame(write.frame, includingSize: write.includingSize)
+                let elapsed = now() - start
+                endWrite(write.window)
+
+                lock.lock()
+                statistics.applied += 1
+                statistics.totalWriteTime += elapsed
+                lock.unlock()
+            }
+        }
+    }
+}
+
+/**
+ Which screen each animating window currently belongs to.
+
+ While a window is being moved and resized behind the backdrop it can briefly have most of its area on another display, and a reflow on that display, triggered for example by an application activating, would otherwise claim it and tile it there. Registering in-flight windows lets the screen filters keep them with the screen that is animating them.
+ */
+final class AnimatingWindows {
+    static let shared = AnimatingWindows()
+
+    /// Guards every table below and lets a hand-off wait for writes in flight to end.
+    private let lock = NSCondition()
+    private var screenIDsByWindow: [CGWindowID: String] = [:]
+    /// Where the animation is taking each claimed window, so a hand-off can put a window still parked off-screen somewhere sane.
+    private var targetsByWindow: [CGWindowID: CGRect] = [:]
+    /// How many frame writes are being applied to each window right now.
+    private var writesInFlight: [CGWindowID: Int] = [:]
+    private var lastSeenFrames: [CGWindowID: (frame: CGRect, time: TimeInterval)] = [:]
+
+    /// How long a cancelled animation's last picture positions stay relevant to a follow-up animation.
+    static let lastSeenFrameLifetime: TimeInterval = 1.0
+
+    /// How long a hand-off waits for a slow application to finish applying a frame already being written.
+    static let handOffTimeout: TimeInterval = 1.0
+
+    /**
+     Remembers where a cancelled animation last showed each window, so the animation that replaces it can start its pictures
+     there rather than from the windows' real frames. The real windows are left at valid tiles regardless.
+     */
+    func recordLastSeenFrames(_ frames: [CGWindowID: CGRect], at time: TimeInterval) {
+        lock.lock()
+        for (windowID, frame) in frames {
+            lastSeenFrames[windowID] = (frame, time)
+        }
+        lock.unlock()
+    }
+
+    /// Where the window's picture was last seen, if a cancelled animation recorded it recently. Consumed on read.
+    func takeLastSeenFrame(for windowID: CGWindowID, at time: TimeInterval) -> CGRect? {
+        lock.lock()
+        defer { lock.unlock() }
+        lastSeenFrames = lastSeenFrames.filter { time - $0.value.time <= AnimatingWindows.lastSeenFrameLifetime }
+        return lastSeenFrames.removeValue(forKey: windowID)?.frame
+    }
+
+    /// Claims the windows for `screenID`, recording where its animation is taking each one.
+    func claim(_ windowIDs: [CGWindowID], for screenID: String, targets: [CGWindowID: CGRect] = [:]) {
+        lock.lock()
+        for windowID in windowIDs {
+            screenIDsByWindow[windowID] = screenID
+            targetsByWindow[windowID] = targets[windowID]
+        }
+        lock.unlock()
+    }
+
+    /**
+     Registers a frame write about to be applied to the window on behalf of `screenID`.
+
+     - Returns: `false`, registering nothing, if the window is no longer that screen's to move; the write must then be skipped.
+     */
+    func beginWrite(_ windowID: CGWindowID, for screenID: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard screenIDsByWindow[windowID] == screenID else {
+            return false
+        }
+        writesInFlight[windowID, default: 0] += 1
+        return true
+    }
+
+    /// Records that a write registered with `beginWrite` has been applied, releasing any hand-off waiting for it.
+    func endWrite(_ windowID: CGWindowID) {
+        lock.lock()
+        if let count = writesInFlight[windowID] {
+            writesInFlight[windowID] = count > 1 ? count - 1 : nil
+        }
+        lock.broadcast()
+        lock.unlock()
+    }
+
+    /**
+     Drops any claim on the windows, whichever screen holds it, and waits for writes already being applied to them to finish.
+
+     Called when Amethyst itself relocates a window to another screen or Space: the animation that was moving it must stop touching it, and the destination screen must be free to adopt it at once. Once this returns, no frame the animation queued can land on the window any more.
+
+     - Returns: Where the animation was taking each window it had claimed, so a window still parked beyond every display can be put back on its screen before it is moved.
+     */
+    @discardableResult
+    func handOff(_ windowIDs: [CGWindowID], timeout: TimeInterval = AnimatingWindows.handOffTimeout) -> [CGWindowID: CGRect] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var targets: [CGWindowID: CGRect] = [:]
+        for windowID in windowIDs {
+            screenIDsByWindow[windowID] = nil
+            targets[windowID] = targetsByWindow.removeValue(forKey: windowID)
+        }
+
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while windowIDs.contains(where: { writesInFlight[$0] != nil }) && lock.wait(until: deadline) {}
+        return targets
+    }
+
+    /// Releases windows claimed for `screenID`; claims made since by another screen are left alone.
+    func release(_ windowIDs: [CGWindowID], for screenID: String) {
+        lock.lock()
+        for windowID in windowIDs where screenIDsByWindow[windowID] == screenID {
+            screenIDsByWindow[windowID] = nil
+            targetsByWindow[windowID] = nil
+        }
+        lock.unlock()
+    }
+
+    /// The screen animating the window, if any.
+    func screenID(for windowID: CGWindowID) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return screenIDsByWindow[windowID]
+    }
+
+    /// The screen animating the window, provided it is one of `screenIDs`, the screens currently attached. A display unplugged mid-animation keeps its claims until its operation ends, but the windows are no longer its to keep.
+    func screenID(for windowID: CGWindowID, ifAmong screenIDs: Set<String>) -> String? {
+        return screenID(for: windowID).flatMap { screenIDs.contains($0) ? $0 : nil }
+    }
+
+    /// Whether an animation is currently moving the window, so a move or resize notification about it is Amethyst's own doing rather than a user gesture.
+    func isAnimating(_ windowID: CGWindowID) -> Bool {
+        return screenID(for: windowID) != nil
+    }
+}
+
+/**
+ Applies every frame assignment of a reflow together over a fixed duration.
+
+ Regular reflows enqueue one `FrameAssignmentOperation` per window on a serial queue. Wrapping them all in a single operation lets every window move at the same time, keeps the completion operation's dependency structure intact, and makes cancellation via `cancelAllOperations()` take effect between steps.
+
+ Two strategies are available, chosen per reflow:
+
+ **Snapshot** (preferred, needs Screen Recording permission and the private SkyLight capture): an image of each window is captured and shown in an overlay exactly where the window is; the real window is parked off-screen, given its final size there (the one expensive relayout happens out of sight), and the images slide to their targets with Core Animation. Then the real windows are placed at their targets and the images fade out. The user only ever sees the compositor moving pixels, so the motion is smooth regardless of how slow the applications are.
+
+ **Accessibility** (fallback): windows are resized in place, then their positions glide through repeated Accessibility writes, handed to a writer per application. Moving a window is cheap for the application; resizing is not, which is why the resize happens once up front.
+
+ In both cases the final frame goes through the normal `FrameAssignment.perform(withWindow:)`, so the end state is identical to a non-animated reflow.
+ */
+final class AnimatedReflowOperation<Window: WindowType>: Operation, @unchecked Sendable {
+    private struct Participant {
+        let assignment: FrameAssignment<Window>
+        let window: Window
+        let pid: pid_t
+        let start: CGRect
+        /// Where the window's picture starts: where a cancelled animation last showed it, if that was a moment ago, else its real frame.
+        let visualStart: CGRect
+        /// Where the window should end up. Corrected mid-animation if the application refuses the assigned size.
+        var target: CGRect
+        let resizable: Bool
+        var lastIssued: CGRect
+        /// Pixels per point of the window's first capture, for validating later captures.
+        var pixelsPerPoint: CGFloat = 1
+
+        /// Whether the window's size has to change to reach its target.
+        var needsResize: Bool {
+            return resizable && start.size != target.size
+        }
+
+        /// The frame this window should show at `progress` of the accessibility glide: interpolated position, already-final size, kept on screen if focused.
+        func frame(at progress: CGFloat) -> CGRect {
+            let interpolated = FrameInterpolation.interpolate(from: start, to: target, progress: progress)
+            return assignment.keepingFocusedWindowOnScreen(CGRect(origin: interpolated.origin, size: lastIssued.size))
+        }
+    }
+
+    private typealias Writes = [pid_t: [Int: ApplicationFrameWriter<Window>.Write]]
+
+    private struct SnapshotTimings {
+        var inPlace = false
+        var captureDuration: TimeInterval = 0
+        var parkDuration: TimeInterval = 0
+        var placeDuration: TimeInterval = 0
+        var corrected = 0
+        var recaptured = 0
+        /// When, relative to the start of the glide, the first application finished re-laying out and its proxy could be refined.
+        var firstRefinement: TimeInterval?
+        /// Resized windows whose proxy never received a fresh image; they get a slow dissolve at the handoff instead.
+        var unrefreshed: [Int] = []
+    }
+
+    private enum SnapshotOutcome {
+        case completed(animator: SnapshotAnimating, timings: SnapshotTimings)
+        case cancelled
+        case unavailable(reason: String)
+    }
+
+    /// How long the proxies take to fade once the real windows are back in place.
+    private static var handoffFadeDuration: TimeInterval { return 0.08 }
+
+    /// How long a proxy that never received a fresh image takes to dissolve into the real window at the handoff.
+    private static var lingeringFadeDuration: TimeInterval { return 0.25 }
+
+    private let frameAssignments: [FrameAssignment<Window>]
+    private let windowSet: WindowSet<Window>?
+    private let duration: TimeInterval
+    private let frameInterval: TimeInterval
+    private let writesInline: Bool
+    private let writerDrainTimeout: TimeInterval
+    private let captureImages: (([WindowCaptureRequest]) -> [CGImage]?)?
+    private let captureIsVerifiable: (WindowCaptureRequest) -> Bool
+    private let captureBackdrop: ((CGRect, [CGWindowID]) -> CGImage?)?
+    private let makeSnapshotAnimator: (() -> SnapshotAnimating)?
+    private let parkingOrigin: () -> CGPoint
+    private let screenID: String?
+    private let now: () -> TimeInterval
+    private let sleep: (TimeInterval) -> Void
+
+    private let writerGroup = DispatchGroup()
+    private var writers: [pid_t: ApplicationFrameWriter<Window>] = [:]
+
+    /// Participants whose size is being changed by the current snapshot animation; only these need a fresh capture.
+    private var resizedIndexSet: Set<Int> = []
+
+    /// Whether the current snapshot animation keeps the real windows on screen behind a backdrop rather than parking them.
+    private var refinesInPlace = false
+
+    /// Number of accessibility glide ticks performed. Exposed for tests.
+    private(set) var tickCount = 0
+
+    /**
+     - Parameters:
+         - frameAssignmentOperations: The per-window operations a layout produced. Their assignments are animated together and their shared window set resolves live windows.
+         - duration: Total glide time in seconds. Capture and the up-front resize are not counted against it.
+         - frameInterval: Target time between accessibility glide ticks, and the pause that lets the overlay draw before windows are parked.
+         - writesInline: Apply writes synchronously on the operation's thread instead of on per-application queues. For tests.
+         - captureImages: Captures full images of the given windows; `nil` disables the snapshot strategy.
+         - captureIsVerifiable: Whether a fresh capture of the window would reveal a not-yet-redrawn surface by its size. Windows whose captures cannot be verified are not dissolved mid-glide; their proxies linger at the handoff instead.
+         - captureBackdrop: Captures a screen without the given windows. With it, real windows are re-laid out in place behind the backdrop and their proxies cross-dissolve to fresh captures; without it they are parked off-screen.
+         - makeSnapshotAnimator: Creates the overlay that shows and slides the snapshots; `nil` disables the snapshot strategy.
+         - parkingOrigin: A point beyond every display where real windows are hidden during a snapshot animation.
+         - screenID: The screen this reflow belongs to; its windows are registered as in flight so other screens leave them alone.
+         - now: Monotonic clock, injectable for tests.
+         - sleep: Blocking sleep, injectable for tests.
+         - writerDrainTimeout: How long to wait for slow applications to apply their last frame before moving on.
+     */
+    init(
+        frameAssignmentOperations: [FrameAssignmentOperation<Window>],
+        duration: TimeInterval,
+        frameInterval: TimeInterval = 1.0 / 60.0,
+        writesInline: Bool = false,
+        writerDrainTimeout: TimeInterval = defaultWriterDrainTimeout,
+        captureImages: (([WindowCaptureRequest]) -> [CGImage]?)? = nil,
+        captureIsVerifiable: @escaping (WindowCaptureRequest) -> Bool = { _ in true },
+        captureBackdrop: ((CGRect, [CGWindowID]) -> CGImage?)? = nil,
+        makeSnapshotAnimator: (() -> SnapshotAnimating)? = nil,
+        parkingOrigin: @escaping () -> CGPoint = AnimatedReflowOperation.defaultParkingOrigin,
+        screenID: String? = nil,
+        now: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+        sleep: @escaping (TimeInterval) -> Void = { Thread.sleep(forTimeInterval: $0) }
+    ) {
+        self.frameAssignments = frameAssignmentOperations.map { $0.frameAssignment }
+        self.windowSet = frameAssignmentOperations.first?.windowSet
+        self.duration = duration
+        self.frameInterval = frameInterval
+        self.writesInline = writesInline
+        self.writerDrainTimeout = writerDrainTimeout
+        self.captureImages = captureImages
+        self.captureIsVerifiable = captureIsVerifiable
+        self.captureBackdrop = captureBackdrop
+        self.makeSnapshotAnimator = makeSnapshotAnimator
+        self.parkingOrigin = parkingOrigin
+        self.screenID = screenID
+        self.now = now
+        self.sleep = sleep
+        super.init()
+    }
+
+    // MARK: - Parking
+
+    /// A point to the right of every active display, in the flipped coordinates Accessibility uses.
+    static func defaultParkingOrigin() -> CGPoint {
+        return parkingOrigin(forDisplayBounds: ActiveDisplays.bounds())
+    }
+
+    static func parkingOrigin(forDisplayBounds bounds: [CGRect]) -> CGPoint {
+        let union = bounds.reduce(CGRect.null) { $0.union($1) }
+        return CGPoint(x: (union.isNull ? 0 : union.maxX) + 200, y: 0)
+    }
+
+    // MARK: - Operation
+
+    override func main() {
+        guard !isCancelled, let windowSet = windowSet else {
+            return
+        }
+
+        var participants = prepareParticipants(in: windowSet)
+        let windowIDs = participants.map { $0.window.cgID() }
+        if let screenID = screenID {
+            let targets = Dictionary(participants.map { ($0.window.cgID(), $0.target) }, uniquingKeysWith: { first, _ in first })
+            AnimatingWindows.shared.claim(windowIDs, for: screenID, targets: targets)
+        }
+
+        var snapshotAnimator: SnapshotAnimating?
+        var lingeringProxies: [Int] = []
+        var overlayHandedOff = false
+
+        defer {
+            // The overlay never outlives the operation. On a cancellation after the glide the real windows are already in
+            // place, so the panel comes down at once; only the normal path fades it out.
+            if let animator = snapshotAnimator, !overlayHandedOff {
+                runOnMainSync { animator.cancel() }
+            }
+            if let screenID = screenID {
+                AnimatingWindows.shared.release(windowIDs, for: screenID)
+            }
+            participants.forEach { $0.window.endAnimatedMovement() }
+        }
+
+        if !participants.isEmpty {
+            switch attemptSnapshotAnimation(&participants) {
+            case let .completed(animator, timings):
+                snapshotAnimator = animator
+                lingeringProxies = timings.unrefreshed
+                logSnapshotTiming(windowCount: participants.count, timings: timings)
+            case .cancelled:
+                return
+            case let .unavailable(reason):
+                logAnimation("Animated reflow: snapshot animation unavailable (\(reason)); moving the real windows instead")
+
+                let resizeStart = now()
+                resizeInPlace(&participants)
+                let resizeDuration = now() - resizeStart
+
+                // A cancel now, with every window resized but still at its old position, must leave the windows at their
+                // tiles just as a cancel mid-glide does: the reflow that cancelled may not move them.
+                guard !isCancelled else {
+                    abandonPendingWrites(&participants)
+                    return
+                }
+                guard animate(&participants, resizeDuration: resizeDuration) else {
+                    return
+                }
+            }
+        }
+
+        // The same holds for a cancel that arrived while waiting for a slow application after the glide.
+        guard !isCancelled else {
+            abandonPendingWrites(&participants)
+            return
+        }
+
+        // Nothing the writers still hold may land after the settle: drop what is queued, and wait for what is in flight.
+        writers.values.forEach { $0.discardPending() }
+        waitForWriters()
+
+        // Settle: apply the exact final frames through the regular path, including focused-window peeking, except for windows
+        // Amethyst has since moved elsewhere. Only participants were claimed, so a window that never took part, because its
+        // frame could not be read, is settled just as a non-animated reflow would settle it.
+        let claimedWindowIDs = Set(windowIDs)
+        for frameAssignment in frameAssignments {
+            guard let window = windowSet.window(for: frameAssignment), owns(window) || !claimedWindowIDs.contains(window.cgID()) else {
+                continue
+            }
+            windowSet.perform(frameAssignment: frameAssignment)
+        }
+
+        // Only now hand the picture back to the real windows.
+        if let animator = snapshotAnimator {
+            runOnMainSync {
+                animator.finish(
+                    fadeDuration: AnimatedReflowOperation.handoffFadeDuration,
+                    lingering: lingeringProxies,
+                    lingerDuration: AnimatedReflowOperation.lingeringFadeDuration
+                ) {}
+            }
+            overlayHandedOff = true
+            logFinalFrameMismatches(participants)
+        }
+    }
+
+    /// Reports any window whose settled frame differs from where its proxy landed; a non-empty list means the handoff shows a jump.
+    private func logFinalFrameMismatches(_ participants: [Participant]) {
+        let mismatches = participants.compactMap { participant -> String? in
+            guard let actual = FrameInterpolation.readable(participant.window.frame()), actual != participant.target else {
+                return nil
+            }
+            return "pid \(participant.pid) proxy \(Int(participant.target.minX)),\(Int(participant.target.minY)) \(Int(participant.target.width))x\(Int(participant.target.height))"
+                + " window \(Int(actual.minX)),\(Int(actual.minY)) \(Int(actual.width))x\(Int(actual.height))"
+        }
+
+        guard !mismatches.isEmpty else {
+            return
+        }
+
+        logAnimation("Animated reflow: proxy/window mismatch after settle: \(mismatches.joined(separator: "; "))")
+    }
+
+    /// Resolves live windows and captures start frames in a single main-thread hop.
+    private func prepareParticipants(in windowSet: WindowSet<Window>) -> [Participant] {
+        var participants: [Participant] = []
+
+        runOnMainSync {
+            guard !isCancelled else {
+                return
+            }
+
+            for assignment in frameAssignments {
+                guard let window = windowSet.window(for: assignment) else {
+                    continue
+                }
+
+                // A window whose frame cannot be read is left to the settle pass, exactly as a non-animated reflow treats it.
+                guard let start = FrameInterpolation.readable(window.frame()), let assigned = FrameInterpolation.readable(assignment.finalFrame) else {
+                    continue
+                }
+
+                // A window that cannot be resized will only ever be moved, so its picture is aimed at the tile's position with
+                // the window's own size, where the settle pass will actually leave it.
+                let resizable = window.isResizable()
+                let target = resizable
+                    ? assigned
+                    : FrameInterpolation.integral(assignment.keepingFocusedWindowOnScreen(CGRect(origin: assigned.origin, size: start.size)))
+
+                guard start != target else {
+                    continue
+                }
+
+                window.beginAnimatedMovement()
+                participants.append(Participant(
+                    assignment: assignment,
+                    window: window,
+                    pid: window.pid(),
+                    start: start,
+                    visualStart: AnimatingWindows.shared.takeLastSeenFrame(for: window.cgID(), at: now()) ?? start,
+                    target: target,
+                    resizable: resizable,
+                    lastIssued: start
+                ))
+            }
+        }
+
+        return participants
+    }
+
+    // MARK: - Snapshot strategy
+
+    private func attemptSnapshotAnimation(_ participants: inout [Participant]) -> SnapshotOutcome {
+        guard let captureImages = captureImages, let makeSnapshotAnimator = makeSnapshotAnimator else {
+            return .unavailable(reason: "disabled")
+        }
+
+        let windowIDs = participants.map { $0.window.cgID() }
+        let requests = participants.map { WindowCaptureRequest(windowID: $0.window.cgID(), frame: $0.start) }
+        let screenFrame = participants[0].assignment.screenFrame
+        var timings = SnapshotTimings()
+
+        // Window images and the backdrop are independent round trips; take them at the same time.
+        let captureStart = now()
+        var images: [CGImage]?
+        var backdrop: CGImage?
+        let captureBackdrop = self.captureBackdrop
+        DispatchQueue.concurrentPerform(iterations: captureBackdrop == nil ? 1 : 2) { task in
+            if task == 0 {
+                images = captureImages(requests)
+            } else {
+                backdrop = captureBackdrop?(screenFrame, windowIDs)
+            }
+        }
+        timings.captureDuration = now() - captureStart
+
+        guard let images = images, images.count == participants.count else {
+            return .unavailable(reason: "window capture failed")
+        }
+        timings.inPlace = backdrop != nil
+
+        for (index, image) in images.enumerated() where participants[index].start.width > 0 {
+            participants[index].pixelsPerPoint = CGFloat(image.width) / participants[index].start.width
+        }
+
+        let proxies = zip(participants, images).map { participant, image in
+            SnapshotProxy(image: image, start: participant.visualStart, target: participant.target)
+        }
+
+        var animator: SnapshotAnimating?
+        runOnMainSync {
+            let created = makeSnapshotAnimator()
+            created.show(proxies: proxies, screenFrame: screenFrame, backdrop: backdrop)
+            animator = created
+        }
+
+        guard let animator = animator else {
+            return .unavailable(reason: "overlay unavailable")
+        }
+
+        // Give the compositor one frame to draw the overlay over the real windows before those move.
+        sleep(frameInterval)
+
+        let resizedIndices = hideRealWindows(&participants, inPlace: timings.inPlace, timings: &timings)
+        resizedIndexSet = Set(resizedIndices)
+        refinesInPlace = timings.inPlace
+
+        guard !isCancelled else {
+            return abandonSnapshotAnimation(animator, &participants)
+        }
+
+        let finished = DispatchSemaphore(value: 0)
+        runOnMainSync {
+            animator.animate(duration: duration) {
+                finished.signal()
+            }
+        }
+
+        guard glide(&participants, animator: animator, finished: finished, timings: &timings) else {
+            return abandonSnapshotAnimation(animator, &participants)
+        }
+
+        timings.placeDuration = placeRealWindows(&participants)
+        return .completed(animator: animator, timings: timings)
+    }
+
+    /**
+     Waits for the proxies' motion to end while refining them, checking for cancellation every frame and never waiting forever.
+
+     As each application applies its new frame, its proxies are steered to the frame it accepted. Behind a backdrop the resized
+     windows are then captured again, once they have had time to redraw, and their proxies dissolve into the fresh image. A
+     capture whose surface does not yet match the accepted size is retried, since many applications redraw well after the
+     accessibility call returns.
+
+     - Returns: `false` if the operation was cancelled.
+     */
+    private func glide(_ participants: inout [Participant], animator: SnapshotAnimating, finished: DispatchSemaphore, timings: inout SnapshotTimings) -> Bool {
+        let glideStart = now()
+        var pendingSteer = refinesInPlace ? Set(participants.indices) : resizedIndexSet
+        var pendingRecapture: [Int: TimeInterval] = [:]
+        var retiredProxies = Set<Int>()
+        var refinements: [DispatchSemaphore] = []
+        var stalled = false
+        var remainingWaits = Int(((duration + 1.0) / frameInterval).rounded(.up))
+
+        while finished.wait(timeout: .now()) == .timedOut {
+            // Pace the checks with the injectable sleep so the injected clock advances in tests.
+            sleep(frameInterval)
+            remainingWaits -= 1
+            if isCancelled {
+                return false
+            }
+
+            // The render server pauses animations, and their completions, while a display sleeps or the main thread stalls.
+            // That is not a cancellation: the motion is over as far as anyone can see, so carry on to the exact placement.
+            if remainingWaits <= 0 {
+                logAnimation("Animated reflow: the glide never reported completion; settling anyway")
+                stalled = true
+                break
+            }
+
+            // A window thrown to another screen or Space mid-glide is no longer ours: stop refining it and hide its proxy.
+            let retired = retireHandedOffProxies(participants, alreadyRetired: &retiredProxies, animator: animator)
+            pendingSteer.subtract(retired)
+            for index in retired {
+                pendingRecapture[index] = nil
+            }
+
+            let current = now()
+            let elapsed = current - glideStart
+
+            let steerable = pendingSteer.filter { writer(for: participants[$0].pid).isIdle }
+            if !steerable.isEmpty {
+                pendingSteer.subtract(steerable)
+                if timings.firstRefinement == nil {
+                    timings.firstRefinement = elapsed
+                }
+                timings.corrected += steerToAcceptedFrames(animator, &participants, indices: steerable.sorted(), duration: max(duration - elapsed, 0.05), completion: nil)
+                for index in steerable where refinesInPlace && resizedIndexSet.contains(index) {
+                    pendingRecapture[index] = current + redrawSettleDelay
+                }
+            }
+
+            let due = pendingRecapture.filter { $0.value <= current }.map { $0.key }
+            if !due.isEmpty {
+                let remaining = max(duration - elapsed, minimumDissolveDuration)
+                let (dissolveDone, dissolved, unverifiable) = dissolveToFreshCaptures(animator, participants, indices: due.sorted(), duration: remaining, isFinalAttempt: false)
+                refinements.append(contentsOf: [dissolveDone].compactMap { $0 })
+                timings.recaptured += dissolved.count
+                timings.unrefreshed = Array(Set(timings.unrefreshed).union(unverifiable)).sorted()
+                for index in due {
+                    pendingRecapture[index] = dissolved.contains(index) || unverifiable.contains(index) ? nil : current + redrawSettleDelay
+                }
+            }
+        }
+
+        // Nothing on screen moves again until the render server resumes, so late corrections and dissolves could neither be
+        // seen nor report back; none are requested.
+        guard !stalled else {
+            return true
+        }
+
+        refinements += finishRefinement(&participants, animator: animator, pendingSteer: pendingSteer, pendingRecapture: Set(pendingRecapture.keys), timings: &timings)
+
+        for refinement in refinements {
+            _ = refinement.wait(timeout: .now() + minimumDissolveDuration + 0.5)
+        }
+        return true
+    }
+
+    /// Gives whatever the glide left unrefined one last, short correction before the handoff. Returns the animations to wait for.
+    private func finishRefinement(
+        _ participants: inout [Participant],
+        animator: SnapshotAnimating,
+        pendingSteer: Set<Int>,
+        pendingRecapture: Set<Int>,
+        timings: inout SnapshotTimings
+    ) -> [DispatchSemaphore] {
+        var refinements: [DispatchSemaphore] = []
+        var recapture = pendingRecapture
+
+        if !pendingSteer.isEmpty {
+            waitForWriters(timeout: 0.2)
+            // As during the glide, only a window whose application has applied its frame can be read back truthfully; one still
+            // waiting on its application would report its old frame and be steered back to where it started. Those are left
+            // to placement and the settle.
+            let steerable = pendingSteer.filter { writer(for: participants[$0].pid).isIdle }
+            if !steerable.isEmpty {
+                // The wait below is bounded; a semaphore that was never signalled is simply dropped afterwards.
+                let correctionDone = DispatchSemaphore(value: 0)
+                let corrected = steerToAcceptedFrames(animator, &participants, indices: steerable.sorted(), duration: lateCorrectionDuration) { correctionDone.signal() }
+                timings.corrected += corrected
+                if corrected == 0 {
+                    correctionDone.signal()
+                }
+                refinements.append(correctionDone)
+                recapture.formUnion(steerable.filter { refinesInPlace && resizedIndexSet.contains($0) })
+            }
+        }
+
+        guard !recapture.isEmpty else {
+            return refinements
+        }
+
+        // Slow renderers get one more moment before the final attempt; whatever still has not redrawn lingers at the handoff.
+        sleep(redrawSettleDelay)
+        let (dissolveDone, dissolved, _) = dissolveToFreshCaptures(animator, participants, indices: recapture.sorted(), duration: minimumDissolveDuration, isFinalAttempt: true)
+        refinements.append(contentsOf: [dissolveDone].compactMap { $0 })
+        timings.recaptured += dissolved.count
+        timings.unrefreshed = Array(Set(timings.unrefreshed).union(recapture.subtracting(dissolved))).sorted()
+        return refinements
+    }
+
+    /**
+     Gets the real windows out of sight and gives them their final size: at their destinations behind the backdrop, or parked beyond the displays.
+
+     - Returns: The indices of windows whose size changes.
+     */
+    private func hideRealWindows(_ participants: inout [Participant], inPlace: Bool, timings: inout SnapshotTimings) -> [Int] {
+        let resizedIndices = participants.indices.filter { participants[$0].needsResize }
+
+        if inPlace {
+            issue(&participants) { participant in
+                let size = participant.needsResize ? participant.target.size : participant.lastIssued.size
+                return (CGRect(origin: participant.target.origin, size: size), participant.needsResize)
+            }
+            return resizedIndices
+        }
+
+        // Park at the current size first so every window vanishes together, then take the final size out of sight.
+        let parking = parkingOrigin()
+        issue(&participants) { participant in
+            (CGRect(origin: CGPoint(x: parking.x, y: participant.start.minY), size: participant.start.size), false)
+        }
+        let parkStart = now()
+        waitForWriters(timeout: 0.1)
+        timings.parkDuration = now() - parkStart
+
+        issue(&participants) { participant in
+            participant.needsResize ? (CGRect(origin: participant.lastIssued.origin, size: participant.target.size), true) : nil
+        }
+        return resizedIndices
+    }
+
+    /// Brings the real windows to their targets; only the position changes now. Windows re-laid out in place are already there unless their target was corrected.
+    private func placeRealWindows(_ participants: inout [Participant]) -> TimeInterval {
+        issueTargetPositions(&participants)
+
+        let start = now()
+        waitForWriters(timeout: 0.2)
+        return now() - start
+    }
+
+    /**
+     Reads back the frame each window actually took and, for any that differ from the assigned frame, corrects the participant's
+     target and steers its proxy there. Applications with minimum or fixed sizes, or ones that refuse to sit under the menu bar,
+     would otherwise pop at the handoff.
+
+     Behind a backdrop the window is already at its destination, so its whole frame is authoritative. A parked window's position
+     means nothing, so only its size is taken, and the focused window's origin is clamped the way the settle pass will clamp it.
+
+     - Returns: How many proxies were corrected. `completion` is forwarded to the animator only when at least one was.
+     */
+    private func steerToAcceptedFrames(
+        _ animator: SnapshotAnimating,
+        _ participants: inout [Participant],
+        indices: [Int],
+        duration: TimeInterval,
+        completion: (() -> Void)?
+    ) -> Int {
+        var acceptedFrames = [Int: CGRect]()
+        let lock = NSLock()
+        let windows = indices.map { participants[$0].window }
+
+        DispatchQueue.concurrentPerform(iterations: windows.count) { position in
+            // A window whose frame cannot be read keeps the target it has.
+            guard let frame = FrameInterpolation.readable(windows[position].frame()) else {
+                return
+            }
+            lock.lock()
+            acceptedFrames[indices[position]] = frame
+            lock.unlock()
+        }
+
+        var corrections = [CGRect?](repeating: nil, count: participants.count)
+        for index in indices {
+            guard let accepted = acceptedFrames[index] else {
+                continue
+            }
+
+            // Where the settle pass will leave the window: its accepted frame, kept on screen if it is the focused window.
+            let assignment = participants[index].assignment
+            let corrected = assignment.keepingFocusedWindowOnScreen(
+                refinesInPlace ? accepted : CGRect(origin: participants[index].target.origin, size: accepted.size)
+            )
+
+            guard corrected != participants[index].target else {
+                continue
+            }
+
+            participants[index].target = corrected
+            corrections[index] = corrected
+        }
+
+        let count = corrections.compactMap { $0 }.count
+        guard count > 0 else {
+            return 0
+        }
+
+        runOnMainSync {
+            animator.retarget(frames: corrections, duration: duration, completion: completion)
+        }
+        return count
+    }
+
+    /**
+     Captures the given windows again, now that they show their real final rendering, and dissolves their proxies into those images.
+
+     Only an image whose pixel size matches the size the application accepted is used; a window whose application has not
+     finished redrawing keeps its old image and is reported back so the caller can try again.
+
+     - Returns: A semaphore signalled when the dissolve has finished, or `nil` if nothing was dissolved; the indices that received
+       a fresh image; and the indices whose captures cannot be verified and so are never dissolved mid-glide.
+     */
+    private func dissolveToFreshCaptures(
+        _ animator: SnapshotAnimating,
+        _ participants: [Participant],
+        indices: [Int],
+        duration: TimeInterval,
+        isFinalAttempt: Bool
+    ) -> (DispatchSemaphore?, Set<Int>, Set<Int>) {
+        // A capture that cannot reveal a stale surface could dissolve the proxy into old content; such windows blend into the
+        // real window at the handoff instead.
+        let allRequests = indices.map { WindowCaptureRequest(windowID: participants[$0].window.cgID(), frame: participants[$0].target) }
+        let unverifiable = Set(zip(indices, allRequests).filter { !captureIsVerifiable($0.1) }.map { $0.0 })
+        let indices = indices.filter { !unverifiable.contains($0) }
+        let requests = allRequests.filter { captureIsVerifiable($0) }
+
+        guard !indices.isEmpty else {
+            return (nil, [], unverifiable)
+        }
+
+        guard let captureImages = captureImages, let fresh = captureImages(requests), fresh.count == indices.count else {
+            if isFinalAttempt {
+                let pids = indices.map { String(participants[$0].pid) }.joined(separator: ", ")
+                logAnimation("Animated reflow: recapture failed for pids \(pids)")
+            }
+            return (nil, [], unverifiable)
+        }
+
+        var images = [CGImage?](repeating: nil, count: participants.count)
+        var dissolved = Set<Int>()
+        var stale: [String] = []
+        for (position, index) in indices.enumerated() {
+            let participant = participants[index]
+            let image = fresh[position]
+            let expectedWidth = participant.target.width * participant.pixelsPerPoint
+            let expectedHeight = participant.target.height * participant.pixelsPerPoint
+
+            // A few pixels either way is a border or rounding difference, not a stale surface.
+            let tolerance = max(4, 0.005 * max(expectedWidth, expectedHeight))
+            guard abs(CGFloat(image.width) - expectedWidth) <= tolerance, abs(CGFloat(image.height) - expectedHeight) <= tolerance else {
+                stale.append("pid \(participant.pid) got \(image.width)x\(image.height) expected \(Int(expectedWidth))x\(Int(expectedHeight))")
+                continue
+            }
+
+            images[index] = image
+            dissolved.insert(index)
+        }
+
+        if isFinalAttempt, !stale.isEmpty {
+            logAnimation("Animated reflow: window still not redrawn at handoff, keeping old image: \(stale.joined(separator: "; "))")
+        }
+
+        guard !dissolved.isEmpty else {
+            return (nil, [], unverifiable)
+        }
+
+        let dissolveDone = DispatchSemaphore(value: 0)
+        runOnMainSync {
+            animator.crossfade(images: images, duration: duration) {
+                dissolveDone.signal()
+            }
+        }
+        return (dissolveDone, dissolved, unverifiable)
+    }
+
+    /**
+     Leaves every real window at a valid tile, remembers where its proxy was last seen so a follow-up animation can start there,
+     and removes the overlay.
+
+     The reflow that cancelled this operation may return without doing anything, for instance when tiling was just turned off,
+     so the windows must not be left at mid-animation positions. Windows re-laid out in place are already at their tiles.
+     */
+    private func abandonSnapshotAnimation(_ animator: SnapshotAnimating, _ participants: inout [Participant]) -> SnapshotOutcome {
+        var currentFrames: [CGRect] = []
+        runOnMainSync {
+            currentFrames = animator.presentationFrames()
+        }
+
+        // Only windows still ours: a window thrown elsewhere mid-glide had its picture hidden where it was, and the screen
+        // that adopted it must not start that picture from a stale spot on this one.
+        var lastSeen: [CGWindowID: CGRect] = [:]
+        for index in participants.indices where index < currentFrames.count && owns(participants[index].window) {
+            if let frame = FrameInterpolation.readable(currentFrames[index]) {
+                lastSeen[participants[index].window.cgID()] = frame
+            }
+        }
+        AnimatingWindows.shared.recordLastSeenFrames(lastSeen, at: now())
+
+        writers.values.forEach { $0.discardPending() }
+        placeAtTargets(&participants)
+
+        runOnMainSync {
+            animator.cancel()
+        }
+
+        return .cancelled
+    }
+
+    /// Puts every window at its target's position, keeping whatever size it has; skips windows already there.
+    private func placeAtTargets(_ participants: inout [Participant]) {
+        issueTargetPositions(&participants)
+        waitForWriters(timeout: 0.3)
+    }
+
+    /// Moves every window whose position is not yet its target's; sizes stay whatever was last issued.
+    private func issueTargetPositions(_ participants: inout [Participant]) {
+        issue(&participants) { participant in
+            let frame = CGRect(origin: participant.target.origin, size: participant.lastIssued.size)
+            return frame == participant.lastIssued ? nil : (frame, false)
+        }
+    }
+
+    // MARK: - Accessibility strategy
+
+    /// Phase one: give every window its final size at its current position, so the glide only has to move it. Waits for every application so all windows start gliding together.
+    private func resizeInPlace(_ participants: inout [Participant]) {
+        issue(&participants) { participant in
+            participant.needsResize ? (CGRect(origin: participant.start.origin, size: participant.target.size), true) : nil
+        }
+        waitForWriters()
+        writers.values.forEach { $0.resetStatistics() }
+
+        // Applications may keep a different size than assigned; the glide must clamp and land with the size they kept. A
+        // window whose application has not applied the resize yet still reports its old size, so the size asked for
+        // stays in force until the resize lands.
+        for index in participants.indices where participants[index].resizable && writer(for: participants[index].pid).isIdle {
+            guard let accepted = FrameInterpolation.readable(participants[index].window.frame()) else {
+                continue
+            }
+            participants[index].lastIssued.size = accepted.size
+            participants[index].target.size = accepted.size
+        }
+    }
+
+    /// Phase two: drive the positions. Returns `false` if the operation was cancelled before the glide finished.
+    private func animate(_ participants: inout [Participant], resizeDuration: TimeInterval) -> Bool {
+        let animationStart = now()
+
+        while true {
+            let tickStart = now()
+            let elapsed = tickStart - animationStart
+
+            guard elapsed < duration else {
+                break
+            }
+
+            guard !isCancelled else {
+                abandonPendingWrites(&participants)
+                return false
+            }
+
+            let progress = FrameInterpolation.easeInOutSine(CGFloat(elapsed / duration))
+            issue(&participants) { participant in
+                let frame = participant.frame(at: progress)
+                return frame == participant.lastIssued ? nil : (frame, false)
+            }
+            tickCount += 1
+
+            let nextTick = tickStart + frameInterval
+            let tickEnd = now()
+            if nextTick > tickEnd {
+                sleep(nextTick - tickEnd)
+            }
+
+            if isCancelled {
+                abandonPendingWrites(&participants)
+                return false
+            }
+        }
+
+        let drained = waitForWriters()
+        logAccessibilityTiming(resizeDuration: resizeDuration, drained: drained)
+        return true
+    }
+
+    /// Drops frames not yet applied and leaves every window at its tile, since the reflow that cancelled this glide may not move it.
+    private func abandonPendingWrites(_ participants: inout [Participant]) {
+        writers.values.forEach { $0.discardPending() }
+        waitForWriters()
+        placeAtTargets(&participants)
+    }
+
+    // MARK: - Ownership
+
+    /**
+     Whether this operation may still move the window.
+
+     A window Amethyst has since relocated to another screen or Space, or that another screen's animation has claimed, was handed off: writing its old tile back would undo the move. Operations without a screen have no claims and own everything.
+     */
+    private func owns(_ window: Window) -> Bool {
+        guard let screenID = screenID else {
+            return true
+        }
+        return AnimatingWindows.shared.screenID(for: window.cgID()) == screenID
+    }
+
+    /// Finds participants handed off since the last check and hides their proxies so they do not glide on as ghosts.
+    private func retireHandedOffProxies(_ participants: [Participant], alreadyRetired: inout Set<Int>, animator: SnapshotAnimating) -> Set<Int> {
+        let retired = Set(participants.indices.filter { !alreadyRetired.contains($0) && !owns(participants[$0].window) })
+        guard !retired.isEmpty else {
+            return []
+        }
+        alreadyRetired.formUnion(retired)
+        runOnMainSync {
+            animator.hide(indices: retired.sorted())
+        }
+        return retired
+    }
+
+    // MARK: - Writers
+
+    /**
+     Sends every window the frame `frame` chooses for it, batched per application, and records it as the window's last issued frame.
+
+     - Parameter frame: The frame to issue and whether it includes the size, or `nil` to leave the window alone.
+     - Returns: The indices of the windows that were sent a frame.
+     */
+    @discardableResult
+    private func issue(_ participants: inout [Participant], frame: (Participant) -> (frame: CGRect, includingSize: Bool)?) -> [Int] {
+        var writes: Writes = [:]
+        var issued: [Int] = []
+
+        for index in participants.indices {
+            guard let write = frame(participants[index]) else {
+                continue
+            }
+
+            writes[participants[index].pid, default: [:]][index] = .init(window: participants[index].window, frame: write.frame, includingSize: write.includingSize)
+            participants[index].lastIssued = write.frame
+            issued.append(index)
+        }
+
+        dispatch(writes)
+        return issued
+    }
+
+    /// Issues the writes, leaving out windows this operation no longer owns.
+    private func dispatch(_ writes: Writes) {
+        for (pid, applicationWrites) in writes {
+            let owned = applicationWrites.filter { owns($0.value.window) }
+            guard !owned.isEmpty else {
+                continue
+            }
+            writer(for: pid).write(owned)
+        }
+    }
+
+    private func writer(for pid: pid_t) -> ApplicationFrameWriter<Window> {
+        if let writer = writers[pid] {
+            return writer
+        }
+
+        let writer = ApplicationFrameWriter<Window>(
+            pid: pid,
+            group: writerGroup,
+            inline: writesInline,
+            now: now,
+            beginWrite: { [weak self] window in self?.beginWrite(to: window) ?? false },
+            endWrite: { [weak self] window in self?.endWrite(to: window) }
+        )
+        writers[pid] = writer
+        return writer
+    }
+
+    /// Registers a frame about to land on the window, unless the window is no longer this operation's to move.
+    private func beginWrite(to window: Window) -> Bool {
+        guard let screenID = screenID else {
+            return true
+        }
+        return AnimatingWindows.shared.beginWrite(window.cgID(), for: screenID)
+    }
+
+    private func endWrite(to window: Window) {
+        guard screenID != nil else {
+            return
+        }
+        AnimatingWindows.shared.endWrite(window.cgID())
+    }
+
+    /// Waits for every application to apply its newest frame. Returns `false` if a slow application timed out.
+    @discardableResult
+    private func waitForWriters(timeout: TimeInterval? = nil) -> Bool {
+        let timeout = timeout ?? writerDrainTimeout
+        return writerGroup.wait(timeout: .now() + timeout) == .success
+    }
+
+    // MARK: - Logging
+
+    private func logSnapshotTiming(windowCount: Int, timings: SnapshotTimings) {
+        let mode = timings.inPlace ? "in place" : "parked"
+        let capture = Int(timings.captureDuration * 1000)
+        let park = Int(timings.parkDuration * 1000)
+        let place = Int(timings.placeDuration * 1000)
+        let firstRefinement = Int((timings.firstRefinement ?? -0.001) * 1000)
+        let glide = String(format: "%.2f", duration)
+        logAnimation(
+            "Animated reflow (snapshot, \(mode)): \(windowCount) windows, capture \(capture)ms, park \(park)ms, glide \(glide)s, place \(place)ms, "
+                + "\(timings.corrected) size-corrected, \(timings.recaptured) recaptured, first refinement at \(firstRefinement)ms"
+        )
+    }
+
+    private func logAccessibilityTiming(resizeDuration: TimeInterval, drained: Bool) {
+        guard tickCount > 0 else {
+            return
+        }
+
+        let framesPerSecond = Int((Double(tickCount) / duration).rounded())
+        let resizeMilliseconds = Int(resizeDuration * 1000)
+        let slowest = writers.values
+            .map { (pid: $0.pid, statistics: $0.statisticsSnapshot()) }
+            .max { $0.statistics.averageWriteTime < $1.statistics.averageWriteTime }
+        let slowestPid = slowest?.pid ?? 0
+        let slowestAverageMilliseconds = Int((slowest?.statistics.averageWriteTime ?? 0) * 1000)
+        let slowestApplied = slowest?.statistics.applied ?? 0
+        let slowestRequested = slowest?.statistics.requested ?? 0
+        let timeoutNote = drained ? "" : "; timed out waiting for it"
+        let glide = String(format: "%.2f", duration)
+
+        logAnimation(
+            "Animated reflow (accessibility): resize \(resizeMilliseconds)ms, then \(tickCount) ticks over \(glide)s (\(framesPerSecond) fps); "
+                + "slowest app pid \(slowestPid) averaged \(slowestAverageMilliseconds)ms per write and showed \(slowestApplied) of \(slowestRequested) frames\(timeoutNote)"
+        )
+    }
+}

--- a/Amethyst/Layout/BackdropCapture.swift
+++ b/Amethyst/Layout/BackdropCapture.swift
@@ -1,0 +1,200 @@
+//
+//  BackdropCapture.swift
+//  Amethyst
+//
+//  Created by Don Patterson on 9/8/26.
+//  Copyright © 2026 Ian Ynda-Hummel. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+@preconcurrency import ScreenCaptureKit
+
+/**
+ Captures a display with the animating windows removed.
+
+ The snapshot animation shows this frozen backdrop underneath the sliding window images, which lets the real windows be moved to their destinations and re-laid out behind it, out of sight but still on a display where the window server keeps rendering them. That is what makes it possible to capture each window again at its true final size mid-animation.
+ */
+@available(macOS 14.0, *)
+final class BackdropCapturer: @unchecked Sendable {
+    static let shared = BackdropCapturer()
+
+    /// Guards `content` and `fetch`; the fetch task updates them without blocking.
+    private let stateQueue = DispatchQueue(label: "Amethyst.BackdropCapturer.state")
+    private var content: SCShareableContent?
+    private var fetch: Task<SCShareableContent?, Never>?
+
+    /// Fetches the current window list in the background. Exclusion needs ScreenCaptureKit's own window objects, which take tens of milliseconds to enumerate.
+    func refresh() {
+        _ = beginFetch()
+    }
+
+    /// The fetch already under way, or a new one. There is never more than one at a time, and whichever it is caches its result when it completes, whether or not anyone is still waiting for it.
+    private func beginFetch() -> Task<SCShareableContent?, Never> {
+        return stateQueue.sync {
+            if let fetch = fetch {
+                return fetch
+            }
+
+            let fetch = Task { [weak self] () -> SCShareableContent? in
+                let content = try? await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+                self?.stateQueue.async {
+                    if let content = content {
+                        self?.content = content
+                    }
+                    self?.fetch = nil
+                }
+                return content
+            }
+            self.fetch = fetch
+            return fetch
+        }
+    }
+
+    /**
+     The window list, fetched now if the cached one is missing any of the given windows, so that a newly opened window or the first reflow after launch never has to do without a backdrop. Blocks for at most `timeout`.
+     */
+    private func shareableContent(including windowIDs: [CGWindowID], timeout: TimeInterval) -> SCShareableContent? {
+        if let cached = stateQueue.sync(execute: { self.content }), contains(cached, windowIDs) {
+            return cached
+        }
+
+        let fetch = beginFetch()
+        let finished = DispatchSemaphore(value: 0)
+        let result = Box<SCShareableContent>()
+
+        Task {
+            result.value = await fetch.value
+            finished.signal()
+        }
+
+        guard finished.wait(timeout: .now() + timeout) == .success else {
+            return nil
+        }
+
+        return result.value
+    }
+
+    private func contains(_ content: SCShareableContent, _ windowIDs: [CGWindowID]) -> Bool {
+        let known = Set(content.windows.map { $0.windowID })
+        return windowIDs.allSatisfy { known.contains($0) }
+    }
+
+    /**
+     Captures the display containing `screenFrame` without the given windows, blocking the calling thread for at most twice `timeout` (window list, then capture).
+
+     - Parameters:
+         - screenFrame: The screen's frame in the flipped coordinates Amethyst uses.
+         - windowIDs: Windows to leave out.
+     - Returns: The backdrop image at the display's native pixel size, or `nil` if it could not be produced.
+     */
+    func captureBackdrop(screenFrame: CGRect, excluding windowIDs: [CGWindowID], timeout: TimeInterval = 0.5) -> CGImage? {
+        guard let content = shareableContent(including: windowIDs, timeout: timeout) else {
+            return nil
+        }
+
+        guard let display = ActiveDisplays.mostOverlapping(screenFrame, among: content.displays, bounds: { CGDisplayBounds($0.displayID) }) else {
+            return nil
+        }
+
+        let excluded = content.windows.filter { windowIDs.contains($0.windowID) }
+        guard excluded.count == windowIDs.count else {
+            return nil
+        }
+
+        let pixelWidth = CGDisplayCopyDisplayMode(display.displayID)?.pixelWidth ?? display.width
+        let scale = display.width > 0 ? CGFloat(pixelWidth) / CGFloat(display.width) : 1
+
+        let configuration = SCStreamConfiguration()
+        configuration.width = Int(CGFloat(display.width) * scale)
+        configuration.height = Int(CGFloat(display.height) * scale)
+        configuration.showsCursor = false
+        configuration.captureResolution = .best
+
+        let filter = SCContentFilter(display: display, excludingWindows: excluded)
+        let finished = DispatchSemaphore(value: 0)
+        let result = Box<CGImage>()
+
+        Task {
+            result.value = try? await SCScreenshotManager.captureImage(contentFilter: filter, configuration: configuration)
+            finished.signal()
+        }
+
+        guard finished.wait(timeout: .now() + timeout) == .success else {
+            return nil
+        }
+
+        return result.value
+    }
+
+    /**
+     Captures whole windows regardless of which displays they lie on, at the pixel density of the display each is mostly on.
+
+     - Returns: One image per request, in order, or `nil` if any window is unknown or fails to capture within `timeout`.
+     */
+    func captureWindows(_ requests: [WindowCaptureRequest], timeout: TimeInterval = 0.5) -> [CGImage]? {
+        guard !requests.isEmpty, let content = shareableContent(including: requests.map { $0.windowID }, timeout: timeout) else {
+            return nil
+        }
+
+        let windowsByID = Dictionary(content.windows.map { ($0.windowID, $0) }, uniquingKeysWith: { first, _ in first })
+
+        let finished = DispatchSemaphore(value: 0)
+        let results = Box<[Int: CGImage]>()
+        results.value = [:]
+
+        for (index, request) in requests.enumerated() {
+            guard let window = windowsByID[request.windowID] else {
+                return nil
+            }
+
+            let scale = pixelScale(forWindowFrame: request.frame, among: content.displays)
+            let width = request.frame.width * scale
+            let height = request.frame.height * scale
+            guard width.isFinite, height.isFinite, width >= 1, height >= 1 else {
+                return nil
+            }
+
+            let configuration = SCStreamConfiguration()
+            configuration.width = Int(width)
+            configuration.height = Int(height)
+            configuration.showsCursor = false
+            configuration.captureResolution = .best
+            let filter = SCContentFilter(desktopIndependentWindow: window)
+
+            Task { [stateQueue] in
+                let image = try? await SCScreenshotManager.captureImage(contentFilter: filter, configuration: configuration)
+                // Record on the state queue and signal from there, so the waiting thread sees the write once it wakes.
+                stateQueue.async {
+                    if let image = image {
+                        results.value?[index] = image
+                    }
+                    finished.signal()
+                }
+            }
+        }
+
+        let deadline = DispatchTime.now() + timeout
+        for _ in requests where finished.wait(timeout: deadline) != .success {
+            return nil
+        }
+
+        let images: [CGImage] = stateQueue.sync { requests.indices.compactMap { results.value?[$0] } }
+        return images.count == requests.count ? images : nil
+    }
+
+    /// Pixels per point of the display a window is mostly on.
+    private func pixelScale(forWindowFrame frame: CGRect, among displays: [SCDisplay]) -> CGFloat {
+        guard let display = ActiveDisplays.mostOverlapping(frame, among: displays, bounds: { CGDisplayBounds($0.displayID) }),
+              let mode = CGDisplayCopyDisplayMode(display.displayID) else {
+            return 1
+        }
+        let width = CGDisplayBounds(display.displayID).width
+        return width > 0 ? CGFloat(mode.pixelWidth) / width : 1
+    }
+
+    /// Hands a value from an async task back to the waiting thread; the semaphore orders the accesses.
+    private final class Box<Value>: @unchecked Sendable {
+        var value: Value?
+    }
+}

--- a/Amethyst/Layout/ReflowOperation.swift
+++ b/Amethyst/Layout/ReflowOperation.swift
@@ -9,6 +9,19 @@
 import Foundation
 import Silica
 
+/**
+ Runs `block` synchronously on the main thread.
+
+ Frame application happens on the main thread, but reflow operations execute on a background queue. Executing inline when already on main means callers (including tests that drive operations directly) never deadlock.
+ */
+func runOnMainSync(_ block: () -> Void) {
+    if Thread.isMainThread {
+        block()
+    } else {
+        DispatchQueue.main.sync(execute: block)
+    }
+}
+
 /// Possible dimensions without constraints.
 enum UnconstrainedDimension: Int {
     /// The dimension along the x-axis.
@@ -93,12 +106,21 @@ struct WindowSet<Window: WindowType> {
         return isWindowWithIDFloating(window.id)
     }
 
-    func perform(frameAssignment: FrameAssignment<Window>) {
+    /// Resolves the live window for a frame assignment, or `nil` if the window is gone, inactive, or floating.
+    func window(for frameAssignment: FrameAssignment<Window>) -> Window? {
         guard let window = windowForID(frameAssignment.window.id) else {
-            return
+            return nil
         }
 
         guard isWindowWithIDActive(frameAssignment.window.id), !isWindowWithIDFloating(frameAssignment.window.id) else {
+            return nil
+        }
+
+        return window
+    }
+
+    func perform(frameAssignment: FrameAssignment<Window>) {
+        guard let window = window(for: frameAssignment) else {
             return
         }
 
@@ -142,36 +164,41 @@ struct FrameAssignment<Window: WindowType> {
     /// If `true`, then  window margins won't be applied
     let disableWindowMargins: Bool
 
-    init(frame: CGRect, window: LayoutWindow<Window>, screenFrame: CGRect, resizeRules: ResizeRules) {
+    /// The settings the final frame applies: window margins and minimum sizes. Tests pass a blank configuration so their frames do not depend on the preferences of whoever runs them.
+    let configuration: UserConfiguration
+
+    init(frame: CGRect, window: LayoutWindow<Window>, screenFrame: CGRect, resizeRules: ResizeRules, configuration: UserConfiguration = .shared) {
         self.frame = frame
         self.window =  window
         self.screenFrame = screenFrame
         self.resizeRules = resizeRules
         self.disableWindowMargins = false
+        self.configuration = configuration
     }
 
-    init(frame: CGRect, window: LayoutWindow<Window>, screenFrame: CGRect, resizeRules: ResizeRules, disableWindowMargins: Bool) {
+    init(frame: CGRect, window: LayoutWindow<Window>, screenFrame: CGRect, resizeRules: ResizeRules, disableWindowMargins: Bool, configuration: UserConfiguration = .shared) {
         self.frame = frame
         self.window =  window
         self.screenFrame = screenFrame
         self.resizeRules = resizeRules
         self.disableWindowMargins = disableWindowMargins
+        self.configuration = configuration
     }
 
     /// The final frame is the desired frame, but transformed to provide desired padding
     var finalFrame: CGRect {
         var ret = frame
-        let padding = floor(UserConfiguration.shared.windowMarginSize() / 2)
+        let padding = floor(configuration.windowMarginSize() / 2)
 
-        if UserConfiguration.shared.windowMargins() && !disableWindowMargins {
+        if configuration.windowMargins() && !disableWindowMargins {
             ret.origin.x += padding
             ret.origin.y += padding
             ret.size.width -= 2 * padding
             ret.size.height -= 2 * padding
         }
 
-        let windowMinimumWidth = UserConfiguration.shared.windowMinimumWidth()
-        let windowMinimumHeight = UserConfiguration.shared.windowMinimumHeight()
+        let windowMinimumWidth = configuration.windowMinimumWidth()
+        let windowMinimumHeight = configuration.windowMinimumHeight()
 
         if windowMinimumWidth > ret.size.width {
             ret.origin.x -= ((windowMinimumWidth - ret.size.width) / 2)
@@ -204,6 +231,29 @@ struct FrameAssignment<Window: WindowType> {
         return resizeRules.isMain ? implied : 1 - implied
     }
 
+    /**
+     The frame shifted, if this is the focused window, so that it lies within the screen.
+
+     Applications may keep a larger size than assigned; the focused window must remain fully on screen regardless, so its origin
+     is moved to fit. This is the one rule every path that positions the focused window shares: the settle pass, the animated
+     glide, and the corrections that follow an application's actual size.
+     */
+    func keepingFocusedWindowOnScreen(_ frame: CGRect) -> CGRect {
+        guard window.isFocused else {
+            return frame
+        }
+
+        return keptOnScreen(frame)
+    }
+
+    /// The frame shifted so that it lies within the screen, whichever window it is for. The settle applies this on the window's live focus rather than the layout-time snapshot, which may be stale by the time an animation ends.
+    func keptOnScreen(_ frame: CGRect) -> CGRect {
+        var kept = frame
+        kept.origin.x = max(screenFrame.minX, min(frame.origin.x, screenFrame.maxX - frame.width))
+        kept.origin.y = max(screenFrame.minY, min(frame.origin.y, screenFrame.maxY - frame.height))
+        return kept
+    }
+
     /// Perform the actual application of the frame to the window
     func perform(withWindow window: Window) {
         var finalFrame = self.finalFrame
@@ -215,7 +265,7 @@ struct FrameAssignment<Window: WindowType> {
             // Just resize the window first to see what the dimensions end up being
             // Sometimes applications have internal window requirements that are not exposed to us directly
             finalFrame.origin = window.frame().origin
-            DispatchQueue.main.sync {
+            runOnMainSync {
                 window.setFrame(finalFrame, withThreshold: CGSize(width: 1, height: 1))
             }
 
@@ -224,13 +274,12 @@ struct FrameAssignment<Window: WindowType> {
                 width: max(window.frame().width, finalFrame.width),
                 height: max(window.frame().height, finalFrame.height)
             )
-            finalOrigin.x = max(screenFrame.minX, min(finalOrigin.x, screenFrame.maxX - finalFrame.size.width))
-            finalOrigin.y = max(screenFrame.minY, min(finalOrigin.y, screenFrame.maxY - finalFrame.size.height))
+            finalOrigin = keptOnScreen(CGRect(origin: finalOrigin, size: finalFrame.size)).origin
         }
 
         // Move the window to its final frame
         finalFrame.origin = finalOrigin
-        DispatchQueue.main.sync {
+        runOnMainSync {
             window.setFrame(finalFrame, withThreshold: CGSize(width: 1, height: 1))
         }
     }

--- a/Amethyst/Layout/WindowCapture.swift
+++ b/Amethyst/Layout/WindowCapture.swift
@@ -1,0 +1,245 @@
+//
+//  WindowCapture.swift
+//  Amethyst
+//
+//  Created by Don Patterson on 9/8/26.
+//  Copyright © 2026 Ian Ynda-Hummel. All rights reserved.
+//
+
+import Cocoa
+
+/**
+ Minimal bridge to the two private SkyLight (window server) functions the snapshot animation needs.
+
+ Both are resolved at runtime with `dlsym`, so a macOS release that drops or renames them makes `isAvailable` false and the animation silently falls back to moving the real windows. Nothing else in the snapshot animation is private.
+ */
+enum SkyLight {
+    private typealias MainConnectionIDFunction = @convention(c) () -> Int32
+    private typealias CaptureWindowListFunction = @convention(c) (Int32, UnsafeMutablePointer<UInt32>, Int32, UInt32) -> Unmanaged<CFArray>?
+
+    private struct Functions {
+        let mainConnectionID: MainConnectionIDFunction
+        let captureWindowList: CaptureWindowListFunction
+    }
+
+    private static let functions: Functions? = {
+        guard
+            let handle = dlopen("/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight", RTLD_NOW),
+            let connectionSymbol = dlsym(handle, "SLSMainConnectionID"),
+            let captureSymbol = dlsym(handle, "SLSHWCaptureWindowList")
+        else {
+            return nil
+        }
+
+        return Functions(
+            mainConnectionID: unsafeBitCast(connectionSymbol, to: MainConnectionIDFunction.self),
+            captureWindowList: unsafeBitCast(captureSymbol, to: CaptureWindowListFunction.self)
+        )
+    }()
+
+    /// The option bits yabai passes to `SLSHWCaptureWindowList`; they yield a full-resolution image of just the window.
+    private static let captureOptions: UInt32 = (1 << 11) | (1 << 8)
+
+    /// Whether both private functions resolved on this system.
+    static var isAvailable: Bool {
+        return functions != nil
+    }
+
+    /**
+     Captures the current contents of the given windows.
+
+     Requires the Screen Recording permission; without it the window server returns nothing. Each window is captured separately because a single call with several IDs yields one composite image, not one per window. The captures run concurrently, since each is a synchronous round trip to the window server of roughly 15ms.
+
+     - Returns: One image per window ID, in the same order, or `nil` if any capture failed.
+     */
+    static func captureImages(for windowIDs: [CGWindowID]) -> [CGImage]? {
+        guard let functions = functions, !windowIDs.isEmpty else {
+            return nil
+        }
+
+        let connection = functions.mainConnectionID()
+        var images = [CGImage?](repeating: nil, count: windowIDs.count)
+        let lock = NSLock()
+
+        DispatchQueue.concurrentPerform(iterations: windowIDs.count) { index in
+            let image = captureImage(of: windowIDs[index], connection: connection, functions: functions)
+            lock.lock()
+            images[index] = image
+            lock.unlock()
+        }
+
+        let captured = images.compactMap { $0 }
+        return captured.count == windowIDs.count ? captured : nil
+    }
+
+    private static func captureImage(of windowID: CGWindowID, connection: Int32, functions: Functions) -> CGImage? {
+        var identifier = UInt32(windowID)
+
+        guard let array = functions.captureWindowList(connection, &identifier, 1, captureOptions)?.takeRetainedValue(), CFArrayGetCount(array) == 1 else {
+            return nil
+        }
+
+        // The array owns the image; keep it alive until Swift holds its own strong reference to the image.
+        return withExtendedLifetime(array) { () -> CGImage? in
+            guard let value = CFArrayGetValueAtIndex(array, 0) else {
+                return nil
+            }
+            return Unmanaged<CGImage>.fromOpaque(value).takeUnretainedValue()
+        }
+    }
+}
+
+/// A window to capture and where it currently is, in the flipped coordinates Accessibility uses.
+struct WindowCaptureRequest {
+    let windowID: CGWindowID
+    let frame: CGRect
+}
+
+/// The displays the window server currently drives, and the one rule for deciding which of them a rectangle belongs to.
+enum ActiveDisplays {
+    static func identifiers() -> [CGDirectDisplayID] {
+        var displayCount: UInt32 = 0
+        CGGetActiveDisplayList(0, nil, &displayCount)
+        var displays = [CGDirectDisplayID](repeating: 0, count: Int(displayCount))
+        CGGetActiveDisplayList(displayCount, &displays, &displayCount)
+        return displays
+    }
+
+    /// The bounds of every active display, in the flipped coordinates Accessibility uses.
+    static func bounds() -> [CGRect] {
+        return identifiers().map { CGDisplayBounds($0) }
+    }
+
+    /// The candidate whose bounds overlap `rect` most, or `nil` if none overlaps it at all.
+    static func mostOverlapping<Candidate>(_ rect: CGRect, among candidates: [Candidate], bounds: (Candidate) -> CGRect) -> Candidate? {
+        func overlap(_ candidate: Candidate) -> CGFloat {
+            let intersection = bounds(candidate).intersection(rect)
+            return intersection.isNull ? 0 : intersection.width * intersection.height
+        }
+        guard let best = candidates.max(by: { overlap($0) < overlap($1) }), overlap(best) > 0 else {
+            return nil
+        }
+        return best
+    }
+}
+
+/**
+ Captures full images of windows, choosing the mechanism per window.
+
+ The window server renders only the part of a window that lies on a display, and for a window straddling two displays it may hand back the part on either one. SkyLight's capture is fast but inherits that limit, so it is used for windows lying entirely within the display being animated, and ScreenCaptureKit's desktop-independent window capture, slower but complete, is used for windows that overhang a display edge, typically because their minimum size exceeds their tile.
+ */
+enum WindowImageCapture {
+    /// The bounds of the display among `bounds` that overlaps `screenFrame` most, or `nil` if none does.
+    static func displayBounds(containing screenFrame: CGRect, among bounds: [CGRect]) -> CGRect? {
+        return ActiveDisplays.mostOverlapping(screenFrame, among: bounds) { $0 }
+    }
+
+    /// The bounds of the active display containing `screenFrame`.
+    static func activeDisplayBounds(containing screenFrame: CGRect) -> CGRect? {
+        return displayBounds(containing: screenFrame, among: ActiveDisplays.bounds())
+    }
+
+    /**
+     Whether a capture of this window reports the window's real surface size, so that a capture taken before the application has
+     redrawn can be told apart from a fresh one. SkyLight captures do; ScreenCaptureKit scales its output to the requested size
+     and so never reveals a stale surface.
+     */
+    static func isCaptureVerifiable(_ request: WindowCaptureRequest, displayBounds: CGRect?) -> Bool {
+        guard let displayBounds = displayBounds else {
+            return true
+        }
+        return displayBounds.contains(request.frame)
+    }
+
+    /**
+     Captures every requested window in full.
+
+     - Parameters:
+         - requests: The windows and their current frames.
+         - displayBounds: The display being animated. Windows not entirely within it go through ScreenCaptureKit.
+     - Returns: One image per request, in order, or `nil` if any capture failed.
+     */
+    static func captureImages(for requests: [WindowCaptureRequest], displayBounds: CGRect?) -> [CGImage]? {
+        var images = [CGImage?](repeating: nil, count: requests.count)
+        var overhanging: [Int] = []
+        var contained: [Int] = []
+
+        for (index, request) in requests.enumerated() {
+            if let displayBounds = displayBounds, !displayBounds.contains(request.frame) {
+                overhanging.append(index)
+            } else {
+                contained.append(index)
+            }
+        }
+
+        if !contained.isEmpty {
+            guard let captured = SkyLight.captureImages(for: contained.map { requests[$0].windowID }) else {
+                return nil
+            }
+            for (position, index) in contained.enumerated() {
+                images[index] = captured[position]
+            }
+        }
+
+        if !overhanging.isEmpty {
+            var captured: [CGImage]?
+            if #available(macOS 14.0, *) {
+                captured = BackdropCapturer.shared.captureWindows(overhanging.map { requests[$0] })
+            }
+            // Without ScreenCaptureKit the clipped image is still better than none.
+            if captured == nil {
+                captured = SkyLight.captureImages(for: overhanging.map { requests[$0].windowID })
+            }
+            guard let captured = captured else {
+                return nil
+            }
+            for (position, index) in overhanging.enumerated() {
+                images[index] = captured[position]
+            }
+        }
+
+        let result = images.compactMap { $0 }
+        return result.count == requests.count ? result : nil
+    }
+}
+
+/// The Screen Recording permission that window capture depends on.
+enum ScreenCapturePermission {
+    private static var hasRequested = false
+
+    static var isGranted: Bool {
+        return CGPreflightScreenCaptureAccess()
+    }
+
+    /**
+     Shows the system permission prompt at most once per launch. macOS applies a new grant on the next launch of the app.
+
+     - Returns: `true` if the prompt was requested by this call.
+     */
+    @discardableResult
+    static func requestOnce() -> Bool {
+        guard !hasRequested else {
+            return false
+        }
+
+        hasRequested = true
+        CGRequestScreenCaptureAccess()
+        return true
+    }
+
+    /// Remembers that Amethyst's own hint about the permission has been shown. macOS prompts only once ever, and the hint is shown once as well.
+    static let hintShownKey = "screen-recording-hint-shown"
+
+    /// How long the hint stays up, long enough to read a sentence.
+    static let hintDuration: TimeInterval = 4
+
+    /// Whether the hint should be shown now, recording that it was. `true` once per `defaults` store.
+    static func takeHintOpportunity(defaults: UserDefaults = .standard) -> Bool {
+        guard !defaults.bool(forKey: hintShownKey) else {
+            return false
+        }
+
+        defaults.set(true, forKey: hintShownKey)
+        return true
+    }
+}

--- a/Amethyst/Managers/ScreenManager.swift
+++ b/Amethyst/Managers/ScreenManager.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Ian Ynda-Hummel. All rights reserved.
 //
 
+import AppKit
 import Foundation
 import Silica
 
@@ -44,7 +45,7 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
 
     private let reflowOperationDispatchQueue = DispatchQueue(
         label: "ScreenManager.reflowOperationQueue",
-        qos: .utility,
+        qos: .userInitiated,
         attributes: [],
         autoreleaseFrequency: .inherit,
         target: nil
@@ -88,6 +89,11 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
         layouts = LayoutType.layoutsWithConfiguration(userConfiguration)
 
         reflowOperationQueue.underlyingQueue = reflowOperationDispatchQueue
+
+        // Warm the window list the snapshot animation's backdrop needs so the first reflow does not have to wait for it.
+        if #available(macOS 14.0, *), userConfiguration.shouldAnimateWindowMovement(), ScreenCapturePermission.isGranted {
+            BackdropCapturer.shared.refresh()
+        }
     }
 
     init(from decoder: Decoder) throws {
@@ -290,12 +296,59 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
             }
         }
 
+        // Either animate every assignment together in one operation or apply them individually
+        let operations: [Operation]
+        if userConfiguration.shouldAnimateWindowMovement() {
+            // Smooth snapshot animation needs the private capture call and the Screen Recording permission; otherwise the real windows are moved.
+            let canSnapshot = SkyLight.isAvailable && ScreenCapturePermission.isGranted
+            if !canSnapshot && SkyLight.isAvailable {
+                // macOS is asked every launch; the hint is shown once, for long enough to read.
+                ScreenCapturePermission.requestOnce()
+                if ScreenCapturePermission.takeHintOpportunity() {
+                    displayCustomHUD(title: "Allow Screen Recording for smooth window animation", duration: ScreenCapturePermission.hintDuration)
+                }
+            }
+
+            // Windows lying within this display are captured through SkyLight; ones overhanging its edge go through ScreenCaptureKit, which returns them whole.
+            let displayBounds = WindowImageCapture.activeDisplayBounds(containing: screen.frameIncludingDockAndMenu())
+            let captureImages: (([WindowCaptureRequest]) -> [CGImage]?)? = canSnapshot
+                ? { requests in WindowImageCapture.captureImages(for: requests, displayBounds: displayBounds) }
+                : nil
+            let captureIsVerifiable: (WindowCaptureRequest) -> Bool = { request in
+                WindowImageCapture.isCaptureVerifiable(request, displayBounds: displayBounds)
+            }
+            let makeSnapshotAnimator: (() -> SnapshotAnimating)? = canSnapshot ? { ReflowAnimationOverlay() } : nil
+
+            // A backdrop lets windows re-lay out in place and their proxies dissolve into fresh captures. The capturer waits
+            // for the window list it needs if the cached one is stale, and refreshes it here for the next reflow.
+            var captureBackdrop: ((CGRect, [CGWindowID]) -> CGImage?)?
+            if canSnapshot, #available(macOS 14.0, *) {
+                let capturer = BackdropCapturer.shared
+                captureBackdrop = { screenFrame, windowIDs in capturer.captureBackdrop(screenFrame: screenFrame, excluding: windowIDs) }
+                capturer.refresh()
+            }
+
+            operations = [
+                AnimatedReflowOperation(
+                    frameAssignmentOperations: frameAssignments,
+                    duration: userConfiguration.windowAnimationDuration(),
+                    captureImages: captureImages,
+                    captureIsVerifiable: captureIsVerifiable,
+                    captureBackdrop: captureBackdrop,
+                    makeSnapshotAnimator: makeSnapshotAnimator,
+                    screenID: screen.screenID()
+                )
+            ]
+        } else {
+            operations = frameAssignments
+        }
+
         // The completion should be dependent on all assignments finishing
-        frameAssignments.forEach { completeOperation.addDependency($0) }
+        operations.forEach { completeOperation.addDependency($0) }
 
         // Start the operation
         delegate?.onReflowInitiation()
-        reflowOperationQueue.addOperations(frameAssignments, waitUntilFinished: false)
+        reflowOperationQueue.addOperations(operations, waitUntilFinished: false)
         reflowOperationQueue.addOperation(completeOperation)
     }
 
@@ -394,7 +447,7 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
         layoutNameWindowController.close()
     }
 
-    func displayCustomHUD(title: String, description: String = "") {
+    func displayCustomHUD(title: String, description: String = "", duration: TimeInterval = 0.6) {
         guard let screen = screen else {
             return
         }
@@ -405,7 +458,7 @@ final class ScreenManager<Delegate: ScreenManagerDelegate>: NSObject, Codable {
 
         defer {
             NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(hideLayoutHUD(_:)), object: nil)
-            perform(#selector(hideLayoutHUD(_:)), with: nil, afterDelay: 0.6)
+            perform(#selector(hideLayoutHUD(_:)), with: nil, afterDelay: duration)
         }
 
         guard let layoutNameWindow = layoutNameWindowController.window as? LayoutNameWindow else {

--- a/Amethyst/Managers/WindowManager.swift
+++ b/Amethyst/Managers/WindowManager.swift
@@ -374,6 +374,14 @@ extension WindowManager {
         }
     }
 
+    func displayAnimateWindowsHUD() {
+        let state = userConfiguration.animatesWindowMovement() ? "On" : "Off"
+
+        for screenManager in screens.screenManagers {
+            screenManager.displayCustomHUD(title: "Window Animation: \(state)")
+        }
+    }
+
     func add(runningApplication: NSRunningApplication) {
         switch runningApplication.isManageable {
         case .manageable:
@@ -809,6 +817,12 @@ extension WindowManager: ApplicationObservationDelegate {
             return
         }
 
+        // An animation's own writes generate move notifications for the windows it is moving; those are not user drags.
+        // Notifications about any other window are gestures and go through.
+        guard !AnimatingWindows.shared.isAnimating(window.cgID()) else {
+            return
+        }
+
         guard let screen = window.screen(), activeWindows(on: screen).contains(window) else {
             return
         }
@@ -836,6 +850,11 @@ extension WindowManager: ApplicationObservationDelegate {
 
     func application(_ application: AnyApplication<Application>, didResizeWindow window: Window) {
         guard userConfiguration.mouseResizesWindows() else {
+            return
+        }
+
+        // Intermediate animation frames of a window being animated are not user-driven main pane ratios.
+        guard !AnimatingWindows.shared.isAnimating(window.cgID()) else {
             return
         }
 
@@ -915,6 +934,24 @@ extension WindowManager {
 
 // MARK: Window Transition
 extension WindowManager: WindowTransitionTarget {
+    /**
+     Puts a window an animation had parked beyond every display back where that animation was taking it.
+
+     A move to another screen or Space must start from a window that is actually on screen: Silica moves a window between Spaces by dragging it, which cannot take hold of one parked out of sight, and a window left there would belong to no screen and never be tiled again.
+     */
+    private func unpark(_ window: Window, handedOff targets: [CGWindowID: CGRect]) {
+        guard let target = targets[window.cgID()] else {
+            return
+        }
+
+        let frame = window.frame()
+        guard !ActiveDisplays.bounds().contains(where: { $0.intersects(frame) }) else {
+            return
+        }
+
+        window.setAnimationFrame(CGRect(origin: target.origin, size: frame.size), includingSize: false)
+    }
+
     func executeTransition(_ transition: WindowTransition<Window>) {
         switch transition {
         case let .switchWindows(window, otherWindow):
@@ -926,6 +963,8 @@ extension WindowManager: WindowTransitionTarget {
             markAllScreensForReflow()
         case let .moveWindowToScreen(window, screen):
             let currentScreen = window.screen()
+            // A deliberate move: any animation still moving this window must let go, and the new screen adopts it at once.
+            unpark(window, handedOff: AnimatingWindows.shared.handOff([window.cgID()]))
             window.moveScaled(to: screen)
             if currentScreen != nil {
                 distributeEventToScreen(screen, change: .remove(window: window))
@@ -948,6 +987,7 @@ extension WindowManager: WindowTransitionTarget {
             }
             distributeEventToScreen(screen, change: .remove(window: window))
             eventQueue.append(PendingEvent(screen: targetScreen, event: .add(window: window)))
+            unpark(window, handedOff: AnimatingWindows.shared.handOff([window.cgID()]))
             window.move(toSpaceAtIndex: UInt(spaceIndex + 1))
             if targetScreen.screenID() != screen.screenID() {
                 // necessary to set frame here as window is expected to be at origin relative to targe screen when moved, can be improved.

--- a/Amethyst/Managers/Windows.swift
+++ b/Amethyst/Managers/Windows.swift
@@ -28,7 +28,25 @@ extension WindowManager {
         }
 
         func windows(onScreen screen: Screen) -> [Window] {
-            return windows.filter { $0.screen() == screen }
+            let attachedScreenIDs = Windows.attachedScreenIDs()
+            return windows.filter { isWindow($0, on: screen, attachedScreenIDs: attachedScreenIDs) }
+        }
+
+        /// The identifiers of the screens currently attached, computed once per query.
+        private static func attachedScreenIDs() -> Set<String> {
+            return Set(Screen.availableScreens.compactMap { $0.screenID() })
+        }
+
+        /**
+         A window being animated by a screen's reflow belongs to that screen even while it briefly straddles another display.
+
+         A registration for a screen that is no longer attached is ignored, as the window's own screen lookup ignores it: the display was unplugged mid-animation and the windows now lie wherever macOS put them.
+         */
+        private func isWindow(_ window: Window, on screen: Screen, attachedScreenIDs: Set<String>) -> Bool {
+            if let animatingScreenID = AnimatingWindows.shared.screenID(for: window.cgID(), ifAmong: attachedScreenIDs), let screenID = screen.screenID() {
+                return animatingScreenID == screenID
+            }
+            return window.screen() == screen
         }
 
         func activeWindows(onScreen screen: Screen) -> [Window] {
@@ -41,10 +59,11 @@ extension WindowManager {
                 return []
             }
 
+            let attachedScreenIDs = Windows.attachedScreenIDs()
             let screenWindows = windows.filter { window in
                 let space = CGWindowsInfo.windowSpace(window)
 
-                guard let windowScreen = window.screen(), currentSpace.id == space else {
+                guard currentSpace.id == space, isWindow(window, on: screen, attachedScreenIDs: attachedScreenIDs) else {
                     return false
                 }
 
@@ -52,7 +71,7 @@ extension WindowManager {
                 let isHidden = self.isWindowHidden(window)
                 let isFloating = self.isWindowFloating(window)
 
-                return windowScreen.screenID() == screen.screenID() && isActive && !isHidden && !isFloating
+                return isActive && !isHidden && !isFloating
             }
 
             return screenWindows

--- a/Amethyst/Model/Screen.swift
+++ b/Amethyst/Model/Screen.swift
@@ -72,6 +72,11 @@ struct AMScreen: ScreenType {
     static var availableScreens: [AMScreen] { return NSScreen.screens.map { AMScreen(screen: $0) } }
     static var screensHaveSeparateSpaces: Bool { return NSScreen.screensHaveSeparateSpaces }
 
+    /// The screen with the given identifier, if it is currently attached.
+    static func screen(withID screenID: String) -> AMScreen? {
+        return availableScreens.first { $0.screenID() == screenID }
+    }
+
     let screen: NSScreen
 
     func adjustedFrame(disableWindowMargins: Bool) -> CGRect {

--- a/Amethyst/Model/Window.swift
+++ b/Amethyst/Model/Window.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Ian Ynda-Hummel. All rights reserved.
 //
 
+import ApplicationServices
 import Foundation
 import Silica
 
@@ -63,6 +64,26 @@ protocol WindowType: Equatable {
      */
 
     func setFrame(_ frame: CGRect, withThreshold threshold: CGSize)
+
+    /// Whether or not the window can be resized.
+    func isResizable() -> Bool
+
+    /**
+     Applies a frame with the minimum number of accessibility calls: no read-back and no threshold checks.
+
+     Intended only for intermediate frames during an animated reflow. The final frame must still be applied with `setFrame(_:withThreshold:)`, which handles the finicky accessibility behavior that this method deliberately skips.
+
+     - Parameters:
+         - frame: The frame to apply.
+         - includingSize: Whether to apply the size as well as the position. Resizes force a relayout in the target application and are far more expensive than moves.
+     */
+    func setAnimationFrame(_ frame: CGRect, includingSize: Bool)
+
+    /// Called once before a sequence of `setAnimationFrame(_:includingSize:)` calls.
+    func beginAnimatedMovement()
+
+    /// Called once after a sequence of `setAnimationFrame(_:includingSize:)` calls, whether or not the animation completed.
+    func endAnimatedMovement()
 
     /// Whether or not the window is currently holding focus.
     func isFocused() -> Bool
@@ -134,6 +155,11 @@ protocol WindowType: Equatable {
     func move(toSpace spaceID: CGSSpaceID)
 }
 
+extension WindowType {
+    func beginAnimatedMovement() {}
+    func endAnimatedMovement() {}
+}
+
 enum WindowDecodingError: Error {
     case idNotFound
 }
@@ -143,7 +169,74 @@ enum WindowDecodingError: Error {
  
  A final class is necessary for satisfying the `focusedWindow()` requirement in the `WindowType` protocol. Otherwise, as `SIWindow` is not final, the type system does not know how to constrain `Self`.
  */
-final class AXWindow: SIWindow {}
+final class AXWindow: SIWindow {
+    /// One entry per animation currently registered with `EnhancedUserInterfaceSuppression` for this window, holding the
+    /// application it registered with. Two screens can animate the same window object in turn when it is thrown between
+    /// them; each begin registers, each end deregisters, and the two balance out.
+    fileprivate var suppressedApplicationPIDs: [pid_t] = []
+    /// Guards `suppressedApplicationPIDs`, which the reflow operations of different screens touch from their own queues.
+    fileprivate static let suppressionLock = NSLock()
+}
+
+/**
+ Keeps an application's enhanced user interface flag cleared for as long as any of its windows is being animated.
+
+ The flag belongs to the application, not to a window. When windows of one application animate on several screens at once, each
+ screen's operation begins and ends on its own, so the flag is cleared for the first window to begin and restored only when the
+ last window ends. The flag is read and written under the lock so that two screens cannot interleave a clear and a restore.
+ */
+final class EnhancedUserInterfaceSuppression {
+    static let shared = EnhancedUserInterfaceSuppression()
+
+    private let lock = NSLock()
+    private var animatingWindows: [pid_t: Int] = [:]
+    private var clearedApplications: Set<pid_t> = []
+
+    /**
+     Registers a window of the application as animating.
+
+     - Parameters:
+         - pid: The application's process identifier.
+         - clear: Invoked for the application's first animating window; clears the flag if it is set and returns whether it did.
+     */
+    func begin(for pid: pid_t, clear: () -> Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let count = (animatingWindows[pid] ?? 0) + 1
+        animatingWindows[pid] = count
+
+        if count == 1, clear() {
+            clearedApplications.insert(pid)
+        }
+    }
+
+    /**
+     Registers that a window of the application has finished animating.
+
+     - Parameters:
+         - pid: The application's process identifier.
+         - restore: Invoked when the application's last animating window ends and the flag had been cleared for it.
+     */
+    func end(for pid: pid_t, restore: () -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let count = animatingWindows[pid] else {
+            return
+        }
+
+        guard count == 1 else {
+            animatingWindows[pid] = count - 1
+            return
+        }
+
+        animatingWindows[pid] = nil
+        if clearedApplications.remove(pid) != nil {
+            restore()
+        }
+    }
+}
 
 /**
  Identifier for `AXWindow` objects.
@@ -219,6 +312,58 @@ extension AXWindow: WindowType {
     typealias Screen = AMScreen
     typealias WindowID = AXWindowID
 
+    /// Some assistive apps set this attribute on applications. Silica clears it around every frame change because it interferes with positioning; an animation keeps it cleared for as long as any of the application's windows is animating.
+    private static let enhancedUserInterfaceKey = "AXEnhancedUserInterface" as CFString
+
+    func setAnimationFrame(_ frame: CGRect, includingSize: Bool) {
+        var origin = frame.origin
+        if let positionValue = AXValueCreate(.cgPoint, &origin) {
+            AXUIElementSetAttributeValue(axElementRef, kAXPositionAttribute as CFString, positionValue)
+        }
+
+        guard includingSize else {
+            return
+        }
+
+        var size = frame.size
+        if let sizeValue = AXValueCreate(.cgSize, &size) {
+            AXUIElementSetAttributeValue(axElementRef, kAXSizeAttribute as CFString, sizeValue)
+        }
+    }
+
+    func beginAnimatedMovement() {
+        guard let application = app() else {
+            return
+        }
+
+        let pid = application.processIdentifier()
+        AXWindow.suppressionLock.lock()
+        suppressedApplicationPIDs.append(pid)
+        AXWindow.suppressionLock.unlock()
+        EnhancedUserInterfaceSuppression.shared.begin(for: pid) {
+            guard application.number(forKey: AXWindow.enhancedUserInterfaceKey)?.boolValue == true else {
+                return false
+            }
+
+            application.setFlag(false, forKey: AXWindow.enhancedUserInterfaceKey)
+            return true
+        }
+    }
+
+    func endAnimatedMovement() {
+        AXWindow.suppressionLock.lock()
+        let pid = suppressedApplicationPIDs.popLast()
+        AXWindow.suppressionLock.unlock()
+        guard let pid = pid else {
+            return
+        }
+
+        let application = app()
+        EnhancedUserInterfaceSuppression.shared.end(for: pid) {
+            application?.setFlag(true, forKey: AXWindow.enhancedUserInterfaceKey)
+        }
+    }
+
     /**
      Returns the currently focused window.
      
@@ -256,6 +401,12 @@ extension AXWindow: WindowType {
     }
 
     func screen() -> AMScreen? {
+        // A window an animation is moving belongs to the screen animating it even while its frame lies elsewhere or, when
+        // parked beyond every display, nowhere at all. Everything that routes hotkeys and focus by screen relies on this answer.
+        if let animatingScreenID = AnimatingWindows.shared.screenID(for: cgID()), let screen = AMScreen.screen(withID: animatingScreenID) {
+            return screen
+        }
+
         let nsScreen: NSScreen? = screen()
         return nsScreen.flatMap { AMScreen(screen: $0) }
     }

--- a/Amethyst/Preferences/GeneralPreferencesViewController.xib
+++ b/Amethyst/Preferences/GeneralPreferencesViewController.xib
@@ -452,6 +452,43 @@
                         <binding destination="XhK-Tn-zrU" name="value" keyPath="values.hide-menu-bar-icon" id="xeg-d8-MWC"/>
                     </connections>
                 </button>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="anm-wn-chk">
+                    <rect key="frame" x="192" y="432" width="200" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Animate window movement" bezelStyle="regularSquare" imagePosition="left" inset="2" id="anm-wn-cel">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="value" keyPath="values.animate-windows" id="anm-wn-bnd"/>
+                    </connections>
+                </button>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="anm-du-fld">
+                    <rect key="frame" x="396" y="430" width="50" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="0.3" drawsBackground="YES" usesSingleLineMode="YES" id="anm-du-cel">
+                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="1" minimumFractionDigits="1" maximumFractionDigits="2" id="anm-du-fmt">
+                            <real key="minimum" value="0.05"/>
+                            <real key="maximum" value="1.0"/>
+                        </numberFormatter>
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="XhK-Tn-zrU" name="value" keyPath="values.window-animation-duration" id="anm-du-bnd"/>
+                        <binding destination="XhK-Tn-zrU" name="enabled" keyPath="values.animate-windows" id="anm-du-enb"/>
+                    </connections>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="anm-du-lbl">
+                    <rect key="frame" x="450" y="433" width="60" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="seconds" id="anm-du-lbc">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
             <point key="canvasLocation" x="561" y="274"/>
         </customView>

--- a/Amethyst/Preferences/UserConfiguration.swift
+++ b/Amethyst/Preferences/UserConfiguration.swift
@@ -99,6 +99,8 @@ enum ConfigurationKey: String {
     case restoreLayoutsOnLaunch = "restore-layouts-on-launch"
     case disablePaddingOnBuiltinDisplay = "disable-padding-on-builtin-display"
     case hideMenuBarIcon = "hide-menu-bar-icon"
+    case animateWindows = "animate-windows"
+    case windowAnimationDuration = "window-animation-duration"
 }
 
 extension ConfigurationKey: CaseIterable {}
@@ -139,6 +141,7 @@ enum CommandKey: String {
     case relaunchAmethyst = "relaunch-amethyst"
     case increaseWindowMaxCount = "increase-window-max-count"
     case decreaseWindowMaxCount = "decrease-window-max-count"
+    case toggleAnimateWindows = "toggle-animate-windows"
 }
 
 protocol UserConfigurationDelegate: AnyObject {
@@ -763,6 +766,38 @@ class UserConfiguration: NSObject {
 
     func hideMenuBarIcon() -> Bool {
         return storage.bool(forKey: .hideMenuBarIcon)
+    }
+
+    static let defaultWindowAnimationDuration: TimeInterval = 0.3
+    static let minimumWindowAnimationDuration: TimeInterval = 0.05
+    static let maximumWindowAnimationDuration: TimeInterval = 1.0
+
+    /// Whether the system asks for reduced motion. Replaceable so the animation rule can be tested without touching system settings.
+    var systemReducesMotion: () -> Bool = { NSWorkspace.shared.accessibilityDisplayShouldReduceMotion }
+
+    /// The stored setting: whether the user asked for animated reflows. This is what the toggle flips and the HUD reports.
+    func animatesWindowMovement() -> Bool {
+        return storage.bool(forKey: .animateWindows)
+    }
+
+    /// Whether a reflow should animate now: the setting is on and the system does not ask for reduced motion.
+    func shouldAnimateWindowMovement() -> Bool {
+        return animatesWindowMovement() && !systemReducesMotion()
+    }
+
+    /// Duration of an animated reflow in seconds, clamped to a sane range. An unset value falls back to the default rather than the minimum.
+    func windowAnimationDuration() -> TimeInterval {
+        let configured = TimeInterval(storage.float(forKey: .windowAnimationDuration))
+
+        guard configured > 0 else {
+            return UserConfiguration.defaultWindowAnimationDuration
+        }
+
+        return min(max(configured, UserConfiguration.minimumWindowAnimationDuration), UserConfiguration.maximumWindowAnimationDuration)
+    }
+
+    func toggleAnimateWindows() {
+        setConfigurationValueWithKVO(!animatesWindowMovement(), forKey: .animateWindows)
     }
 }
 

--- a/Amethyst/View/LayoutNameWindow.swift
+++ b/Amethyst/View/LayoutNameWindow.swift
@@ -32,6 +32,8 @@ class LayoutNameWindow: NSWindow {
         ignoresMouseEvents = true
         backgroundColor = NSColor.clear
         level = .floating
+        // Left out of screen capture, so an animated reflow's backdrop does not include this flash.
+        sharingType = .none
     }
 
     // Display custom notification with dynamic sizing

--- a/Amethyst/View/ReflowAnimationOverlay.swift
+++ b/Amethyst/View/ReflowAnimationOverlay.swift
@@ -1,0 +1,371 @@
+//
+//  ReflowAnimationOverlay.swift
+//  Amethyst
+//
+//  Created by Don Patterson on 9/8/26.
+//  Copyright © 2026 Ian Ynda-Hummel. All rights reserved.
+//
+
+import Cocoa
+import QuartzCore
+
+/// A captured window image and where it should travel, in the flipped (Accessibility) coordinate space Amethyst uses for frames.
+struct SnapshotProxy {
+    let image: CGImage
+    let start: CGRect
+    let target: CGRect
+}
+
+/// Something that can show window snapshots on screen and slide them. All methods are called on the main thread.
+protocol SnapshotAnimating: AnyObject {
+    /// Shows the proxies at their start frames, covering the real windows. With a `backdrop`, an opaque image of the screen sits beneath them so the real windows can move behind it unseen.
+    func show(proxies: [SnapshotProxy], screenFrame: CGRect, backdrop: CGImage?)
+
+    /**
+     Cross-dissolves proxies to fresh images of their windows over `duration`, so they land showing the real final rendering rather than a stretched old one.
+
+     `images` is indexed like the proxies given to `show`; `nil` leaves a proxy alone. `completion` runs on the main thread when the dissolve has finished.
+     */
+    func crossfade(images: [CGImage?], duration: TimeInterval, completion: (() -> Void)?)
+
+    /// Slides every proxy to its target frame. `completion` runs on the main thread when the motion has finished.
+    func animate(duration: TimeInterval, completion: @escaping () -> Void)
+
+    /**
+     Steers proxies that are already moving to new frames, from wherever they currently are, over `duration`.
+
+     `frames` is indexed like the proxies given to `show`; `nil` leaves a proxy alone. A non-nil `completion` replaces the pending one, which is called first; otherwise the completion given to `animate` still fires when the last motion ends.
+     */
+    func retarget(frames: [CGRect?], duration: TimeInterval, completion: (() -> Void)?)
+
+    /// Where each proxy currently appears on screen, in flipped coordinates and in the order given to `show`.
+    func presentationFrames() -> [CGRect]
+
+    /**
+     Fades the overlay out over the real windows and removes it. `completion` runs on the main thread afterwards.
+
+     Proxies listed in `lingering` never received a fresh image of their window; they dissolve over the longer `lingerDuration` so the stretched image blends into the real window rather than cutting to it.
+     */
+    func finish(fadeDuration: TimeInterval, lingering: [Int], lingerDuration: TimeInterval, completion: @escaping () -> Void)
+
+    /// Hides individual proxies at once, for windows Amethyst has moved elsewhere mid-animation.
+    func hide(indices: [Int])
+
+    /// Removes the proxies immediately.
+    func cancel()
+}
+
+/// Conversions between AppKit's bottom-left coordinates and the top-left, primary-screen-relative coordinates used by Accessibility and Amethyst's layouts. Same flip Silica applies to screen frames.
+enum FlippedCoordinates {
+    static var primaryScreenHeight: CGFloat {
+        return NSScreen.screens.first?.frame.height ?? 0
+    }
+
+    static func appKitRect(fromFlipped rect: CGRect, primaryScreenHeight: CGFloat) -> CGRect {
+        return CGRect(x: rect.minX, y: primaryScreenHeight - rect.height - rect.minY, width: rect.width, height: rect.height)
+    }
+
+    static func flippedRect(fromAppKit rect: CGRect, primaryScreenHeight: CGFloat) -> CGRect {
+        // The flip is its own inverse.
+        return appKitRect(fromFlipped: rect, primaryScreenHeight: primaryScreenHeight)
+    }
+}
+
+/**
+ A click-through panel that shows captured window images and slides them with Core Animation.
+
+ The panel is never managed by Amethyst because Amethyst's own process is not a regular application, and `sharingType = .none` keeps it out of any later capture.
+ */
+final class ReflowAnimationOverlay: SnapshotAnimating {
+    /// Marks the overlay's panel so stray ones can be found, for example by tests.
+    static let panelIdentifier = NSUserInterfaceItemIdentifier("AmethystReflowAnimationOverlay")
+
+    /// How many overlay panels the application currently has on screen. A closed panel may stay allocated for a while, held by AppKit; only visible ones count.
+    static var livePanelCount: Int {
+        return NSApplication.shared.windows.filter { $0.identifier == panelIdentifier && $0.isVisible }.count
+    }
+
+    private var panel: NSPanel?
+    private var backdropLayer: CALayer?
+    private var layers: [CALayer] = []
+    private var proxies: [SnapshotProxy] = []
+    private var primaryScreenHeight: CGFloat = 0
+
+    /// Completion of the most recent `animate` or `retarget`. Only the latest batch of animations may fire it.
+    private var completion: (() -> Void)?
+    private var generation = 0
+
+    func show(proxies: [SnapshotProxy], screenFrame: CGRect, backdrop: CGImage?) {
+        primaryScreenHeight = FlippedCoordinates.primaryScreenHeight
+        let appKitScreenFrame = FlippedCoordinates.appKitRect(fromFlipped: screenFrame, primaryScreenHeight: primaryScreenHeight)
+        let screen = NSScreen.screens.max { lhs, rhs in
+            area(lhs.frame.intersection(appKitScreenFrame)) < area(rhs.frame.intersection(appKitScreenFrame))
+        }
+        let panelFrame = screen?.frame ?? appKitScreenFrame
+
+        let panel = NSPanel(contentRect: panelFrame, styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.ignoresMouseEvents = true
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        // The panel belongs to the Space it was made on: a reflow only runs on the active Space, and a Space switch
+        // carries the picture away with that Space.
+        panel.collectionBehavior = [.ignoresCycle, .fullScreenAuxiliary]
+        panel.sharingType = .none
+        panel.animationBehavior = .none
+        panel.identifier = ReflowAnimationOverlay.panelIdentifier
+
+        let contentView = NSView(frame: NSRect(origin: .zero, size: panelFrame.size))
+        contentView.wantsLayer = true
+        panel.contentView = contentView
+
+        let scale = screen?.backingScaleFactor ?? 2
+
+        if let backdrop = backdrop {
+            let backdropLayer = CALayer()
+            backdropLayer.contents = backdrop
+            backdropLayer.contentsGravity = .resize
+            backdropLayer.contentsScale = scale
+            backdropLayer.frame = contentView.bounds
+            backdropLayer.actions = ["contents": NSNull(), "opacity": NSNull()]
+            contentView.layer?.addSublayer(backdropLayer)
+            self.backdropLayer = backdropLayer
+        }
+
+        var layers: [CALayer] = []
+        for proxy in proxies {
+            let layer = CALayer()
+            layer.contents = proxy.image
+            layer.contentsGravity = .resize
+            layer.contentsScale = scale
+            layer.frame = layerFrame(for: proxy.start, panelFrame: panelFrame)
+            layer.shadowColor = NSColor.black.cgColor
+            layer.shadowOpacity = 0.4
+            layer.shadowRadius = 16
+            layer.shadowOffset = CGSize(width: 0, height: -8)
+            // Drive every change explicitly; implicit animations would fight the glide.
+            layer.actions = ["position": NSNull(), "bounds": NSNull(), "opacity": NSNull(), "contents": NSNull()]
+            contentView.layer?.addSublayer(layer)
+            layers.append(layer)
+        }
+
+        self.panel = panel
+        self.layers = layers
+        self.proxies = proxies
+
+        panel.orderFrontRegardless()
+        CATransaction.flush()
+    }
+
+    func animate(duration: TimeInterval, completion: @escaping () -> Void) {
+        guard let panel = panel else {
+            completion()
+            return
+        }
+
+        fireCompletion()
+        self.completion = completion
+        let frames = proxies.map { Optional($0.target) }
+        glide(layerIndices: Array(layers.indices), to: frames, duration: duration, timing: CAMediaTimingFunction(name: .easeInEaseOut), panel: panel)
+    }
+
+    func retarget(frames: [CGRect?], duration: TimeInterval, completion: (() -> Void)?) {
+        if let completion = completion {
+            fireCompletion()
+            self.completion = completion
+        }
+
+        let indices = layers.indices.filter { $0 < frames.count && frames[$0] != nil }
+
+        guard let panel = panel, !indices.isEmpty else {
+            if completion != nil {
+                fireCompletion()
+            }
+            return
+        }
+
+        for index in indices {
+            if let frame = frames[index] {
+                proxies[index] = SnapshotProxy(image: proxies[index].image, start: proxies[index].start, target: frame)
+            }
+        }
+
+        glide(layerIndices: indices, to: frames, duration: duration, timing: CAMediaTimingFunction(name: .easeOut), panel: panel)
+    }
+
+    /// Animates the given layers from wherever they currently appear to their new frames. Replacing a running animation is what makes retargeting seamless.
+    private func glide(layerIndices: [Int], to frames: [CGRect?], duration: TimeInterval, timing: CAMediaTimingFunction, panel: NSPanel) {
+        generation += 1
+        let thisGeneration = generation
+
+        CATransaction.begin()
+        CATransaction.setCompletionBlock { [weak self] in
+            guard let self = self, self.generation == thisGeneration else {
+                return
+            }
+            self.fireCompletion()
+        }
+
+        for index in layerIndices {
+            guard let frame = frames[index] else {
+                continue
+            }
+
+            let layer = layers[index]
+            let current = layer.presentation() ?? layer
+            let targetFrame = layerFrame(for: frame, panelFrame: panel.frame)
+            let targetBounds = CGRect(origin: .zero, size: targetFrame.size)
+            let targetPosition = CGPoint(x: targetFrame.midX, y: targetFrame.midY)
+
+            let bounds = CABasicAnimation(keyPath: "bounds")
+            bounds.fromValue = current.bounds
+            bounds.toValue = targetBounds
+
+            let position = CABasicAnimation(keyPath: "position")
+            position.fromValue = current.position
+            position.toValue = targetPosition
+
+            let group = CAAnimationGroup()
+            group.animations = [bounds, position]
+            group.duration = duration
+            group.timingFunction = timing
+
+            layer.bounds = targetBounds
+            layer.position = targetPosition
+            layer.add(group, forKey: "glide")
+        }
+
+        CATransaction.commit()
+    }
+
+    private func fireCompletion() {
+        guard let completion = completion else {
+            return
+        }
+        self.completion = nil
+        completion()
+    }
+
+    func crossfade(images: [CGImage?], duration: TimeInterval, completion: (() -> Void)?) {
+        let indices = layers.indices.filter { $0 < images.count && images[$0] != nil }
+
+        guard panel != nil, !indices.isEmpty else {
+            completion?()
+            return
+        }
+
+        CATransaction.begin()
+        if let completion = completion {
+            CATransaction.setCompletionBlock(completion)
+        }
+
+        for index in indices {
+            guard let image = images[index] else {
+                continue
+            }
+
+            let layer = layers[index]
+            let dissolve = CABasicAnimation(keyPath: "contents")
+            dissolve.fromValue = layer.presentation()?.contents ?? layer.contents
+            dissolve.toValue = image
+            dissolve.duration = duration
+            // Ease out: bring the fresh rendering in quickly, then let the last of the old image linger briefly.
+            dissolve.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            layer.contents = image
+            layer.add(dissolve, forKey: "dissolve")
+        }
+
+        CATransaction.commit()
+    }
+
+    func presentationFrames() -> [CGRect] {
+        guard let panel = panel else {
+            return proxies.map { $0.target }
+        }
+
+        return layers.map { layer in
+            let frame = (layer.presentation() ?? layer).frame.offsetBy(dx: panel.frame.minX, dy: panel.frame.minY)
+            return FlippedCoordinates.flippedRect(fromAppKit: frame, primaryScreenHeight: primaryScreenHeight)
+        }
+    }
+
+    func finish(fadeDuration: TimeInterval, lingering: [Int], lingerDuration: TimeInterval, completion: @escaping () -> Void) {
+        guard panel != nil, fadeDuration > 0 else {
+            tearDown()
+            completion()
+            return
+        }
+
+        // Nothing else holds the overlay once the reflow operation returns, so the completion keeps it alive until the
+        // panel has been taken down. A fallback timer takes the panel down even if the render server never reports the
+        // fade complete.
+        var finished = false
+        let finishOnce = {
+            guard !finished else {
+                return
+            }
+            finished = true
+            self.tearDown()
+            completion()
+        }
+        let longestFade = max(fadeDuration, lingering.isEmpty ? 0 : lingerDuration)
+        DispatchQueue.main.asyncAfter(deadline: .now() + longestFade + 0.5, execute: finishOnce)
+
+        CATransaction.begin()
+        CATransaction.setCompletionBlock(finishOnce)
+
+        // The backdrop and refreshed proxies fade quickly over windows that already show what they show; proxies that never
+        // got a fresh image dissolve slowly into the real window now revealed beneath them.
+        let lingering = Set(lingering)
+        let fading = [backdropLayer].compactMap { $0 }.map { ($0, fadeDuration) } + layers.enumerated().map { ($1, lingering.contains($0) ? lingerDuration : fadeDuration) }
+        for (layer, duration) in fading {
+            let fade = CABasicAnimation(keyPath: "opacity")
+            // From the current opacity, so a picture hidden earlier does not reappear for the length of the fade.
+            fade.fromValue = layer.opacity
+            fade.toValue = 0
+            fade.duration = duration
+            fade.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            layer.opacity = 0
+            layer.add(fade, forKey: "fade")
+        }
+
+        CATransaction.commit()
+    }
+
+    func hide(indices: [Int]) {
+        // Opacity carries no implicit animation here and leaves the picture's motion running unseen, so hiding one
+        // picture neither snaps it nor ends the batch of motion the other pictures are still in.
+        for index in indices where index < layers.count {
+            layers[index].opacity = 0
+        }
+    }
+
+    func cancel() {
+        layers.forEach { $0.removeAllAnimations() }
+        tearDown()
+    }
+
+    /// Takes the panel down and calls any completion still pending, so every completion the overlay accepted is called
+    /// exactly once.
+    private func tearDown() {
+        panel?.orderOut(nil)
+        panel?.close()
+        panel = nil
+        backdropLayer = nil
+        layers = []
+        proxies = []
+        fireCompletion()
+    }
+
+    private func layerFrame(for flipped: CGRect, panelFrame: CGRect) -> CGRect {
+        return FlippedCoordinates.appKitRect(fromFlipped: flipped, primaryScreenHeight: primaryScreenHeight)
+            .offsetBy(dx: -panelFrame.minX, dy: -panelFrame.minY)
+    }
+
+    private func area(_ rect: CGRect) -> CGFloat {
+        return rect.isNull ? 0 : rect.width * rect.height
+    }
+}

--- a/Amethyst/default.amethyst
+++ b/Amethyst/default.amethyst
@@ -204,6 +204,7 @@
         "mod": "mod2",
         "key": "x"
     },
+    "toggle-animate-windows": false,
     "relaunch-amethyst": {
         "mod": "mod2",
         "key": "z"
@@ -226,6 +227,8 @@
     "ignore-menu-bar": false,
     "use-canary-build": false,
     "new-windows-to-main": false,
+    "animate-windows": false,
+    "window-animation-duration": 0.3,
     "follow-space-thrown-windows": true,
     "screen-padding-top": 0,
     "screen-padding-bottom": 0,

--- a/AmethystTests/Model/TestWindow.swift
+++ b/AmethystTests/Model/TestWindow.swift
@@ -17,10 +17,28 @@ final class TestWindow: WindowType {
     static var focused: TestWindow?
 
     private let element: SIAccessibilityElement?
-    private let cgWindowID = CGWindowID(Int.random(in: 1...1000))
+    /// Unique for the life of the test process: the animation code keys its registry, captures and remembered positions on
+    /// this identifier.
+    private let cgWindowID = TestWindow.nextWindowID()
     private let uuid = UUID().uuidString
+
+    private static var lastWindowID: CGWindowID = 0
+    private static let windowIDLock = NSLock()
+
+    private static func nextWindowID() -> CGWindowID {
+        windowIDLock.lock()
+        defer { windowIDLock.unlock() }
+        lastWindowID += 1
+        return lastWindowID
+    }
     private var _frame: CGRect = .zero
     var isFocusedValue = false
+    var isResizableValue = true
+    /// The application this window belongs to; windows of different applications get writers of their own.
+    var pidValue: pid_t = 1234
+
+    /// Every frame applied through `setFrame` or `setAnimationFrame`, in order.
+    private(set) var frameHistory: [CGRect] = []
 
     static func currentlyFocused() -> Self? {
         return (focused as? Self)
@@ -38,8 +56,11 @@ final class TestWindow: WindowType {
         return cgWindowID
     }
 
+    /// Simulates an application that cannot answer, the way a hung app or a closed window does: frame reads return the null rect.
+    var frameIsUnreadable = false
+
     func frame() -> CGRect {
-        return _frame
+        return frameIsUnreadable ? .null : _frame
     }
 
     func screen() -> Screen? {
@@ -47,7 +68,59 @@ final class TestWindow: WindowType {
     }
 
     func setFrame(_ frame: CGRect, withThreshold threshold: CGSize) {
-        _frame = frame
+        // Like Silica, a window that cannot be resized only takes the position.
+        _frame = CGRect(origin: constrained(frame.origin), size: isResizableValue ? constrained(frame.size) : _frame.size)
+        frameHistory.append(_frame)
+    }
+
+    func isResizable() -> Bool {
+        return isResizableValue
+    }
+
+    /// Simulates a slow application: how long each animation frame write should block.
+    var animationFrameDelay: TimeInterval = 0
+
+    /// Lets a test react to each animation frame write, for example to cancel an operation at a precise moment.
+    var onAnimationFrame: ((CGRect) -> Void)?
+
+    /// Simulates an application that refuses to grow beyond a certain size, like System Settings.
+    var maximumSize: CGSize?
+
+    /// Simulates a window kept below a certain y, the way macOS keeps windows below the menu bar.
+    var minimumY: CGFloat?
+
+    /// Simulates an application that refuses to shrink below a certain size, like Mail.
+    var minimumSize: CGSize?
+
+    private func constrained(_ size: CGSize) -> CGSize {
+        var result = size
+        if let maximumSize = maximumSize {
+            result = CGSize(width: min(result.width, maximumSize.width), height: min(result.height, maximumSize.height))
+        }
+        if let minimumSize = minimumSize {
+            result = CGSize(width: max(result.width, minimumSize.width), height: max(result.height, minimumSize.height))
+        }
+        return result
+    }
+
+    private func constrained(_ origin: CGPoint) -> CGPoint {
+        guard let minimumY = minimumY else {
+            return origin
+        }
+        return CGPoint(x: origin.x, y: max(origin.y, minimumY))
+    }
+
+    func setAnimationFrame(_ frame: CGRect, includingSize: Bool) {
+        if animationFrameDelay > 0 {
+            Thread.sleep(forTimeInterval: animationFrameDelay)
+        }
+        _frame = CGRect(origin: constrained(frame.origin), size: includingSize && isResizableValue ? constrained(frame.size) : _frame.size)
+        frameHistory.append(_frame)
+        onAnimationFrame?(_frame)
+    }
+
+    func clearFrameHistory() {
+        frameHistory.removeAll()
     }
 
     func isFocused() -> Bool {
@@ -55,7 +128,7 @@ final class TestWindow: WindowType {
     }
 
     func pid() -> pid_t {
-        return pid_t(1234)
+        return pidValue
     }
 
     func title() -> String? {

--- a/AmethystTests/Tests/Configuration/UserConfigurationTests.swift
+++ b/AmethystTests/Tests/Configuration/UserConfigurationTests.swift
@@ -69,6 +69,61 @@ class UserConfigurationTests: QuickSpec {
     }
 
     override func spec() {
+        describe("window animation") {
+            it("is disabled in the bundled defaults") {
+                let path = Bundle.main.path(forResource: "default", ofType: "amethyst")!
+                let defaults = try JSON(data: Data(contentsOf: URL(fileURLWithPath: path)))
+                expect(defaults["animate-windows"].bool) == false
+                expect(defaults["window-animation-duration"].double) == 0.3
+
+                // Seeding a fresh configuration from those defaults leaves animation off.
+                let configuration = UserConfiguration(storage: TestConfigurationStorage())
+                configuration.defaultConfiguration = defaults
+                configuration.loadConfiguration()
+                expect(configuration.animatesWindowMovement()).to(beFalse())
+            }
+
+            it("toggles") {
+                let configuration = UserConfiguration(storage: TestConfigurationStorage())
+                configuration.toggleAnimateWindows()
+                expect(configuration.animatesWindowMovement()).to(beTrue())
+                configuration.toggleAnimateWindows()
+                expect(configuration.animatesWindowMovement()).to(beFalse())
+            }
+
+            it("animates only when the setting is on and the system does not ask for reduced motion") {
+                let configuration = UserConfiguration(storage: TestConfigurationStorage())
+                configuration.systemReducesMotion = { false }
+                expect(configuration.shouldAnimateWindowMovement()).to(beFalse())
+
+                configuration.toggleAnimateWindows()
+                expect(configuration.shouldAnimateWindowMovement()).to(beTrue())
+
+                configuration.systemReducesMotion = { true }
+                expect(configuration.animatesWindowMovement()).to(beTrue())
+                expect(configuration.shouldAnimateWindowMovement()).to(beFalse())
+            }
+
+            it("falls back to the default duration when unset") {
+                let configuration = UserConfiguration(storage: TestConfigurationStorage())
+                expect(configuration.windowAnimationDuration()).to(beCloseTo(UserConfiguration.defaultWindowAnimationDuration))
+            }
+
+            it("clamps the duration") {
+                let storage = TestConfigurationStorage()
+                let configuration = UserConfiguration(storage: storage)
+
+                storage.set(Float(5), forKey: .windowAnimationDuration)
+                expect(configuration.windowAnimationDuration()).to(beCloseTo(UserConfiguration.maximumWindowAnimationDuration))
+
+                storage.set(Float(0.01), forKey: .windowAnimationDuration)
+                expect(configuration.windowAnimationDuration()).to(beCloseTo(UserConfiguration.minimumWindowAnimationDuration))
+
+                storage.set(Float(0.3), forKey: .windowAnimationDuration)
+                expect(configuration.windowAnimationDuration()).to(beCloseTo(0.3))
+            }
+        }
+
         describe("constructing commands") {
             context("overrides") {
                 it("when user configuration exists") {

--- a/AmethystTests/Tests/Layout/AnimatedReflowOperationTests.swift
+++ b/AmethystTests/Tests/Layout/AnimatedReflowOperationTests.swift
@@ -1,0 +1,1735 @@
+//
+//  AnimatedReflowOperationTests.swift
+//  AmethystTests
+//
+//  Created by Don Patterson on 9/8/26.
+//  Copyright © 2026 Ian Ynda-Hummel. All rights reserved.
+//
+
+@testable import Amethyst
+import CoreGraphics
+import Nimble
+import Quick
+import XCTest
+import Silica
+
+class AnimatedReflowOperationTests: QuickSpec {
+    /// A deterministic clock: every sleep advances time by exactly the requested amount.
+    private final class FakeClock {
+        private(set) var time: TimeInterval = 0
+        private(set) var sleepCount = 0
+        var onSleep: ((Int) -> Void)?
+
+        func now() -> TimeInterval {
+            return time
+        }
+
+        func sleep(_ interval: TimeInterval) {
+            time += interval
+            sleepCount += 1
+            onSleep?(sleepCount)
+        }
+    }
+
+    private struct Fixture {
+        let windows: [TestWindow]
+        let operations: [FrameAssignmentOperation<TestWindow>]
+
+        /// The window a capture request is about, whichever windows the operation asks about and in whatever order.
+        func window(for request: WindowCaptureRequest) -> TestWindow {
+            return windows.first { $0.cgID() == request.windowID }!
+        }
+    }
+
+    /// Records the overlay calls the operation makes and completes the glide immediately unless told otherwise.
+    private final class FakeSnapshotAnimator: SnapshotAnimating {
+        var shownProxies: [SnapshotProxy] = []
+        var shownScreenFrame: CGRect?
+        var animateDuration: TimeInterval?
+        var completesImmediately = true
+        /// Whether a mid-glide refinement stands in for the overlay reaching its target; `false` keeps the glide pending until `endGlide()` or a stall, as when a display is asleep.
+        var endsGlideOnRefinement = true
+        var onAnimate: (() -> Void)?
+        /// Called after each dissolve, so a test can end the glide at a moment of its choosing.
+        var onCrossfade: (() -> Void)?
+        var framesToPresent: [CGRect] = []
+        var finishCalled = false
+        var lingering: [Int] = []
+        var cancelCalled = false
+        var retargetedFrames: [[CGRect?]] = []
+        var retargetDurations: [TimeInterval] = []
+        var shownBackdrop: CGImage?
+        var hiddenIndices: [Int] = []
+        var crossfadeImages: [[CGImage?]] = []
+        var crossfadeDurations: [TimeInterval] = []
+        /// Keeps late-correction completions instead of calling them, like an overlay whose animations never report back.
+        var swallowsCorrectionCompletions = false
+        private var swallowedCompletions: [() -> Void] = []
+        private var pendingCompletion: (() -> Void)?
+
+        func show(proxies: [SnapshotProxy], screenFrame: CGRect, backdrop: CGImage?) {
+            shownProxies = proxies
+            shownScreenFrame = screenFrame
+            shownBackdrop = backdrop
+        }
+
+        /// Stands in for the real overlay reaching its target and ends the pending glide.
+        func endGlide() {
+            let pending = pendingCompletion
+            pendingCompletion = nil
+            pending?()
+        }
+
+        private func endPendingGlide() {
+            endGlide()
+        }
+
+        func crossfade(images: [CGImage?], duration: TimeInterval, completion: (() -> Void)?) {
+            crossfadeImages.append(images)
+            crossfadeDurations.append(duration)
+            completion?()
+            if endsGlideOnRefinement {
+                endPendingGlide()
+            }
+            onCrossfade?()
+        }
+
+        func animate(duration: TimeInterval, completion: @escaping () -> Void) {
+            animateDuration = duration
+            onAnimate?()
+            if completesImmediately {
+                completion()
+            } else {
+                pendingCompletion = completion
+            }
+        }
+
+        /// A late correction completes at once; a mid-glide retarget ends the pending glide.
+        func retarget(frames: [CGRect?], duration: TimeInterval, completion: (() -> Void)?) {
+            retargetedFrames.append(frames)
+            retargetDurations.append(duration)
+            if let completion = completion {
+                if swallowsCorrectionCompletions {
+                    swallowedCompletions.append(completion)
+                } else {
+                    completion()
+                }
+            } else if endsGlideOnRefinement {
+                endPendingGlide()
+            }
+        }
+
+        func presentationFrames() -> [CGRect] {
+            return framesToPresent
+        }
+
+        func finish(fadeDuration: TimeInterval, lingering: [Int], lingerDuration: TimeInterval, completion: @escaping () -> Void) {
+            finishCalled = true
+            self.lingering = lingering
+            completion()
+        }
+
+        func hide(indices: [Int]) {
+            hiddenIndices += indices
+        }
+
+        func cancel() {
+            cancelCalled = true
+        }
+    }
+
+    /// Runs `work` on the main thread and returns its result; the overlay's panel and animations live there.
+    private func onMain<Value>(_ work: () -> Value) -> Value {
+        var value: Value?
+        runOnMainSync { value = work() }
+        return value!
+    }
+
+    /// Gives the main thread time to deliver its queued work and animation completions, without occupying it, until `done` holds or `attempts` run out.
+    private func letMainThreadRun(attempts: Int, until done: () -> Bool) {
+        for _ in 0..<attempts where !done() {
+            if Thread.isMainThread {
+                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            } else {
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+        }
+    }
+
+    /// The primary screen's frame in the flipped coordinates the overlay takes, or a skip: the overlay needs a display to put its panel on.
+    private func primaryScreenFrameOrSkip() throws -> CGRect {
+        guard let screen = NSScreen.screens.first else {
+            throw XCTSkip("needs an attached display")
+        }
+        return FlippedCoordinates.flippedRect(fromAppKit: screen.frame, primaryScreenHeight: FlippedCoordinates.primaryScreenHeight)
+    }
+
+    private static func makeImage(width: Int = 1, height: Int = 1) -> CGImage {
+        let context = CGContext(
+            data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(), bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        return context.makeImage()!
+    }
+
+    private let parkingOrigin = CGPoint(x: 5000, y: 0)
+
+    private func makeSnapshotOperation(
+        _ fixture: Fixture,
+        clock: FakeClock,
+        animator: FakeSnapshotAnimator,
+        capture: @escaping ([WindowCaptureRequest]) -> [CGImage]?,
+        backdrop: ((CGRect, [CGWindowID]) -> CGImage?)? = nil,
+        screenID: String? = nil,
+        writesInline: Bool = true,
+        verifiable: @escaping (WindowCaptureRequest) -> Bool = { _ in true }
+    ) -> AnimatedReflowOperation<TestWindow> {
+        return AnimatedReflowOperation(
+            frameAssignmentOperations: fixture.operations,
+            duration: duration,
+            frameInterval: frameInterval,
+            writesInline: writesInline,
+            captureImages: capture,
+            captureIsVerifiable: verifiable,
+            captureBackdrop: backdrop,
+            makeSnapshotAnimator: { animator },
+            parkingOrigin: { self.parkingOrigin },
+            screenID: screenID,
+            now: clock.now,
+            sleep: clock.sleep
+        )
+    }
+
+    // Exactly representable in binary so the tick count is deterministic: 8 ticks at 0, 1/32 ... 7/32.
+    private let duration: TimeInterval = 0.25
+    private let frameInterval: TimeInterval = 1.0 / 32.0
+    private let expectedTicks = 8
+
+    private func makeFixture(startFrames: [CGRect], targetFrames: [CGRect], focusedIndex: Int? = nil) -> Fixture {
+        let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1000)
+        let windows: [TestWindow] = startFrames.enumerated().map { index, frame in
+            let window = TestWindow(element: nil)!
+            window.setFrame(frame, withThreshold: .zero)
+            window.isFocusedValue = index == focusedIndex
+            window.clearFrameHistory()
+            return window
+        }
+        let layoutWindows = windows.map {
+            LayoutWindow<TestWindow>(id: $0.id(), frame: $0.frame(), isFocused: $0.isFocused())
+        }
+        let windowSet = WindowSet<TestWindow>(
+            windows: layoutWindows,
+            isWindowWithIDActive: { _ in return true },
+            isWindowWithIDFloating: { _ in return false },
+            windowForID: { id in return windows.first { $0.id() == id } }
+        )
+        let resizeRules = ResizeRules(isMain: true, unconstrainedDimension: .horizontal, scaleFactor: 1)
+        // A blank configuration: the frames these tests assert on must not pick up the margins or minimum sizes set in the
+        // preferences of whoever runs them.
+        let configuration = UserConfiguration(storage: TestConfigurationStorage())
+        let operations = zip(layoutWindows, targetFrames).map { layoutWindow, target in
+            FrameAssignmentOperation(
+                frameAssignment: FrameAssignment(frame: target, window: layoutWindow, screenFrame: screenFrame, resizeRules: resizeRules, configuration: configuration),
+                windowSet: windowSet
+            )
+        }
+        return Fixture(windows: windows, operations: operations)
+    }
+
+    private func makeOperation(_ fixture: Fixture, clock: FakeClock, writesInline: Bool = true, drainTimeout: TimeInterval = 1.0) -> AnimatedReflowOperation<TestWindow> {
+        return AnimatedReflowOperation(
+            frameAssignmentOperations: fixture.operations,
+            duration: duration,
+            frameInterval: frameInterval,
+            writesInline: writesInline,
+            writerDrainTimeout: drainTimeout,
+            now: clock.now,
+            sleep: clock.sleep
+        )
+    }
+
+    /// Whether `values` never reverses direction on its way from the first element to the last.
+    private func isMonotonic(_ values: [CGFloat]) -> Bool {
+        guard let first = values.first, let last = values.last else {
+            return true
+        }
+        let increasing = last >= first
+        return zip(values, values.dropFirst()).allSatisfy { increasing ? $1 >= $0 : $1 <= $0 }
+    }
+
+    override func spec() {
+        describe("easing") {
+            it("starts at zero and ends at one") {
+                expect(FrameInterpolation.easeInOutSine(0)) == 0
+                expect(FrameInterpolation.easeInOutSine(1)).to(beCloseTo(1))
+            }
+
+            it("is monotonic, symmetric, and gentle at both ends") {
+                let samples = (0...100).map { FrameInterpolation.easeInOutSine(CGFloat($0) / 100) }
+                expect(self.isMonotonic(samples)).to(beTrue())
+                expect(FrameInterpolation.easeInOutSine(0.5)).to(beCloseTo(0.5))
+                expect(FrameInterpolation.easeInOutSine(0.1)) < 0.1
+                expect(FrameInterpolation.easeInOutSine(0.9)) > 0.9
+            }
+
+            it("clamps out-of-range progress") {
+                expect(FrameInterpolation.easeInOutSine(-1)) == 0
+                expect(FrameInterpolation.easeInOutSine(2)).to(beCloseTo(1))
+            }
+        }
+
+        describe("interpolation") {
+            let start = CGRect(x: 0, y: 0, width: 100, height: 100)
+            let end = CGRect(x: 200, y: 100, width: 300, height: 50)
+
+            it("returns the endpoints at zero and one") {
+                expect(FrameInterpolation.interpolate(from: start, to: end, progress: 0)) == start
+                expect(FrameInterpolation.interpolate(from: start, to: end, progress: 1)) == end
+            }
+
+            it("rejects frames that could not be read") {
+                expect(FrameInterpolation.readable(.null)).to(beNil())
+                expect(FrameInterpolation.readable(.infinite)).to(beNil())
+                expect(FrameInterpolation.readable(CGRect(x: CGFloat.nan, y: 0, width: 10, height: 10))).to(beNil())
+                expect(FrameInterpolation.readable(CGRect(x: 0.4, y: 0, width: 10.6, height: 10))) == CGRect(x: 0, y: 0, width: 11, height: 10)
+            }
+
+            it("produces integral intermediate frames") {
+                let odd = CGRect(x: 1, y: 1, width: 101, height: 101)
+                let mid = FrameInterpolation.interpolate(from: start, to: odd, progress: 0.5)
+                for value in [mid.minX, mid.minY, mid.width, mid.height] {
+                    expect(value) == value.rounded()
+                }
+            }
+        }
+
+        describe("application frame writer") {
+            func makeWrite(_ window: TestWindow, xPosition: CGFloat) -> ApplicationFrameWriter<TestWindow>.Write {
+                return .init(window: window, frame: CGRect(x: xPosition, y: 0, width: 100, height: 100), includingSize: false)
+            }
+
+            /// A writer whose every frame signals `started` and then waits for `release` before it is applied, so a test can
+            /// queue frames behind one in flight without guessing how soon the writer's thread picks it up.
+            func makeGatedWriter(group: DispatchGroup, started: DispatchSemaphore, release: DispatchSemaphore) -> ApplicationFrameWriter<TestWindow> {
+                return ApplicationFrameWriter<TestWindow>(pid: 1, group: group, inline: false, now: { ProcessInfo.processInfo.systemUptime }, beginWrite: { _ in
+                    started.signal()
+                    release.wait()
+                    return true
+                })
+            }
+
+            it("drops a queued frame once its window may no longer be touched") {
+                let window = TestWindow(element: nil)!
+                let group = DispatchGroup()
+                let checked = DispatchSemaphore(value: 0)
+                let proceed = DispatchSemaphore(value: 0)
+                var allowed = true
+                let holdUntilHandedOff: (TestWindow) -> Bool = { _ in
+                    // Decide from the state on entry, then hold the frame until the test has queued the next one behind it
+                    // and handed the window off.
+                    let decision = allowed
+                    checked.signal()
+                    proceed.wait()
+                    return decision
+                }
+                let writer = ApplicationFrameWriter<TestWindow>(pid: 1, group: group, inline: false, now: { 0 }, beginWrite: holdUntilHandedOff)
+
+                writer.write([0: makeWrite(window, xPosition: 1)])
+                expect(checked.wait(timeout: .now() + 2)) == .success
+                writer.write([0: makeWrite(window, xPosition: 2)])
+                allowed = false
+                // Release the first frame, and let the second be checked at once.
+                proceed.signal()
+                proceed.signal()
+
+                expect(group.wait(timeout: .now() + 2)) == .success
+                expect(window.frameHistory.map { $0.minX }) == [1]
+            }
+
+            it("applies every frame when writing inline") {
+                let window = TestWindow(element: nil)!
+                let group = DispatchGroup()
+                let writer = ApplicationFrameWriter<TestWindow>(pid: 1, group: group, inline: true, now: { 0 })
+
+                for step in 1...5 {
+                    writer.write([0: makeWrite(window, xPosition: CGFloat(step))])
+                }
+
+                expect(window.frameHistory.map { $0.minX }) == [1, 2, 3, 4, 5]
+                expect(writer.statisticsSnapshot().applied) == 5
+                expect(writer.statisticsSnapshot().requested) == 5
+                expect(group.wait(timeout: .now())) == .success
+            }
+
+            it("drops frames a slow application cannot keep up with but always lands on the newest") {
+                let window = TestWindow(element: nil)!
+                window.animationFrameDelay = 0.03
+                let group = DispatchGroup()
+                let writer = ApplicationFrameWriter<TestWindow>(pid: 1, group: group, inline: false, now: { ProcessInfo.processInfo.systemUptime })
+
+                // Ten frames arrive faster than the window can apply them.
+                for step in 1...10 {
+                    writer.write([0: makeWrite(window, xPosition: CGFloat(step))])
+                    Thread.sleep(forTimeInterval: 0.002)
+                }
+
+                expect(group.wait(timeout: .now() + 2)) == .success
+                let statistics = writer.statisticsSnapshot()
+                expect(statistics.requested) == 10
+                expect(statistics.applied) < 10
+                expect(window.frame().minX) == 10
+                expect(self.isMonotonic(window.frameHistory.map { $0.minX })).to(beTrue())
+            }
+
+            it("keeps a queued resize when a later move replaces it") {
+                let window = TestWindow(element: nil)!
+                let group = DispatchGroup()
+                let started = DispatchSemaphore(value: 0)
+                let release = DispatchSemaphore(value: 0)
+                let writer = makeGatedWriter(group: group, started: started, release: release)
+
+                // A move is in flight; a resize queues behind it; then another move for the same window arrives.
+                writer.write([0: makeWrite(window, xPosition: 1)])
+                expect(started.wait(timeout: .now() + 2)) == .success
+                writer.write([0: .init(window: window, frame: CGRect(x: 2, y: 0, width: 300, height: 200), includingSize: true)])
+                writer.write([0: .init(window: window, frame: CGRect(x: 3, y: 0, width: 300, height: 200), includingSize: false)])
+                // Let the move through, then the frame merged behind it.
+                release.signal()
+                release.signal()
+
+                expect(group.wait(timeout: .now() + 2)) == .success
+                expect(window.frame()) == CGRect(x: 3, y: 0, width: 300, height: 200)
+            }
+
+            it("forgets discarded frames") {
+                let window = TestWindow(element: nil)!
+                let group = DispatchGroup()
+                let started = DispatchSemaphore(value: 0)
+                let release = DispatchSemaphore(value: 0)
+                let writer = makeGatedWriter(group: group, started: started, release: release)
+
+                writer.write([0: makeWrite(window, xPosition: 1)])
+                expect(started.wait(timeout: .now() + 2)) == .success
+                writer.write([0: makeWrite(window, xPosition: 2)])
+                writer.discardPending()
+                release.signal()
+
+                expect(group.wait(timeout: .now() + 2)) == .success
+                expect(window.frameHistory.map { $0.minX }) == [1]
+            }
+        }
+
+        describe("coordinates and parking") {
+            it("flips between AppKit and Accessibility coordinates and back") {
+                let flipped = CGRect(x: 10, y: 20, width: 100, height: 50)
+                let appKit = FlippedCoordinates.appKitRect(fromFlipped: flipped, primaryScreenHeight: 1000)
+                expect(appKit) == CGRect(x: 10, y: 930, width: 100, height: 50)
+                expect(FlippedCoordinates.flippedRect(fromAppKit: appKit, primaryScreenHeight: 1000)) == flipped
+            }
+
+            it("parks windows to the right of every display") {
+                let displays = [CGRect(x: 0, y: 0, width: 1728, height: 1117), CGRect(x: -962, y: -1600, width: 3840, height: 1600)]
+                let origin = AnimatedReflowOperation<TestWindow>.parkingOrigin(forDisplayBounds: displays)
+                expect(origin.x) == 2878 + 200
+            }
+
+            it("finds an attached screen by its identifier") {
+                expect(AMScreen.screen(withID: "not-a-screen")).to(beNil())
+
+                guard let screen = AMScreen.availableScreens.last, let screenID = screen.screenID() else {
+                    throw XCTSkip("needs an attached display")
+                }
+                expect(AMScreen.screen(withID: screenID)?.screenID()) == screenID
+            }
+
+            it("finds the display a screen frame lies on") {
+                let displays = [CGRect(x: 0, y: 0, width: 1728, height: 1117), CGRect(x: -962, y: -1600, width: 3840, height: 1600)]
+                let external = CGRect(x: -962, y: -1570, width: 3840, height: 1570)
+                expect(WindowImageCapture.displayBounds(containing: external, among: displays)) == displays[1]
+                expect(WindowImageCapture.displayBounds(containing: CGRect(x: 5000, y: 0, width: 10, height: 10), among: displays)).to(beNil())
+            }
+
+            it("picks the candidate whose bounds overlap a rectangle most") {
+                let displays = [CGRect(x: 0, y: 0, width: 1000, height: 800), CGRect(x: 1000, y: 0, width: 1000, height: 800)]
+                let names = ["left", "right"]
+                let mostlyRight = CGRect(x: 900, y: 100, width: 400, height: 100)
+                let mostlyLeft = CGRect(x: 700, y: 100, width: 400, height: 100)
+                let offEveryDisplay = CGRect(x: 3000, y: 100, width: 10, height: 10)
+                expect(ActiveDisplays.mostOverlapping(mostlyRight, among: [0, 1], bounds: { displays[$0] }).map { names[$0] }) == "right"
+                expect(ActiveDisplays.mostOverlapping(mostlyLeft, among: [0, 1], bounds: { displays[$0] }).map { names[$0] }) == "left"
+                expect(ActiveDisplays.mostOverlapping(offEveryDisplay, among: [0, 1], bounds: { displays[$0] })).to(beNil())
+            }
+        }
+
+        describe("screen capture permission hint") {
+            it("is offered once per preferences store") {
+                let suiteName = "AmethystTests.\(UUID().uuidString)"
+                let defaults = UserDefaults(suiteName: suiteName)!
+                defer { defaults.removePersistentDomain(forName: suiteName) }
+
+                expect(ScreenCapturePermission.takeHintOpportunity(defaults: defaults)).to(beTrue())
+                expect(ScreenCapturePermission.takeHintOpportunity(defaults: defaults)).to(beFalse())
+
+                defaults.removeObject(forKey: ScreenCapturePermission.hintShownKey)
+                expect(ScreenCapturePermission.takeHintOpportunity(defaults: defaults)).to(beTrue())
+            }
+        }
+
+        describe("overlay panel") {
+            it("calls a pending completion when it is replaced or the overlay is cancelled") {
+                let image = AnimatedReflowOperationTests.makeImage(width: 10, height: 10)
+                let proxy = SnapshotProxy(image: image, start: CGRect(x: 10, y: 60, width: 40, height: 40), target: CGRect(x: 80, y: 60, width: 40, height: 40))
+                var glideCompletions = 0
+                var correctionCompletions = 0
+                let screenFrame = try self.primaryScreenFrameOrSkip()
+                let overlay: ReflowAnimationOverlay = self.onMain {
+                    let overlay = ReflowAnimationOverlay()
+                    overlay.show(proxies: [proxy], screenFrame: screenFrame, backdrop: nil)
+                    overlay.animate(duration: 5) { glideCompletions += 1 }
+                    return overlay
+                }
+
+                self.onMain { overlay.retarget(frames: [CGRect(x: 90, y: 60, width: 40, height: 40)], duration: 5) { correctionCompletions += 1 } }
+                expect(glideCompletions) == 1
+                expect(correctionCompletions) == 0
+
+                self.onMain { overlay.cancel() }
+                expect(correctionCompletions) == 1
+
+                // Late Core Animation callbacks for the removed animations must not call anything a second time.
+                self.letMainThreadRun(attempts: 6) { false }
+                expect(glideCompletions) == 1
+                expect(correctionCompletions) == 1
+            }
+
+            it("hides a proxy without ending the glide of the others") {
+                let image = AnimatedReflowOperationTests.makeImage(width: 10, height: 10)
+                let proxies = [
+                    SnapshotProxy(image: image, start: CGRect(x: 10, y: 60, width: 40, height: 40), target: CGRect(x: 80, y: 60, width: 40, height: 40)),
+                    SnapshotProxy(image: image, start: CGRect(x: 10, y: 160, width: 40, height: 40), target: CGRect(x: 80, y: 160, width: 40, height: 40))
+                ]
+                var glideCompletions = 0
+                let screenFrame = try self.primaryScreenFrameOrSkip()
+                let overlay: ReflowAnimationOverlay = self.onMain {
+                    let overlay = ReflowAnimationOverlay()
+                    overlay.show(proxies: proxies, screenFrame: screenFrame, backdrop: nil)
+                    overlay.animate(duration: 5) { glideCompletions += 1 }
+                    // Correcting the first picture alone starts a newer batch of motion that holds only it.
+                    overlay.retarget(frames: [CGRect(x: 90, y: 60, width: 40, height: 40), nil], duration: 5, completion: nil)
+                    return overlay
+                }
+
+                // Hiding that picture, as happens when its window is thrown elsewhere, must not end the glide for the other.
+                self.onMain { overlay.hide(indices: [0]) }
+                self.letMainThreadRun(attempts: 6) { false }
+                expect(glideCompletions) == 0
+
+                self.onMain { overlay.cancel() }
+                expect(glideCompletions) == 1
+            }
+
+            it("keeps its panel on the Space it was made on") {
+                let image = AnimatedReflowOperationTests.makeImage(width: 10, height: 10)
+                let proxy = SnapshotProxy(image: image, start: CGRect(x: 10, y: 60, width: 40, height: 40), target: CGRect(x: 80, y: 60, width: 40, height: 40))
+                let screenFrame = try self.primaryScreenFrameOrSkip()
+                let overlay: ReflowAnimationOverlay = self.onMain {
+                    let overlay = ReflowAnimationOverlay()
+                    overlay.show(proxies: [proxy], screenFrame: screenFrame, backdrop: nil)
+                    return overlay
+                }
+                let behavior: NSWindow.CollectionBehavior? = self.onMain {
+                    NSApplication.shared.windows.first { $0.identifier == ReflowAnimationOverlay.panelIdentifier }?.collectionBehavior
+                }
+
+                // The panel stays with the Space it was made on; a Space switch carries it away.
+                expect(behavior).toNot(beNil())
+                expect(behavior?.contains(.canJoinAllSpaces)) == false
+                expect(behavior?.contains(.stationary)) == false
+                expect(behavior?.contains(.fullScreenAuxiliary)) == true
+
+                self.onMain { overlay.cancel() }
+            }
+
+            it("calls a pending completion when the overlay finishes") {
+                let image = AnimatedReflowOperationTests.makeImage(width: 10, height: 10)
+                let proxy = SnapshotProxy(image: image, start: CGRect(x: 10, y: 60, width: 40, height: 40), target: CGRect(x: 80, y: 60, width: 40, height: 40))
+                var glideCompletions = 0
+                var finishCompletions = 0
+                let screenFrame = try self.primaryScreenFrameOrSkip()
+                let overlay: ReflowAnimationOverlay = self.onMain {
+                    let overlay = ReflowAnimationOverlay()
+                    overlay.show(proxies: [proxy], screenFrame: screenFrame, backdrop: nil)
+                    overlay.animate(duration: 5) { glideCompletions += 1 }
+                    return overlay
+                }
+
+                self.onMain { overlay.finish(fadeDuration: 0.02, lingering: [], lingerDuration: 0.02) { finishCompletions += 1 } }
+                self.letMainThreadRun(attempts: 40) { glideCompletions == 1 && finishCompletions == 1 }
+                expect(glideCompletions) == 1
+                expect(finishCompletions) == 1
+            }
+
+            it("takes its panel down after the fade even when nothing else retains the overlay") {
+                let livePanels = { self.onMain { ReflowAnimationOverlay.livePanelCount } }
+                let image = AnimatedReflowOperationTests.makeImage(width: 10, height: 10)
+                let proxy = SnapshotProxy(image: image, start: CGRect(x: 10, y: 60, width: 40, height: 40), target: CGRect(x: 80, y: 60, width: 40, height: 40))
+
+                let screenFrame = try self.primaryScreenFrameOrSkip()
+                var overlay: ReflowAnimationOverlay? = self.onMain {
+                    let overlay = ReflowAnimationOverlay()
+                    overlay.show(proxies: [proxy], screenFrame: screenFrame, backdrop: nil)
+                    return overlay
+                }
+                expect(livePanels()) == 1
+
+                // The reflow operation drops its reference as soon as it has asked for the fade.
+                weak var stillAlive = overlay
+                self.onMain { overlay?.finish(fadeDuration: 0.02, lingering: [], lingerDuration: 0.02) {} }
+                overlay = nil
+
+                // The pending fade keeps the overlay alive by itself.
+                expect(stillAlive).toNot(beNil())
+
+                // Then the fade, or its fallback timer, takes the panel down, and once the fallback has fired nothing holds
+                // the overlay any more. The main thread must be left free to deliver both.
+                self.letMainThreadRun(attempts: 100) { livePanels() == 0 && stillAlive == nil }
+                expect(livePanels()) == 0
+                expect(stillAlive).to(beNil())
+            }
+        }
+
+        describe("frame assignment") {
+            it("applies window margins from the configuration it is given") {
+                let window = LayoutWindow<TestWindow>(id: "window", frame: .zero, isFocused: false)
+                let rules = ResizeRules(isMain: true, unconstrainedDimension: .horizontal, scaleFactor: 1)
+                let tile = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+                let storage = TestConfigurationStorage()
+                storage.set(true, forKey: .windowMargins)
+                storage.set(Float(20), forKey: .windowMarginSize)
+                let withMargins = FrameAssignment(frame: tile, window: window, screenFrame: tile, resizeRules: rules, configuration: UserConfiguration(storage: storage))
+                let withoutMargins = FrameAssignment(frame: tile, window: window, screenFrame: tile, resizeRules: rules, configuration: UserConfiguration(storage: TestConfigurationStorage()))
+
+                expect(withMargins.finalFrame) == CGRect(x: 10, y: 10, width: 980, height: 980)
+                expect(withoutMargins.finalFrame) == tile
+            }
+        }
+
+        describe("fake windows") {
+            it("never share a window identifier") {
+                let windows = (0..<50).map { _ in TestWindow(element: nil)! }
+                expect(Set(windows.map { $0.cgID() }).count) == windows.count
+            }
+        }
+
+        describe("animating windows registry") {
+            it("keeps a window with the screen animating it until that screen releases it") {
+                let registry = AnimatingWindows()
+                registry.claim([1, 2], for: "external")
+                expect(registry.screenID(for: 1)) == "external"
+                expect(registry.screenID(for: 3)).to(beNil())
+
+                // Another screen's release must not disturb the claim.
+                registry.release([1], for: "builtin")
+                expect(registry.screenID(for: 1)) == "external"
+
+                registry.release([1, 2], for: "external")
+                expect(registry.screenID(for: 1)).to(beNil())
+                expect(registry.screenID(for: 2)).to(beNil())
+            }
+
+            it("remembers a picture's last position for a second and hands it out once") {
+                let registry = AnimatingWindows()
+                let frame = CGRect(x: 10, y: 20, width: 300, height: 400)
+                registry.recordLastSeenFrames([1: frame], at: 0)
+                expect(registry.takeLastSeenFrame(for: 1, at: 1.5)).to(beNil())
+
+                registry.recordLastSeenFrames([1: frame], at: 0)
+                expect(registry.takeLastSeenFrame(for: 1, at: 0.5)) == frame
+                expect(registry.takeLastSeenFrame(for: 1, at: 0.5)).to(beNil())
+            }
+
+            it("ignores a claim by a screen that is no longer attached") {
+                let registry = AnimatingWindows()
+                registry.claim([1], for: "external")
+                expect(registry.screenID(for: 1, ifAmong: ["builtin", "external"])) == "external"
+                expect(registry.screenID(for: 1, ifAmong: ["builtin"])).to(beNil())
+                expect(registry.screenID(for: 2, ifAmong: ["builtin", "external"])).to(beNil())
+            }
+
+            it("refuses a write to a window that was handed off and reports where it was headed") {
+                let registry = AnimatingWindows()
+                let target = CGRect(x: 10, y: 20, width: 300, height: 400)
+                registry.claim([1], for: "external", targets: [1: target])
+                expect(registry.beginWrite(1, for: "external")).to(beTrue())
+                registry.endWrite(1)
+                expect(registry.beginWrite(1, for: "builtin")).to(beFalse())
+
+                expect(registry.handOff([1])) == [1: target]
+                expect(registry.beginWrite(1, for: "external")).to(beFalse())
+                expect(registry.screenID(for: 1)).to(beNil())
+                expect(registry.handOff([1])).to(beEmpty())
+            }
+
+            it("waits for a write in flight before handing a window off, but not forever") {
+                let registry = AnimatingWindows()
+                let target = CGRect(x: 10, y: 20, width: 300, height: 400)
+                registry.claim([1], for: "external", targets: [1: target])
+                expect(registry.beginWrite(1, for: "external")).to(beTrue())
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { registry.endWrite(1) }
+
+                var start = Date()
+                expect(registry.handOff([1])) == [1: target]
+                expect(Date().timeIntervalSince(start)) >= 0.09
+                expect(Date().timeIntervalSince(start)) < 0.9
+
+                // A write that never ends must not hold the throw hostage.
+                registry.claim([2], for: "external")
+                expect(registry.beginWrite(2, for: "external")).to(beTrue())
+                start = Date()
+                registry.handOff([2], timeout: 0.05)
+                expect(Date().timeIntervalSince(start)) >= 0.04
+                expect(Date().timeIntervalSince(start)) < 0.9
+                expect(registry.screenID(for: 2)).to(beNil())
+            }
+
+            it("forgets a window's destination when its screen releases it") {
+                let registry = AnimatingWindows()
+                registry.claim([1], for: "external", targets: [1: CGRect(x: 1, y: 2, width: 3, height: 4)])
+                registry.release([1], for: "external")
+                expect(registry.handOff([1])).to(beEmpty())
+            }
+
+            it("reports only the windows an animation is moving, so other windows' move notifications count as gestures") {
+                let registry = AnimatingWindows()
+                registry.claim([7], for: "external")
+                expect(registry.isAnimating(7)).to(beTrue())
+                expect(registry.isAnimating(8)).to(beFalse())
+
+                registry.release([7], for: "external")
+                expect(registry.isAnimating(7)).to(beFalse())
+            }
+        }
+
+        describe("snapshot animation") {
+            let startFrames = [
+                CGRect(x: 0, y: 0, width: 1000, height: 1000),
+                CGRect(x: 1000, y: 0, width: 1000, height: 1000)
+            ]
+            let targetFrames = [
+                CGRect(x: 0, y: 0, width: 500, height: 1000),
+                CGRect(x: 500, y: 0, width: 1500, height: 1000)
+            ]
+            let captureAll: ([WindowCaptureRequest]) -> [CGImage]? = { requests in requests.map { _ in AnimatedReflowOperationTests.makeImage() } }
+
+            it("parks, resizes out of sight, places, and settles each window") {
+                // Windows at distinct, non-zero heights: a window parks at the parking spot's x but keeps its own y.
+                let starts = [
+                    CGRect(x: 0, y: 40, width: 1000, height: 800),
+                    CGRect(x: 1000, y: 120, width: 1000, height: 800)
+                ]
+                let targets = [
+                    CGRect(x: 0, y: 40, width: 500, height: 800),
+                    CGRect(x: 500, y: 40, width: 1500, height: 800)
+                ]
+                let fixture = self.makeFixture(startFrames: starts, targetFrames: targets)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll)
+
+                operation.main()
+
+                for (index, window) in fixture.windows.enumerated() {
+                    let start = starts[index]
+                    let target = fixture.operations[index].frameAssignment.finalFrame
+                    let parked = CGPoint(x: self.parkingOrigin.x, y: start.minY)
+
+                    expect(window.frameHistory) == [
+                        CGRect(origin: parked, size: start.size),
+                        CGRect(origin: parked, size: target.size),
+                        CGRect(origin: target.origin, size: target.size),
+                        target
+                    ]
+                }
+
+                expect(operation.tickCount) == 0
+                expect(clock.sleepCount) == 1
+                expect(animator.finishCalled).to(beTrue())
+                expect(animator.cancelCalled).to(beFalse())
+            }
+
+            it("hands the overlay the start and target frames and the duration") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll)
+
+                operation.main()
+
+                expect(animator.shownProxies.map { $0.start }) == startFrames
+                expect(animator.shownProxies.map { $0.target }) == fixture.operations.map { FrameInterpolation.integral($0.frameAssignment.finalFrame) }
+                expect(animator.shownScreenFrame) == fixture.operations[0].frameAssignment.screenFrame
+                expect(animator.animateDuration) == self.duration
+            }
+
+            it("falls back to moving the real windows when capture fails") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: { _ in nil })
+
+                operation.main()
+
+                expect(animator.shownProxies).to(beEmpty())
+                expect(operation.tickCount) == self.expectedTicks
+                // The accessibility strategy starts with the in-place resize.
+                expect(fixture.windows[1].frameHistory.first) == CGRect(origin: startFrames[1].origin, size: fixture.operations[1].frameAssignment.finalFrame.size)
+            }
+
+            it("falls back when capture returns the wrong number of images") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: { _ in [AnimatedReflowOperationTests.makeImage()] })
+
+                operation.main()
+
+                expect(animator.shownProxies).to(beEmpty())
+                expect(operation.tickCount) == self.expectedTicks
+            }
+
+            it("re-lays out windows in place behind a backdrop and dissolves proxies into fresh captures") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                var glideStartedAt: TimeInterval = 0
+                var dissolvedAt: TimeInterval = 0
+                animator.onAnimate = { glideStartedAt = clock.now() }
+                animator.onCrossfade = { dissolvedAt = clock.now() }
+                // Captures are sized like the windows they picture, one pixel per point, so a fresh capture matches the accepted size.
+                let captureCurrent: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    requests.map { request in
+                        let size = fixture.window(for: request).frame().size
+                        return AnimatedReflowOperationTests.makeImage(width: Int(size.width), height: Int(size.height))
+                    }
+                }
+                var excludedFromBackdrop: [CGWindowID] = []
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureCurrent, backdrop: { _, ids in
+                    excludedFromBackdrop = ids
+                    return AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                expect(animator.shownBackdrop).toNot(beNil())
+                expect(excludedFromBackdrop) == fixture.windows.map { $0.cgID() }
+
+                // No parking: each window goes straight to its destination at its final size, then settles.
+                for (index, window) in fixture.windows.enumerated() {
+                    let target = fixture.operations[index].frameAssignment.finalFrame
+                    expect(window.frameHistory) == [target, target]
+                }
+
+                expect(animator.retargetedFrames).to(beEmpty())
+                expect(animator.crossfadeImages.count) == 1
+                expect(animator.crossfadeImages[0].compactMap { $0 }.count) == 2
+                // A mid-glide dissolve gets the time the glide has left, never less than the minimum dissolve.
+                expect(animator.crossfadeDurations[0]) == max(self.duration - (dissolvedAt - glideStartedAt), 0.15)
+                expect(animator.finishCalled).to(beTrue())
+            }
+
+            it("corrects the size and still dissolves when an application constrains its window in place") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let constrained = fixture.windows[1]
+                constrained.maximumSize = CGSize(width: 1200, height: 1000)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                let captureCurrent: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    requests.map { request in
+                        let size = fixture.window(for: request).frame().size
+                        return AnimatedReflowOperationTests.makeImage(width: Int(size.width), height: Int(size.height))
+                    }
+                }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureCurrent, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                let target = fixture.operations[1].frameAssignment.finalFrame
+                let accepted = CGRect(origin: target.origin, size: CGSize(width: 1200, height: 1000))
+                expect(animator.retargetedFrames.count) == 1
+                expect(animator.retargetedFrames[0][1]) == accepted
+                expect(animator.crossfadeImages.count) == 1
+                expect(animator.crossfadeImages[0][1]?.width) == 1200
+                expect(constrained.frame()) == accepted
+            }
+
+            it("refines one application's windows without waiting for a slower application") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let quick = fixture.windows[0]
+                quick.maximumSize = CGSize(width: 400, height: 1000)
+                let slow = fixture.windows[1]
+                // Window 1 belongs to another application, one that takes 0.4 s over every frame.
+                slow.pidValue = 5678
+                slow.animationFrameDelay = 0.4
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                let captureCurrent: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    requests.map { request in
+                        let size = fixture.window(for: request).frame().size
+                        return AnimatedReflowOperationTests.makeImage(width: Int(size.width), height: Int(size.height))
+                    }
+                }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureCurrent, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                }, writesInline: false)
+
+                operation.main()
+
+                // Window 0 is corrected on the first tick, while window 1's application is still busy: each application has a
+                // writer of its own.
+                let accepted = CGRect(origin: fixture.operations[0].frameAssignment.finalFrame.origin, size: CGSize(width: 400, height: 1000))
+                expect(animator.retargetedFrames.count) == 1
+                expect(animator.retargetedFrames[0][0]) == accepted
+                expect(animator.retargetedFrames[0][1]).to(beNil())
+                expect(clock.sleepCount) < 10
+                expect(animator.finishCalled).to(beTrue())
+            }
+
+            it("lets a window's picture linger when its recapture fails") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                var captureCalls = 0
+                // The first capture works; every later one comes back empty, as when the window server is busy.
+                let captureOnce: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    captureCalls += 1
+                    return captureCalls == 1 ? requests.map { _ in AnimatedReflowOperationTests.makeImage() } : nil
+                }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureOnce, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                expect(captureCalls) > 1
+                expect(animator.crossfadeImages).to(beEmpty())
+                expect(animator.lingering) == [0, 1]
+                expect(animator.finishCalled).to(beTrue())
+            }
+
+            it("judges a recapture's freshness at the display's pixel density") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                var captureCalls = 0
+                // A Retina display: two pixels per point. Window 1's recapture comes back at one pixel per point, the size a
+                // stale surface would have, while window 0's comes back at the display's density.
+                let captureRetina: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    captureCalls += 1
+                    return requests.map { request in
+                        let size = fixture.window(for: request).frame().size
+                        let scale = captureCalls > 1 && request.windowID == fixture.windows[1].cgID() ? 1 : 2
+                        return AnimatedReflowOperationTests.makeImage(width: Int(size.width) * scale, height: Int(size.height) * scale)
+                    }
+                }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureRetina, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                expect(animator.crossfadeImages.count) == 1
+                expect(animator.crossfadeImages[0][0]?.width) == Int(fixture.operations[0].frameAssignment.finalFrame.width) * 2
+                expect(animator.crossfadeImages[0][1]).to(beNil())
+                expect(animator.lingering) == [1]
+            }
+
+            it("dissolves a corrected window to a fresh picture within the glide") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let constrained = fixture.windows[1]
+                constrained.maximumSize = CGSize(width: 1200, height: 1000)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                // The glide keeps going through the correction and ends only once the fresh picture is in.
+                animator.endsGlideOnRefinement = false
+                animator.onCrossfade = { animator.endGlide() }
+                let captureCurrent: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    requests.map { request in
+                        let window = fixture.window(for: request)
+                        return AnimatedReflowOperationTests.makeImage(width: Int(window.frame().width), height: Int(window.frame().height))
+                    }
+                }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureCurrent, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                // Corrected in the loop, then dissolved in the loop with the time remaining, well before a stall.
+                expect(animator.retargetedFrames.count) == 1
+                expect(animator.crossfadeImages.count) == 1
+                expect(animator.crossfadeImages[0][1]?.width) == 1200
+                expect(animator.crossfadeDurations[0]) > 0.15
+                expect(clock.sleepCount) < 20
+                expect(animator.finishCalled).to(beTrue())
+            }
+
+            it("retries a stale recapture within the glide") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                animator.endsGlideOnRefinement = false
+                // The glide ends on the second dissolve, the one that brings the retried picture in.
+                animator.onCrossfade = { animator.onCrossfade = { animator.endGlide() } }
+                var captureCalls = 0
+                let captureLagging: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    captureCalls += 1
+                    return requests.map { request in
+                        let window = fixture.window(for: request)
+                        // The second window's first recapture still shows its old surface, the way a slow renderer does.
+                        let stale = captureCalls == 2 && request.windowID == fixture.windows[1].cgID()
+                        let size = stale ? startFrames[1].size : window.frame().size
+                        return AnimatedReflowOperationTests.makeImage(width: Int(size.width), height: Int(size.height))
+                    }
+                }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureLagging, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                expect(captureCalls) == 3
+                expect(animator.crossfadeImages.count) == 2
+                expect(animator.crossfadeImages[0][1]).to(beNil())
+                expect(animator.crossfadeImages[1][1]?.width) == Int(fixture.operations[1].frameAssignment.finalFrame.width)
+                // The glide could only end through the second dissolve, so a short glide proves the retry came within it
+                // rather than at a stall's final attempt, which takes over forty sleeps to reach.
+                expect(clock.sleepCount) < 20
+                expect(animator.lingering).to(beEmpty())
+            }
+
+            it("retries a recapture until the window has redrawn at its accepted size") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                var captureCalls = 0
+                // The second window's first recapture still shows its old surface, the way a slow renderer does.
+                let captureLagging: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    captureCalls += 1
+                    return requests.map { request in
+                        let stale = captureCalls == 2 && request.windowID == fixture.windows[1].cgID()
+                        let size = stale ? startFrames[1].size : fixture.window(for: request).frame().size
+                        return AnimatedReflowOperationTests.makeImage(width: Int(size.width), height: Int(size.height))
+                    }
+                }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureLagging, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                expect(captureCalls) == 3
+                expect(animator.crossfadeImages.count) == 2
+                expect(animator.crossfadeImages[0][0]).toNot(beNil())
+                expect(animator.crossfadeImages[0][1]).to(beNil())
+                expect(animator.crossfadeImages[1][1]?.width) == Int(fixture.operations[1].frameAssignment.finalFrame.width)
+                expect(animator.finishCalled).to(beTrue())
+                expect(animator.lingering).to(beEmpty())
+            }
+
+            it("does not dissolve a window whose capture cannot be verified and lets its proxy linger instead") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                let captureCurrent: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    requests.map { request in
+                        let window = fixture.window(for: request)
+                        return AnimatedReflowOperationTests.makeImage(width: Int(window.frame().width), height: Int(window.frame().height))
+                    }
+                }
+                // Window 1 overhangs the display, so its recapture would come back scaled to size whether or not it has redrawn.
+                let overhanging = fixture.windows[1].cgID()
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureCurrent, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                }, verifiable: { $0.windowID != overhanging })
+
+                operation.main()
+
+                expect(animator.crossfadeImages.count) == 1
+                expect(animator.crossfadeImages[0][0]).toNot(beNil())
+                expect(animator.crossfadeImages[0][1]).to(beNil())
+                expect(animator.lingering) == [1]
+            }
+
+            it("lets a proxy linger at the handoff when its window never redraws") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                var captureCalls = 0
+                // The second window's surface never changes, the way an app that does not repaint while covered behaves.
+                let captureStuck: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    captureCalls += 1
+                    return requests.map { request in
+                        let stuck = captureCalls > 1 && request.windowID == fixture.windows[1].cgID()
+                        let size = stuck ? startFrames[1].size : fixture.window(for: request).frame().size
+                        return AnimatedReflowOperationTests.makeImage(width: Int(size.width), height: Int(size.height))
+                    }
+                }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureStuck, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                expect(animator.crossfadeImages.count) == 1
+                expect(animator.crossfadeImages[0][1]).to(beNil())
+                expect(animator.lingering) == [1]
+                expect(animator.finishCalled).to(beTrue())
+            }
+
+            it("captures a window that overhangs the display edge whole and asks for it at its current frame") {
+                // A window too wide for its tile, like Mail, ends up 100 points past the right edge of the display.
+                let fixture = self.makeFixture(startFrames: [CGRect(x: 0, y: 0, width: 1100, height: 1000)], targetFrames: [CGRect(x: 1000, y: 0, width: 1000, height: 1000)])
+                let window = fixture.windows[0]
+                window.minimumSize = CGSize(width: 1100, height: 1000)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                var requestedFrames: [CGRect] = []
+                let captureWhole: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    requests.map { request in
+                        requestedFrames.append(request.frame)
+                        let size = window.frame().size
+                        return AnimatedReflowOperationTests.makeImage(width: Int(size.width), height: Int(size.height))
+                    }
+                }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureWhole, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                let landed = CGRect(x: 1000, y: 0, width: 1100, height: 1000)
+                expect(window.frame()) == landed
+                expect(requestedFrames.first) == CGRect(x: 0, y: 0, width: 1100, height: 1000)
+                expect(requestedFrames.last) == landed
+                expect(animator.retargetedFrames.count) == 1
+                expect(animator.retargetedFrames[0][0]) == landed
+                expect(animator.crossfadeImages.count) == 1
+                expect(animator.crossfadeImages[0][0]?.width) == 1100
+                expect(animator.lingering).to(beEmpty())
+            }
+
+            it("keeps the focused window's proxy on screen in place when the application keeps a larger size") {
+                // A focused window with a 1100-point minimum width assigned a 500-point tile at the right edge of a 2000-point screen.
+                let fixture = self.makeFixture(startFrames: [CGRect(x: 0, y: 0, width: 1100, height: 1000)], targetFrames: [CGRect(x: 1500, y: 0, width: 500, height: 1000)], focusedIndex: 0)
+                let window = fixture.windows[0]
+                window.minimumSize = CGSize(width: 1100, height: 1000)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                let captureWhole: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    requests.map { _ in AnimatedReflowOperationTests.makeImage(width: Int(window.frame().width), height: Int(window.frame().height)) }
+                }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureWhole, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                // The settle keeps the window on screen; the proxy must be steered to that same frame, not to the overhanging one.
+                let onScreen = CGRect(x: 900, y: 0, width: 1100, height: 1000)
+                expect(window.frame()) == onScreen
+                expect(animator.retargetedFrames.count) == 1
+                expect(animator.retargetedFrames[0][0]) == onScreen
+            }
+
+            it("does not correct a window whose application has still not applied its frame when the glide ends") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                // Window 1's application takes longer than the whole animation to apply the in-place frame.
+                fixture.windows[1].animationFrameDelay = 0.6
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                }, writesInline: false)
+
+                operation.main()
+
+                // Reading it back now would return its old frame; no correction may be issued for it.
+                expect(animator.retargetedFrames.flatMap { $0 }.compactMap { $0 }).to(beEmpty())
+                expect(animator.finishCalled).to(beTrue())
+            }
+
+            it("aims a non-resizable window's proxy at the tile position with the window's own size, in parked mode too") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let fixed = fixture.windows[1]
+                fixed.isResizableValue = false
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll)
+
+                operation.main()
+
+                // The window only ever moves, so both its picture and its final frame use its original size.
+                let expected = CGRect(origin: fixture.operations[1].frameAssignment.finalFrame.origin, size: startFrames[1].size)
+                expect(animator.shownProxies[1].target) == expected
+                expect(fixed.frame()) == expected
+            }
+
+            it("steers a proxy to where its window actually lands when the application refuses a position") {
+                let fixture = self.makeFixture(startFrames: [CGRect(x: 0, y: 500, width: 1000, height: 500)], targetFrames: [CGRect(x: 0, y: 0, width: 1000, height: 500)])
+                let window = fixture.windows[0]
+                window.minimumY = 30
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                let captureFixed: ([WindowCaptureRequest]) -> [CGImage]? = { requests in
+                    requests.map { _ in AnimatedReflowOperationTests.makeImage(width: 1000, height: 500) }
+                }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureFixed, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                let landed = CGRect(x: 0, y: 30, width: 1000, height: 500)
+                expect(animator.retargetedFrames.count) == 1
+                expect(animator.retargetedFrames[0][0]) == landed
+                expect(window.frame()) == landed
+            }
+
+            it("survives a late correction whose completion never arrives") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                fixture.windows[1].maximumSize = CGSize(width: 1200, height: 1000)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.swallowsCorrectionCompletions = true
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll)
+
+                operation.main()
+
+                // The correction was requested and its completion never came; the operation still finishes.
+                expect(animator.retargetedFrames.count) == 1
+                expect(animator.finishCalled).to(beTrue())
+            }
+
+            it("steers a proxy to the size its application actually accepts") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let constrained = fixture.windows[1]
+                constrained.maximumSize = CGSize(width: 1200, height: 1000)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll)
+
+                operation.main()
+
+                let target = fixture.operations[1].frameAssignment.finalFrame
+                let accepted = CGRect(origin: target.origin, size: CGSize(width: 1200, height: 1000))
+
+                // Only the constrained window is corrected, to its accepted size at the assigned position.
+                expect(animator.retargetedFrames.count) == 1
+                expect(animator.retargetedFrames[0][0]).to(beNil())
+                expect(animator.retargetedFrames[0][1]) == accepted
+                expect(constrained.frame()) == accepted
+                expect(animator.finishCalled).to(beTrue())
+                // Parked windows cannot be captured, so no dissolve happens in this mode.
+                expect(animator.crossfadeImages).to(beEmpty())
+            }
+
+            it("leaves out a window whose frame cannot be read and still settles it") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                fixture.windows[0].frameIsUnreadable = true
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                // A real screen identifier, as the screen manager always supplies one: the settle must not mistake a window
+                // that was never claimed for one that was handed off.
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll, screenID: "screen-a")
+
+                operation.main()
+
+                // Only the readable window animates; the other gets the settle pass alone, as in a non-animated reflow.
+                expect(animator.shownProxies.count) == 1
+                expect(fixture.windows[0].frameHistory.count) == 1
+                expect(fixture.windows[1].frame()) == fixture.operations[1].frameAssignment.finalFrame
+            }
+
+            it("keeps a window's target when its frame becomes unreadable mid-animation") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                // The app stops answering right after it accepts its new frame.
+                fixture.windows[1].onAnimationFrame = { _ in fixture.windows[1].frameIsUnreadable = true }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                })
+
+                operation.main()
+
+                // No correction: the proxy keeps its original target and the handoff still happens.
+                expect(animator.retargetedFrames.flatMap { $0 }.compactMap { $0 }).to(beEmpty())
+                expect(animator.finishCalled).to(beTrue())
+            }
+
+            it("drops frames still queued for a window handed off while its application was busy") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                let thrown = fixture.windows[1]
+                // The application takes 0.4 s over the park write, so the resize queued behind it is still waiting when the
+                // throw comes 0.2 s in.
+                thrown.animationFrameDelay = 0.4
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll, screenID: "source", writesInline: false)
+
+                // The wait below is polled, and polling a group does not consume its signal.
+                let finished = DispatchGroup()
+                finished.enter()
+                Thread.detachNewThread {
+                    operation.main()
+                    finished.leave()
+                }
+                self.letMainThreadRun(attempts: 4) { false }
+                let handedOff = AnimatingWindows.shared.handOff([thrown.cgID()])
+
+                // The hand-off waited for the park write to land and reported where the window was headed, so the throw can
+                // put it back on screen first.
+                expect(thrown.frameHistory.count) == 1
+                expect(handedOff[thrown.cgID()]) == fixture.operations[1].frameAssignment.finalFrame
+                self.letMainThreadRun(attempts: 100) { finished.wait(timeout: .now()) == .success }
+
+                // The resize queued behind the park must not land, nor anything after it.
+                expect(thrown.frameHistory.count) == 1
+                expect(fixture.windows[0].frame()) == fixture.operations[0].frameAssignment.finalFrame
+                expect(animator.finishCalled).to(beTrue())
+            }
+
+            it("forgets where a handed-off window's picture was when cancelled") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                animator.framesToPresent = [
+                    CGRect(x: 0, y: 0, width: 500, height: 1000),
+                    CGRect(x: 750, y: 0, width: 1500, height: 1000)
+                ]
+                let thrown = fixture.windows[1]
+                var operation: AnimatedReflowOperation<TestWindow>!
+                // The user throws window 1 elsewhere as the glide starts, and a new reflow cancels right after.
+                animator.onAnimate = {
+                    AnimatingWindows.shared.handOff([thrown.cgID()])
+                    operation.cancel()
+                }
+                operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll, screenID: "source")
+
+                operation.main()
+
+                // The window still ours starts its next picture where it was; the thrown one must not be remembered here.
+                expect(AnimatingWindows.shared.takeLastSeenFrame(for: fixture.windows[0].cgID(), at: clock.now())) == animator.framesToPresent[0]
+                expect(AnimatingWindows.shared.takeLastSeenFrame(for: thrown.cgID(), at: clock.now())).to(beNil())
+            }
+
+            it("lets go of a window Amethyst moves elsewhere mid-glide") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                let thrown = fixture.windows[1]
+                // The user throws window 1 to another screen just as the glide starts.
+                animator.onAnimate = { AnimatingWindows.shared.handOff([thrown.cgID()]) }
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                }, screenID: "source")
+
+                operation.main()
+
+                // Its proxy is hidden, and it receives nothing beyond the write that had already been issued: no correction,
+                // no placement, no settle to its old tile. The other window completes normally.
+                expect(animator.hiddenIndices) == [1]
+                expect(thrown.frameHistory.count) == 1
+                expect(fixture.windows[0].frame()) == fixture.operations[0].frameAssignment.finalFrame
+                expect(animator.finishCalled).to(beTrue())
+                expect(AnimatingWindows.shared.screenID(for: fixture.windows[0].cgID())).to(beNil())
+            }
+
+            it("settles and fades even when the glide never reports completion") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                // Nothing ever completes the glide, as when a display is asleep.
+                animator.completesImmediately = false
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll)
+
+                operation.main()
+
+                expect(animator.cancelCalled).to(beFalse())
+                expect(animator.finishCalled).to(beTrue())
+                expect(fixture.windows.map { $0.frame() }) == fixture.operations.map { $0.frameAssignment.finalFrame }
+            }
+
+            it("skips late corrections and dissolves once the glide has stalled") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                // The render server never reports anything back, as when a display is asleep.
+                animator.completesImmediately = false
+                animator.endsGlideOnRefinement = false
+                let constrained = fixture.windows[1]
+                constrained.maximumSize = CGSize(width: 1200, height: 1000)
+                // Its application is busy for the whole glide, which passes in an instant on the fake clock, so its correction
+                // would only be possible afterwards, when nothing can be seen or reported any more.
+                constrained.animationFrameDelay = 0.1
+                let operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll, backdrop: { _, _ in
+                    AnimatedReflowOperationTests.makeImage(width: 4, height: 4)
+                }, writesInline: false)
+
+                operation.main()
+
+                expect(animator.finishCalled).to(beTrue())
+                expect(animator.retargetedFrames).to(beEmpty())
+                expect(animator.crossfadeImages).to(beEmpty())
+            }
+
+            it("takes the overlay down when cancelled after the glide but before the handoff") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                var operation: AnimatedReflowOperation<TestWindow>!
+                // Parked mode places the real windows only after the glide; a new reflow cancels right then.
+                let target = fixture.operations[1].frameAssignment.finalFrame
+                fixture.windows[1].onAnimationFrame = { frame in
+                    if frame.origin == target.origin {
+                        operation.cancel()
+                    }
+                }
+                operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll)
+
+                operation.main()
+
+                expect(operation.isCancelled).to(beTrue())
+                expect(animator.finishCalled).to(beFalse())
+                expect(animator.cancelCalled).to(beTrue())
+            }
+
+            it("leaves windows at their tiles when cancelled mid-glide and lets the next animation start from where the pictures were") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let animator = FakeSnapshotAnimator()
+                animator.completesImmediately = false
+                let midway = [
+                    CGRect(x: 0, y: 0, width: 500, height: 1000),
+                    CGRect(x: 750, y: 0, width: 1500, height: 1000)
+                ]
+                animator.framesToPresent = midway
+                var operation: AnimatedReflowOperation<TestWindow>!
+                animator.onAnimate = { operation.cancel() }
+                operation = self.makeSnapshotOperation(fixture, clock: clock, animator: animator, capture: captureAll)
+
+                operation.main()
+
+                expect(animator.cancelCalled).to(beTrue())
+                expect(animator.finishCalled).to(beFalse())
+                // The reflow that cancelled us may do nothing, so the real windows must already be at valid tiles.
+                let moved = fixture.windows[1]
+                expect(moved.frame().origin) == fixture.operations[1].frameAssignment.finalFrame.origin
+
+                // A follow-up animation moving the same windows back starts its pictures where the user last saw them.
+                let followUpAnimator = FakeSnapshotAnimator()
+                let followUpOperations = fixture.operations.enumerated().map { index, original -> FrameAssignmentOperation<TestWindow> in
+                    let assignment = original.frameAssignment
+                    let reversed = FrameAssignment(
+                        frame: startFrames[index], window: assignment.window, screenFrame: assignment.screenFrame,
+                        resizeRules: assignment.resizeRules, configuration: assignment.configuration
+                    )
+                    return FrameAssignmentOperation(frameAssignment: reversed, windowSet: original.windowSet)
+                }
+                let followUpOperation = AnimatedReflowOperation(
+                    frameAssignmentOperations: followUpOperations,
+                    duration: self.duration,
+                    frameInterval: self.frameInterval,
+                    writesInline: true,
+                    captureImages: captureAll,
+                    makeSnapshotAnimator: { followUpAnimator },
+                    parkingOrigin: { self.parkingOrigin },
+                    now: clock.now,
+                    sleep: clock.sleep
+                )
+                followUpOperation.main()
+
+                expect(followUpAnimator.shownProxies.map { $0.start }) == midway
+            }
+        }
+
+        describe("animated reflow") {
+            let startFrames = [
+                CGRect(x: 0, y: 0, width: 1000, height: 1000),
+                CGRect(x: 1000, y: 0, width: 1000, height: 1000)
+            ]
+            let targetFrames = [
+                CGRect(x: 0, y: 0, width: 500, height: 1000),
+                CGRect(x: 500, y: 0, width: 1500, height: 1000)
+            ]
+
+            it("moves every window together to its final frame") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let operation = self.makeOperation(fixture, clock: clock)
+
+                operation.main()
+
+                expect(operation.tickCount) == self.expectedTicks
+
+                for (index, window) in fixture.windows.enumerated() {
+                    let target = fixture.operations[index].frameAssignment.finalFrame
+                    // Windows first take their final size in place, then glide: every frame lies within that envelope.
+                    let resizedInPlace = CGRect(origin: startFrames[index].origin, size: target.size)
+                    let bounds = startFrames[index].union(target).union(resizedInPlace)
+
+                    expect(window.frame()) == target
+                    // Window 0 only changes size, so it is done after the in-place resize plus the settle; window 1 also glides.
+                    if startFrames[index].origin == target.origin {
+                        expect(window.frameHistory.count) == 2
+                    } else {
+                        expect(window.frameHistory.count) > 2
+                    }
+
+                    for frame in window.frameHistory {
+                        expect(bounds.contains(frame)).to(beTrue())
+                    }
+
+                    let history = [startFrames[index]] + window.frameHistory
+                    expect(self.isMonotonic(history.map { $0.minX })).to(beTrue())
+                    expect(self.isMonotonic(history.map { $0.minY })).to(beTrue())
+                    expect(self.isMonotonic(history.map { $0.width })).to(beTrue())
+                    expect(self.isMonotonic(history.map { $0.height })).to(beTrue())
+                }
+            }
+
+            it("starts gently") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let operation = self.makeOperation(fixture, clock: clock)
+
+                operation.main()
+
+                let window = fixture.windows[1]
+                let target = fixture.operations[1].frameAssignment.finalFrame
+                let totalTravel = abs(target.minX - startFrames[1].minX)
+                // frameHistory[0] is the in-place resize; frameHistory[1] is the first glide frame.
+                let firstStep = abs(window.frameHistory[1].minX - startFrames[1].minX)
+
+                expect(firstStep) < totalTravel / 10
+            }
+
+            it("resizes each window once in place, then only moves it") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let operation = self.makeOperation(fixture, clock: clock)
+
+                operation.main()
+
+                let window = fixture.windows[1]
+                let target = fixture.operations[1].frameAssignment.finalFrame
+                let history = window.frameHistory
+
+                // First write: final size at the original position, issued before the clock started.
+                expect(history.first) == CGRect(origin: startFrames[1].origin, size: target.size)
+                expect(clock.sleepCount) == operation.tickCount
+
+                // Every glide frame keeps that size; only the settle pass at the very end may differ by rounding.
+                for frame in history.dropFirst().dropLast() {
+                    expect(frame.size) == target.size
+                }
+                expect(Set(history.map { "\($0.minX),\($0.minY)" }).count) > 4
+            }
+
+            it("skips windows that are already in place") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: [startFrames[0], targetFrames[1]])
+                let clock = FakeClock()
+                let operation = self.makeOperation(fixture, clock: clock)
+
+                operation.main()
+
+                // The unchanged window only receives the settle pass; the moving window animates.
+                expect(fixture.windows[0].frameHistory.count) == 1
+                expect(fixture.windows[1].frameHistory.count) > 2
+            }
+
+            it("does nothing but settle when no window needs to move") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: startFrames)
+                let clock = FakeClock()
+                let operation = self.makeOperation(fixture, clock: clock)
+
+                operation.main()
+
+                expect(operation.tickCount) == 0
+                expect(clock.sleepCount) == 0
+                expect(fixture.windows.map { $0.frameHistory.count }) == [1, 1]
+            }
+
+            it("stops without settling when cancelled") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                let operation = self.makeOperation(fixture, clock: clock)
+                clock.onSleep = { count in
+                    if count == 3 {
+                        operation.cancel()
+                    }
+                }
+
+                operation.main()
+
+                expect(operation.tickCount) == 3
+                // The glide stops, but the window is left at its tile rather than mid-way, since no reflow may follow.
+                expect(fixture.windows[1].frame()) == fixture.operations[1].frameAssignment.finalFrame
+            }
+
+            it("clamps the focused window with the size it asked for while a slow application is still resizing") {
+                // The focused window shrinks to 400pt and moves to the right edge of the 2000pt screen. Its application takes
+                // longer over the resize than the operation waits before reading sizes back, so the on-screen clamp must use
+                // the 400pt size asked for.
+                let edgeTarget = CGRect(x: 1600, y: 0, width: 400, height: 1000)
+                let fixture = self.makeFixture(startFrames: [startFrames[0]], targetFrames: [edgeTarget], focusedIndex: 0)
+                let clock = FakeClock()
+                let slow = fixture.windows[0]
+                slow.animationFrameDelay = 0.65
+                let operation = self.makeOperation(fixture, clock: clock, writesInline: false, drainTimeout: 0.5)
+
+                operation.main()
+
+                // The resize lands first, then the last glide frame, then the settle's writes. Clamped with the 400pt size
+                // asked for, the glide nearly reaches the tile.
+                expect(slow.frameHistory.count) >= 3
+                expect(slow.frameHistory[0].size) == edgeTarget.size
+                expect(slow.frameHistory[1].origin.x) > 1500
+                expect(slow.frame()) == edgeTarget
+            }
+
+            it("leaves windows at their tiles when cancelled right after the in-place resize") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                var operation: AnimatedReflowOperation<TestWindow>!
+                // The first frame any window receives is its in-place resize; a new reflow cancels the moment it lands.
+                fixture.windows[0].onAnimationFrame = { _ in operation.cancel() }
+                operation = self.makeOperation(fixture, clock: clock)
+
+                operation.main()
+
+                expect(operation.tickCount) == 0
+                expect(fixture.windows.map { $0.frame() }) == fixture.operations.map { $0.frameAssignment.finalFrame }
+            }
+
+            it("leaves windows at their tiles when cancelled while waiting for a slow application after the glide") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let clock = FakeClock()
+                var operation: AnimatedReflowOperation<TestWindow>!
+                let slow = fixture.windows[1]
+                // The glide runs on the fake clock in an instant, so the second frame the slow window receives, its first
+                // glide frame, lands while the operation is already waiting for the application after the glide.
+                slow.animationFrameDelay = 0.1
+                slow.onAnimationFrame = { _ in
+                    slow.onAnimationFrame = { _ in operation.cancel() }
+                }
+                operation = self.makeOperation(fixture, clock: clock, writesInline: false)
+
+                operation.main()
+
+                expect(operation.isCancelled).to(beTrue())
+                expect(slow.frame().origin) == fixture.operations[1].frameAssignment.finalFrame.origin
+                expect(fixture.windows[0].frame()) == fixture.operations[0].frameAssignment.finalFrame
+            }
+
+            it("keeps the focused window on screen") {
+                // The target hangs off the right edge of the 2000pt screen; the focused window must be clamped every tick.
+                let offscreenTarget = CGRect(x: 1600, y: 0, width: 800, height: 1000)
+                let fixture = self.makeFixture(startFrames: [startFrames[0]], targetFrames: [offscreenTarget], focusedIndex: 0)
+                let clock = FakeClock()
+                let operation = self.makeOperation(fixture, clock: clock)
+
+                operation.main()
+
+                // Every animated frame (all but the settle pass at the end) stays within the screen.
+                for frame in fixture.windows[0].frameHistory.dropLast() {
+                    expect(frame.maxX) <= 2000
+                }
+            }
+
+            it("keeps a window that took focus after the layout was planned on screen when settling") {
+                // The layout was planned with nothing focused; focus then moved to the window, whose application refuses to
+                // shrink below 800pt, so the settle must shift it left to stay within the 2000pt screen.
+                let offscreenTarget = CGRect(x: 1600, y: 0, width: 400, height: 1000)
+                let fixture = self.makeFixture(startFrames: [startFrames[0]], targetFrames: [offscreenTarget])
+                let window = fixture.windows[0]
+                window.minimumSize = CGSize(width: 800, height: 1000)
+                window.isFocusedValue = true
+
+                fixture.operations[0].frameAssignment.perform(withWindow: window)
+
+                expect(window.frame()) == CGRect(x: 1200, y: 0, width: 800, height: 1000)
+            }
+
+            it("keeps the focused window on screen with the size its application kept") {
+                // The tile fits the screen, but the app keeps the window 1100 wide, so the glide must clamp with that width.
+                let fixture = self.makeFixture(startFrames: [CGRect(x: 0, y: 0, width: 1100, height: 1000)], targetFrames: [CGRect(x: 1500, y: 0, width: 500, height: 1000)], focusedIndex: 0)
+                fixture.windows[0].minimumSize = CGSize(width: 1100, height: 1000)
+                let clock = FakeClock()
+                let operation = self.makeOperation(fixture, clock: clock)
+
+                operation.main()
+
+                for frame in fixture.windows[0].frameHistory {
+                    expect(frame.maxX) <= 2000
+                }
+                expect(fixture.windows[0].frame()) == CGRect(x: 900, y: 0, width: 1100, height: 1000)
+            }
+
+            it("lets no queued frame land after the settle when an application outlasts the wait") {
+                let fixture = self.makeFixture(startFrames: startFrames, targetFrames: targetFrames)
+                let slow = fixture.windows[1]
+                slow.animationFrameDelay = 0.6
+                let clock = FakeClock()
+                let operation = AnimatedReflowOperation(
+                    frameAssignmentOperations: fixture.operations,
+                    duration: self.duration,
+                    frameInterval: self.frameInterval,
+                    writesInline: false,
+                    now: clock.now,
+                    sleep: clock.sleep
+                )
+
+                operation.main()
+
+                // The operation waits for its writers before settling and before returning, so nothing is in flight now and
+                // the settle's write must be the last thing the window received.
+                expect(slow.frameHistory.last) == fixture.operations[1].frameAssignment.finalFrame
+                expect(slow.frame()) == fixture.operations[1].frameAssignment.finalFrame
+            }
+
+            it("finishes immediately with no assignments") {
+                let clock = FakeClock()
+                let operation = AnimatedReflowOperation<TestWindow>(
+                    frameAssignmentOperations: [],
+                    duration: self.duration,
+                    frameInterval: self.frameInterval,
+                    writesInline: true,
+                    now: clock.now,
+                    sleep: clock.sleep
+                )
+
+                operation.main()
+
+                expect(operation.tickCount) == 0
+            }
+        }
+    }
+}

--- a/AmethystTests/Tests/Model/EnhancedUserInterfaceSuppressionTests.swift
+++ b/AmethystTests/Tests/Model/EnhancedUserInterfaceSuppressionTests.swift
@@ -1,0 +1,87 @@
+//
+//  EnhancedUserInterfaceSuppressionTests.swift
+//  AmethystTests
+//
+
+@testable import Amethyst
+import Foundation
+import Nimble
+import Quick
+
+class EnhancedUserInterfaceSuppressionTests: QuickSpec {
+    override func spec() {
+        describe("enhanced user interface suppression") {
+            var suppression: EnhancedUserInterfaceSuppression!
+            var clears: [pid_t] = []
+            var restores: [pid_t] = []
+
+            func begin(_ pid: pid_t, flagWasSet: Bool = true) {
+                suppression.begin(for: pid) {
+                    clears.append(pid)
+                    return flagWasSet
+                }
+            }
+
+            func end(_ pid: pid_t) {
+                suppression.end(for: pid) {
+                    restores.append(pid)
+                }
+            }
+
+            beforeEach {
+                suppression = EnhancedUserInterfaceSuppression()
+                clears = []
+                restores = []
+            }
+
+            it("clears the flag for the first window and restores it only after the last window ends") {
+                begin(1)
+                begin(1)
+                expect(clears) == [1]
+
+                end(1)
+                expect(restores) == []
+
+                end(1)
+                expect(restores) == [1]
+            }
+
+            it("leaves an application alone whose flag was not set") {
+                begin(1, flagWasSet: false)
+                end(1)
+                expect(clears) == [1]
+                expect(restores) == []
+            }
+
+            it("tracks applications independently") {
+                begin(1)
+                begin(2)
+                end(1)
+                expect(restores) == [1]
+
+                end(2)
+                expect(restores) == [1, 2]
+            }
+
+            it("ignores an end without a matching begin") {
+                end(1)
+                expect(restores) == []
+
+                begin(1)
+                end(1)
+                end(1)
+                expect(clears) == [1]
+                expect(restores) == [1]
+            }
+
+            it("clears the flag again for a later animation") {
+                begin(1)
+                end(1)
+                begin(1)
+                end(1)
+                expect(clears) == [1, 1]
+                expect(restores) == [1, 1]
+            }
+        }
+    }
+}

--- a/docs/configuration-files.md
+++ b/docs/configuration-files.md
@@ -40,6 +40,8 @@ Amethyst will pick up a config file located at `~/.amethyst.yml` or `~/.config/a
 | `restore-layouts-on-launch` | `true` to maintain layout state across application executions (default `true`). |
 | `debug-layout-info` | `true` to display some optional debug information in the layout HUD (default `false`). |
 | `disable-padding-on-builtin-display` |  `true` to disable screen padding on in-built display (default `false`). |
+| `animate-windows` | `true` to animate windows as they move to their new frames during a reflow (default `false`). With the Screen Recording permission granted, Amethyst slides snapshots of the windows for smooth motion; without it, it moves the real windows. Respects the system Reduce Motion setting. |
+| `window-animation-duration` | Duration of the window movement animation in seconds, between `0.05` and `1.0` (default `0.3`). |
 | `hide-menu-bar-icon` | `true` to hide the menu bar icon (default `false`). |
 
 ## Commands
@@ -93,6 +95,7 @@ A mod is a list of keyboard modifiers. Namely, `option`, `control`, `shift`, and
 | `disable-tiling` | Turn off tiling. |
 | `reevaluate-windows` | Rerun the current layout's algorithm. |
 | `toggle-focus-follows-mouse` | Turn on or off `focus-follows-mouse`. |
+| `toggle-animate-windows` | Turn on or off `animate-windows`. Unbound by default. |
 | `relaunch-amethyst` | Automatically quit and reopen Amethyst. |
 
 ### Layout Selection


### PR DESCRIPTION
## Animate windows as they move between tiles

Until now every reflow snapped windows straight to their new positions. With the new "Animate window movement" setting turned on, windows glide to their new tiles instead. It is off by default.

Amethyst takes a picture of each window that is about to move, shows those pictures exactly where the windows are, and slides the pictures to their destinations using the system's own compositor, which keeps the motion smooth no matter how slow the apps are. Meanwhile the real windows are moved and resized behind a frozen backdrop of the screen, out of sight. Once an app has redrawn its window at the new size, Amethyst takes a fresh picture and dissolves it into the sliding one, so the picture that lands is the real final rendering rather than a stretched old one. At the end the overlay fades away over windows that already look exactly like it.

Along the way this handles the awkward cases:

- apps that refuse the size or position they are given (System Settings, or anything that will not sit under the menu bar) get their pictures steered to where the window actually ends up;
- apps that repaint slowly are retried, and any window that never repaints in time dissolves gently at the handoff instead of cutting;
- windows that overhang a display edge are captured whole through ScreenCaptureKit;
- windows caught mid-animation are pinned to the screen animating them, so another screen's reflow cannot grab them, and a window the user throws to another screen or Space mid-animation is handed off cleanly, brought back on screen first if it was parked out of sight.

Smooth animation needs the Screen Recording permission. Amethyst asks for it once, shows a one-time hint, and until it is granted (or on macOS 13 and earlier) falls back to moving the real windows: first resizing them in place, then gliding their positions through per-app writers so one slow app never holds the others back. Reduce Motion turns animation off. Either way the end state of a reflow is identical to a non-animated one, because the final frame still goes through `FrameAssignment.perform(withWindow:)`, focused-window peeking included.

### Settings

- `animate-windows`, off by default: the General preferences checkbox, the YAML key, or the `toggle-animate-windows` hotkey, which is unbound by default and shows a HUD.
- `window-animation-duration`, 0.3 s by default, clamped to 0.05 to 1.0.

### Under the hood

Each screen's reflow becomes one `AnimatedReflowOperation` on the existing serial queue, so cancellation and the completion operation behave as before. It picks one of three strategies per reflow:

1. **Snapshot in place**, macOS 14 and later with Screen Recording: the backdrop-and-pictures approach described above.
2. **Snapshot parked**, macOS 13 or when the backdrop capture fails: the same overlay, but the real windows are parked beyond every display while their pictures glide, then brought back.
3. **Accessibility glide**, no permission or no private capture: the resize-then-glide fallback described above.

Two private SkyLight functions are used, `SLSMainConnectionID` and `SLSHWCaptureWindowList`, both resolved at runtime with `dlsym`; if either is missing the operation falls back to the accessibility glide. ScreenCaptureKit is weak-linked and every use sits behind an availability check, so the deployment target is unchanged. A process-wide registry tracks which screen is animating each window; the window-list filters, the window's own screen lookup, the drag handlers, and the throw commands consult it. Per-application `AXEnhancedUserInterface` suppression stays cleared for as long as any of the application's windows is animating.

### Verification

- 237 tests, up from 188, covering the interpolation, the per-application writer, the registry, the overlay panel, and every strategy of the operation through fakes with an injectable clock.
- Live on macOS 26.6.2 across three displays: snapshot-mode reflows with backdrop captures between 90 ms and 230 ms, mid-glide recaptures, throws between screens and Spaces during an animation, cancellation mid-glide, and Reduce Motion.

### Known limitations

- An application that refuses its tile's size, a minimum height for instance, is placed as the settle would place it, and a diagnostic in the unified log reports the difference from where its picture landed.
- In snapshot-in-place mode a window whose application keeps an oversized frame is visible on the neighboring display while it glides, since the backdrop covers only its own screen.
- Log lines go to the unified log under subsystem `com.amethyst.Amethyst`, category `animation`.

### Files

New: `Layout/AnimatedReflowOperation.swift`, `Layout/WindowCapture.swift`, `Layout/BackdropCapture.swift`, `View/ReflowAnimationOverlay.swift`, and their tests.

Touched: `ScreenManager`, `WindowManager`, `Windows`, `Window`, `Screen`, `ReflowOperation`, `UserConfiguration`, `HotKeyManager`, `LayoutNameWindow`, the General preferences xib, `default.amethyst`, the sample config, and the configuration docs.
